### PR TITLE
[WIP] Add option to take photo and insert it's markdown link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,9 @@
         android:name="android.hardware.type.pc"
         android:required="false" />
 
+    <uses-feature android:name="android.hardware.camera"
+        android:required="false" />
+
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentActivity.java
@@ -246,6 +246,21 @@ public class DocumentActivity extends AppCompatActivity {
         return super.onOptionsItemSelected(item);
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+//        super.onActivityResult(requestCode, resultCode, data);
+        // Don't need the above call as fragment's on activity result is being called manually
+        // see: https://stackoverflow.com/questions/6147884/onactivityresult-is-not-being-called-in-fragment
+
+        GsFragmentBase frag = getCurrentVisibleFragment();
+        // if in the future the current activity needs to call getActivityForResult, don't call fragment's
+        // onActivityResult for such results
+        if (frag != null && frag instanceof DocumentEditFragment) {
+            frag.onActivityResult(requestCode, resultCode, data);
+        }
+
+    }
+
     public void setDocumentTitle(final String title) {
         _toolbarTitleEdit.setText(title);
         _toolbarTitleText.setText(title);

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -14,6 +14,7 @@ import android.app.Activity;
 import android.appwidget.AppWidgetManager;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -32,6 +33,8 @@ import android.widget.TextView;
 import net.gsantner.markor.App;
 import net.gsantner.markor.R;
 import net.gsantner.markor.format.TextFormat;
+import net.gsantner.markor.format.markdown.MarkdownTextConverter;
+import net.gsantner.markor.format.markdown.MarkdownTextModuleActions;
 import net.gsantner.markor.model.Document;
 import net.gsantner.markor.ui.hleditor.HighlightingEditor;
 import net.gsantner.markor.util.AppSettings;
@@ -147,6 +150,16 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
         enable = !(_document.getContent().isEmpty() || _document.getTitle().isEmpty());
         drawable = menu.findItem(R.id.action_save).setEnabled(enable).getIcon();
         drawable.mutate().setAlpha(enable ? 255 : 40);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (_textFormat != null &&
+                _textFormat.getTextModuleActions() instanceof MarkdownTextModuleActions) {
+            ((MarkdownTextModuleActions) _textFormat.getTextModuleActions())
+                    .onActivityResult(requestCode, resultCode, data);
+        }
     }
 
     public void loadDocumentIntoUi() {

--- a/app/src/main/res/drawable/ic_add_a_photo_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_a_photo_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,4L3,1h2v3h3v2L5,6v3L3,9L3,6L0,6L0,4h3zM6,10L6,7h3L9,4h7l1.83,2L21,6c1.1,0 2,0.9 2,2v12c0,1.1 -0.9,2 -2,2L5,22c-1.1,0 -2,-0.9 -2,-2L3,10h3zM13,19c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5 -5,2.24 -5,5 2.24,5 5,5zM9.8,14c0,1.77 1.43,3.2 3.2,3.2s3.2,-1.43 3.2,-3.2 -1.43,-3.2 -3.2,-3.2 -3.2,1.43 -3.2,3.2z"/>
+</vector>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -10,6 +10,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
 -->
 <resources>
     <string name="app_name" translatable="false">Markor</string>
+    <string name="app_fileprovider" translatable="false">net.gsantner.markor.provider</string>
     <string name="app_license_name" translatable="false">Apache 2.0</string>
     <string name="app_community_url" translatable="false">https://matrix.to/#/#markor:matrix.org</string>
     <string name="app_bugreport_url" translatable="false">https://github.com/gsantner/markor/issues</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,4 +237,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="details">Details</string>
     <string name="calendar">Calendar</string>
     <string name="warning_disallowed_sd_access">Warning! The app doesn\'t have the permission to save this file, all changes here will be lost. There is no possibility to resolve the problem or to confirm something, Android denies any access here.</string>
+
+    <string name="main__error_no_picture_selected">No picture was selected.</string>
+    <string name="main__error_camera_cannot_start">Camera cannot start</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:$version_gradle_tools"
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         if (project.enable_plugin_kotlin) {
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$version_plugin_kotlin"


### PR DESCRIPTION
Addresses issue #306 
#### Description of the solution and bug

The text module actions are added to the bottom `ViewGroup` (in the `DocumentEditFragment`) in the `MarkdownTextModuleActions` class. `onClick` listeners are attached to each button added. So I added an icon to take a photo and insert it's link at the location of the cursor. 

To call the camera activity and get it's result, we need to use the `startActivityForResult` function which is a member function of `Activity` and `Fragment`. I called the `DocumentActivity`s `startActivityForResult` as the `MarkdownTextModuleActions` class already has a `_activity` member referring to the activity. This is supposed to start the camera activity and call the `onActivityResult` function in `DocumentActivity` on exit of the camera activity (but while debugging using the Android debugger i noticed that the `DocumentEditFragment`'s function is being called). Since it is logical to handle this result in the `MarkdownTextModuleActions` class, i am calling the `DocumentEditFragment`'s `onActivityResult` which in turn calls another method (also called `onActivityResult`) of the `MarkdownTextModuleActions` object. 

Now, if the picture is taken the `url` is inserted using `_hlEditor.getText().insert(...)`. I checked using the Android debugger that this particular statement is being executed on taking a picture but no text is getting inserted. On the other hand the snackbar is being shown when no picture is taken. I have noticed that the cursor position in the editor is being reset to the start of the text when the camera activity returns.


<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
