### PR TITLE
Syntax highlighting for line breaks

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/highlighter/Highlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/highlighter/Highlighter.java
@@ -49,6 +49,7 @@ public class Highlighter {
             createHeaderSpanForMatches(e, MarkdownHighlighterPattern.HEADER, colors.getHeaderColor());
             createColorSpanForMatches(e, MarkdownHighlighterPattern.LINK, colors.getLinkColor());
             createColorSpanForMatches(e, MarkdownHighlighterPattern.LIST, colors.getListColor());
+            createColorSpanForDoublespace(e, MarkdownHighlighterPattern.DOUBLESPACE, colors.getDoublespaceColor());
             createStyleSpanForMatches(e, MarkdownHighlighterPattern.BOLD, Typeface.BOLD);
             createStyleSpanForMatches(e, MarkdownHighlighterPattern.ITALICS, Typeface.ITALIC);
             createColorSpanForMatches(e, MarkdownHighlighterPattern.QUOTATION, colors.getQuotationColor());
@@ -66,7 +67,14 @@ public class Highlighter {
 
         createSpanForMatches(e, pattern, new MarkdownHeaderSpanCreator(this, e, headerColor));
     }
-
+    private void createColorSpanForDoublespace(Editable e, MarkdownHighlighterPattern pattern, final int color){
+        createSpanForMatches(e, pattern, new SpanCreator() {
+            @Override
+            public ParcelableSpan create(Matcher matcher) {
+                return new BackgroundColorSpan(color);
+            }
+        });
+    }
     private void createMonospaceSpanForMatches(Editable e, MarkdownHighlighterPattern pattern) {
         createSpanForMatches(e, pattern, new SpanCreator() {
             @Override

--- a/app/src/main/java/net/gsantner/markor/format/highlighter/markdown/MarkdownHighlighterColors.java
+++ b/app/src/main/java/net/gsantner/markor/format/highlighter/markdown/MarkdownHighlighterColors.java
@@ -13,6 +13,8 @@ public interface MarkdownHighlighterColors {
 
     int getLinkColor();
 
+    int getDoublespaceColor();
+
     int getListColor();
 
     int getQuotationColor();

--- a/app/src/main/java/net/gsantner/markor/format/highlighter/markdown/MarkdownHighlighterColorsNeutral.java
+++ b/app/src/main/java/net/gsantner/markor/format/highlighter/markdown/MarkdownHighlighterColorsNeutral.java
@@ -13,6 +13,7 @@ public class MarkdownHighlighterColorsNeutral implements MarkdownHighlighterColo
     private final int COLOR_LINK = 0xff1ea3fd;
     private final int COLOR_LIST = 0xffdaa520;
     private final int COLOR_QUOTE = 0xff88b04b;
+    private final int COLOR_DOUBLESPACE = 0xffe0e0e0;
 
     @Override
     public int getHeaderColor() {
@@ -27,6 +28,11 @@ public class MarkdownHighlighterColorsNeutral implements MarkdownHighlighterColo
     @Override
     public int getListColor() {
         return COLOR_LIST;
+    }
+
+    @Override
+    public int getDoublespaceColor(){
+        return COLOR_DOUBLESPACE;
     }
 
     @Override

--- a/app/src/main/java/net/gsantner/markor/format/highlighter/markdown/MarkdownHighlighterPattern.java
+++ b/app/src/main/java/net/gsantner/markor/format/highlighter/markdown/MarkdownHighlighterPattern.java
@@ -17,7 +17,8 @@ public enum MarkdownHighlighterPattern {
     STRIKETHROUGH(Pattern.compile("~{2}(.*?)\\S~{2}")),
     MONOSPACED(Pattern.compile("(?m)(`(.*?)`)|(^[^\\S\\n]{4}.*$)")),
     BOLD(Pattern.compile("(?<=(\\n|^|\\s))((\\*|_){2,3})(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s))")),
-    ITALICS(Pattern.compile("(?<=(\\n|^|\\s))(\\*|_)(?=((?!\\2)|\\2{2,}))(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s))"));
+    ITALICS(Pattern.compile("(?<=(\\n|^|\\s))(\\*|_)(?=((?!\\2)|\\2{2,}))(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s))")),
+    DOUBLESPACE(Pattern.compile("(?m)(?<=\\S)([^\\S\\n]{2,})\\n"));
 
     private Pattern pattern;
 


### PR DESCRIPTION
Add a highlighting filter which changes the background to grey for two or more trailing whitespace characters at the end of a non-empty line of text. 