### PR TITLE
Fix the forgetful preview (#10) and some improvements to note saving and updating

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/NoteActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/NoteActivity.java
@@ -288,28 +288,36 @@ public class NoteActivity extends AppCompatActivity {
      * Save the file to its directory
      */
     private void saveNote() {
-        if (_note != null && _initialContent.equals(_note.getName() + _contentEditor.getText().toString())) {
+
+        String content = _contentEditor.getText().toString();
+        String filename = normalizeFilename(content, _editNoteTitle.getText().toString()) + Constants.MD_EXT;
+
+        if (_note != null && _initialContent.equals(filename + content)) {
             return;
         }
+
         try {
-            String content = _contentEditor.getText().toString();
-            String filename = normalizeFilename(content, _editNoteTitle.getText().toString());
+
             if (filename == null) return;
 
             String parent = _targetDirectory != null ? _targetDirectory : _note.getParent();
-            File newNote = new File(parent, filename + Constants.MD_EXT);
+
+            File newNote = new File(parent, filename);
             FileOutputStream fos = new FileOutputStream(newNote);
             OutputStreamWriter writer = new OutputStreamWriter(fos);
 
             writer.write(content);
             writer.flush();
-
             writer.close();
             fos.close();
-            // If we have created a new _note due to renaming, delete the old copy
-            if (_note != null && !newNote.getName().equals(_note.getName()) && newNote.exists()) {
+
+            // FIXME: This ignores renames which only change the case, otherwise the file is deleted
+            if (_note != null && !newNote.getName().equalsIgnoreCase(_note.getName()) && newNote.exists()) {
                 _note.delete();
             }
+            _note=newNote;
+            _initialContent = filename + content;
+
             updateWidgets();
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/src/main/java/net/gsantner/markor/dialog/RenameDialog.java
+++ b/app/src/main/java/net/gsantner/markor/dialog/RenameDialog.java
@@ -13,8 +13,7 @@ import android.widget.EditText;
 import net.gsantner.markor.R;
 import net.gsantner.markor.util.AppCast;
 import net.gsantner.markor.util.AppSettings;
-
-import org.apache.commons.io.FileUtils;
+import net.gsantner.markor.util.Utils;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,7 +62,7 @@ public class RenameDialog extends DialogFragment {
         dialogBuilder.setPositiveButton(getString(android.R.string.ok), new
                 DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int which) {
-                        if (renameFileInSameFolder(file, _newNameField.getText().toString())) {
+                        if (Utils.renameFileInSameFolder(file, _newNameField.getText().toString(), getActivity().getCacheDir().toString())) {
                             AppCast.VIEW_FOLDER_CHANGED.send(getContext(), file.getParent(), true);
                         }
                     }
@@ -79,20 +78,5 @@ public class RenameDialog extends DialogFragment {
         return dialogBuilder;
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    private boolean renameFileInSameFolder(File srcFile, String destFilename) {
-        File destFile = new File(srcFile.getParent(), destFilename);
-        File cacheFile = new File(getActivity().getCacheDir(), "rename.md");
-        try {
-            FileUtils.moveFile(srcFile, cacheFile);
-            FileUtils.moveFile(cacheFile, destFile);
-            return true;
-        } catch (IOException ex) {
-            return false;
-        } finally {
-            if (cacheFile.exists()) {
-                cacheFile.delete();
-            }
-        }
-    }
+
 }

--- a/app/src/main/java/net/gsantner/markor/util/Utils.java
+++ b/app/src/main/java/net/gsantner/markor/util/Utils.java
@@ -6,6 +6,11 @@ import android.graphics.Point;
 import android.view.Display;
 import android.view.WindowManager;
 
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
 public class Utils {
     private static int screenWidth = 0;
     private static int screenHeight = 0;
@@ -36,5 +41,21 @@ public class Utils {
         }
 
         return screenWidth;
+    }
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public static boolean renameFileInSameFolder(File srcFile, String destFilename, String cacheDir) {
+        File destFile = new File(srcFile.getParent(), destFilename);
+        File cacheFile = new File(cacheDir, "rename.md");
+        try {
+            FileUtils.moveFile(srcFile, cacheFile);
+            FileUtils.moveFile(cacheFile, destFile);
+            return true;
+        } catch (IOException ex) {
+            return false;
+        } finally {
+            if (cacheFile.exists()) {
+                cacheFile.delete();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix for #10.
Fix #8 for the case where the renaming is done by changing the title in the editor view.
Tidy up and clarify the `saveNote` method.