### PR TITLE
Allow spaces in markdown links

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
@@ -82,6 +82,8 @@ public class MarkdownTextConverter extends TextConverter {
     public String convertMarkup(String markup, Context context) {
         MutableDataSet options = new MutableDataSet();
         options.set(Parser.EXTENSIONS, MARKDOWN_ENABLED_EXTENSIONS);
+        // allow links like [this](some filename with spaces.md)
+        options.set(Parser.SPACE_IN_LINK_URLS, true);
 
         options.set(EmojiExtension.USE_IMAGE_TYPE, EmojiImageType.UNICODE_ONLY);
         options.set(HtmlRenderer.SOFT_BREAK, "<br />\n");


### PR DESCRIPTION
This enables the space-in-links support of flexmark-java to support spaces in markdown links (especially relevant for filenames). See #317.