### PR TITLE
Add share option from preview activity for sharing file instead of text

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/PreviewActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/PreviewActivity.java
@@ -142,6 +142,9 @@ public class PreviewActivity extends AppCompatActivity {
             case R.id.action_share_text:
                 shareText(_markdownRaw, "text/plain");
                 return true;
+            case R.id.action_share_file:
+                shareFile();
+                return true;
             case R.id.action_share_html:
                 shareText(_markdownHtml, "text/html");
                 return true;
@@ -164,6 +167,10 @@ public class PreviewActivity extends AppCompatActivity {
         shareIntent.putExtra(Intent.EXTRA_TEXT, text);
         shareIntent.setType(type);
         startActivity(Intent.createChooser(shareIntent, getResources().getText(R.string.share_string)));
+    }
+
+    private void shareFile() {
+        shareStream(Uri.fromFile(_note), "text/plain");
     }
 
     private void shareStream(Uri uri, String type) {

--- a/app/src/main/java/net/gsantner/markor/activity/PreviewActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/PreviewActivity.java
@@ -143,7 +143,7 @@ public class PreviewActivity extends AppCompatActivity {
                 shareText(_markdownRaw, "text/plain");
                 return true;
             case R.id.action_share_file:
-                shareFile();
+                shareStream(Uri.fromFile(_note), "text/plain");
                 return true;
             case R.id.action_share_html:
                 shareText(_markdownHtml, "text/html");
@@ -167,10 +167,6 @@ public class PreviewActivity extends AppCompatActivity {
         shareIntent.putExtra(Intent.EXTRA_TEXT, text);
         shareIntent.setType(type);
         startActivity(Intent.createChooser(shareIntent, getResources().getText(R.string.share_string)));
-    }
-
-    private void shareFile() {
-        shareStream(Uri.fromFile(_note), "text/plain");
     }
 
     private void shareStream(Uri uri, String type) {

--- a/app/src/main/res/menu/preview_menu.xml
+++ b/app/src/main/res/menu/preview_menu.xml
@@ -12,6 +12,9 @@
                 android:id="@+id/action_share_text"
                 android:title="@string/share_text" />
             <item
+                android:id="@+id/action_share_file"
+                android:title="@string/share_file" />
+            <item
                 android:id="@+id/action_share_html"
                 android:title="@string/share_html" />
             <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="pref_title__preview_first">Preview first when opening notes</string>
     <string name="about">About Markor</string>
     <string name="share_text">Plain Text</string>
-    <string name="share_file">Markdown File</string>
+    <string name="share_file">File</string>
     <string name="share_image">Image</string>
     <string name="pref_title__font_size">Font Size</string>
     <string name="pref_title__show_markdown_shortcuts">Show Markdown shortcuts bar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="pref_title__preview_first">Preview first when opening notes</string>
     <string name="about">About Markor</string>
     <string name="share_text">Plain Text</string>
+    <string name="share_file">Markdown File</string>
     <string name="share_image">Image</string>
     <string name="pref_title__font_size">Font Size</string>
     <string name="pref_title__show_markdown_shortcuts">Show Markdown shortcuts bar</string>


### PR DESCRIPTION
I attempted to fix issue #28 I raised a few days ago. I've not done any android development previously, but this small change seems to work for me.

Further work could include sharing multiple files after selection from the browser activity.