### PR TITLE
Rework Highlighter

### DIFF
--- a/app/src/main/java/net/gsantner/markor/editor/HighlighterPattern.java
+++ b/app/src/main/java/net/gsantner/markor/editor/HighlighterPattern.java
@@ -16,7 +16,7 @@ enum HighlighterPattern {
     LINK(Pattern.compile("\\[([^\\[]+)\\]\\(([^\\)]+)\\)")),
     STRIKETHROUGH(Pattern.compile("~{2}(.*?)\\S~{2}")),
     MONOSPACED(Pattern.compile("(?m)(`(.*?)`)|(^[^\\S\\n]{4}.*$)")),
-    BOLD(Pattern.compile("(?<=(\\n|^|\\s))(\\*|_){2,3}(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s))")),
+    BOLD(Pattern.compile("(?<=(\\n|^|\\s))((\\*|_){2,3})(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s))")),
     ITALICS(Pattern.compile("(?<=(\\n|^|\\s))(\\*|_)(?=((?!\\2)|\\2{2,}))(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s))"));
 
     private Pattern pattern;

--- a/app/src/test/java/net/gsantner/markor/editor/HighlighterPatternBoldTest.java
+++ b/app/src/test/java/net/gsantner/markor/editor/HighlighterPatternBoldTest.java
@@ -108,6 +108,12 @@ public class HighlighterPatternBoldTest {
     }
 
     @Test
+    public void italicsStarWithTwoStartCharactersShouldNotMatch() {
+        Matcher m = pattern.matcher("**italic*");
+        assertThat(m.find()).isFalse();
+    }
+
+    @Test
     public void boldInAList() {
         Matcher m = pattern.matcher("* **bold** word");
         assertThat(m.find()).isTrue();


### PR DESCRIPTION
Bold requires two trailing characters. This was broken in a previous PR.

Fixes issue https://github.com/gsantner/markor/issues/35