### PR TITLE
Change default line height back to 100

### DIFF
--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -220,7 +220,7 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
     }
 
     public float getEditorLineSpacing() {
-        return getInt(R.string.pref_key__editor_line_spacing, 90) / 100f;
+        return getInt(R.string.pref_key__editor_line_sacing, 100) / 100f;
     }
 
     public void setLastTodoUsedArchiveFilename(String value) {

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -220,7 +220,7 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
     }
 
     public float getEditorLineSpacing() {
-        return getInt(R.string.pref_key__editor_line_sacing, 100) / 100f;
+        return getInt(R.string.pref_key__editor_line_spacing, 100) / 100f;
     }
 
     public void setLastTodoUsedArchiveFilename(String value) {

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -97,7 +97,7 @@
             app:min="1" />
 
         <android.support.v7.preference.SeekBarPreference
-            android:defaultValue="90"
+            android:defaultValue="100"
             android:icon="@drawable/ic_format_line_spacing_black_24dp"
             android:key="@string/pref_key__editor_line_spacing"
             android:max="250"

--- a/app/thirdparty/java/other/writeily/format/markdown/MarkdownHeaderSpanCreator.java
+++ b/app/thirdparty/java/other/writeily/format/markdown/MarkdownHeaderSpanCreator.java
@@ -65,20 +65,15 @@ public class MarkdownHeaderSpanCreator implements SpanCreator.ParcelableSpanCrea
     }
 
     private Float calculateProportionForUnderlineHeader(final char[] charSequence) {
-        float proportion = STANDARD_PROPORTION_MAX;
-        if (Character.valueOf('=').equals(charSequence[charSequence.length - 1])) {
-            proportion -= SIZE_STEP;
-        } else if (Character.valueOf('-').equals(charSequence[charSequence.length - 1])) {
-            proportion -= (SIZE_STEP * 2);
-        }
-        return proportion;
+        return Character.valueOf('=').equals(charSequence[charSequence.length - 1])
+                ? 1.6f : 1.0f;
     }
 
     private Float calculateProportionForHashesHeader(final char[] charSequence) {
         float proportion = STANDARD_PROPORTION_MAX;
         int i = 0;
         // Reduce by SIZE_STEP for each #
-        while (POUND_SIGN.equals(charSequence[i])) {
+        while (POUND_SIGN.equals(charSequence[i]) && proportion >= 1.0) {
             proportion -= SIZE_STEP;
             i++;
         }


### PR DESCRIPTION
* Set default line height back to 100. Less than 100 (even 99) makes some weird edittext problems on some devices. which makes 99% look like 5% all in same line.
* Activate patch again: `Set fixed value for ==== header relative size, always results in same value.` commit f7df021
* fixes #296
* fixes #314
* done via github webui on mobile :p