### PR TITLE
Some fixes for #14

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -373,14 +373,13 @@ public class DocumentEditFragment extends BaseFragment {
                 int cursor = _contentEditor.getSelectionStart();
                 int i=cursor-1;
                 Editable s = _contentEditor.getText();
-                for(i=cursor-1; i> 0; i--){
+                for(; i>= 0; i--){
                     if(s.charAt(i) == '\n') {
-                        i = i + 1;
                         break;
                     }
                 }
 
-                s.insert(i, _action);
+                s.insert(i+1, _action);
             }
         }
     }
@@ -478,15 +477,14 @@ public class DocumentEditFragment extends BaseFragment {
             linkName.setText(selected_text);
         }else{
             Editable contentText = _contentEditor.getText();
-            int lineStartidx = startCursorPos-1;
-            int lineEndidx = startCursorPos - 1;
-            for(lineStartidx = startCursorPos-1; lineStartidx > 0; lineStartidx--){
+            int lineStartidx = Math.max(startCursorPos-1,0);
+            int lineEndidx = Math.min(startCursorPos, contentText.length()-1);
+            for(; lineStartidx > 0; lineStartidx--){
                 if(contentText.charAt(lineStartidx) == '\n'){
-                    lineStartidx  += 1;
                     break;
                 }
             }
-            for(lineEndidx = startCursorPos-1; lineEndidx<=contentText.length()-1; lineEndidx++){
+            for(; lineEndidx<=contentText.length(); lineEndidx++){
                 if(contentText.charAt(lineEndidx) == '\n'){
                     break;
                 }

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -433,7 +433,7 @@ public class DocumentEditFragment extends BaseFragment {
 
                 }
                 else if(_action == "----\n"){
-                    _contentEditor.getText().insert(_contentEditor.getSelectionStart(), "\n"+_action);
+                    _contentEditor.getText().insert(_contentEditor.getSelectionStart(), _action);
                 }
                 else {
                     // Condition for formatting which is inserted on either side of the cursor

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -434,7 +434,7 @@ public class DocumentEditFragment extends BaseFragment {
 
                 }
                 else if(_action == "----\n"){
-                    _contentEditor.getText().insert(_contentEditor.getSelectionStart(), _action);
+                    _contentEditor.getText().insert(_contentEditor.getSelectionStart(), "\n"+_action);
                 }
                 else {
                     // Condition for formatting which is inserted on either side of the cursor

--- a/app/src/main/java/net/gsantner/markor/editor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/editor/HighlightingEditor.java
@@ -235,7 +235,7 @@ public class HighlightingEditor extends AppCompatEditText {
             }
         }
         private String addBulletPointIfNeeded(char character) {
-            if (character == '*' || character == '+' || character == '-') {
+            if (character == '*' || character == '+' || character == '-' || character == '>') {
                 return Character.toString(character) + " ";
             } else {
                 return "";

--- a/app/src/main/java/net/gsantner/markor/editor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/editor/HighlightingEditor.java
@@ -177,8 +177,6 @@ public class HighlightingEditor extends AppCompatEditText {
         }
 
         private String createIndentForNextLine(Spanned dest, int dend, int istart) {
-            //TODO: Auto-populate the next number for ordered-lists in addition to bullet points
-            //TODO: Replace this
             if (istart > -1 && istart < dest.length() - 1) {
                 int iend;
 


### PR DESCRIPTION
* Detect and pre-populate link names and URLS depending on the context. This includes the 'nice to have' request :)
* Auto-start the next line for ordered lists with the correct item number
* Pound-sign prefixed headers are always inserted at the start of the line now. Also do this for lists.
* Horizontal rules are only inserted once
* Blockquote auto-populates the next line (like lists) and the shortcut also always inserts the `>` at the start of the line.

This should close that issue.