### PR TITLE
Added preference options to render math, show TOC, inject to body

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/TextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextConverter.java
@@ -33,15 +33,33 @@ public abstract class TextConverter {
     protected static final String TOKEN_BW_INVERSE_OF_THEME = "{{ app.token_bw_inverse_of_theme }}";
     protected static final String TOKEN_TEXT_CONVERTER_NAME = "{{ post.text_converter_name }}";
 
-
+    protected static final String HTML_DOCTYPE = "<!DOCTYPE html>";
     protected static final String HTML001_HEAD_WITH_BASESTYLE = "<html><head>" + CSS_S + "html,body{padding:4px 8px 4px 8px;font-family:'" + TOKEN_FONT + "';}h1,h2,h3,h4,h5,h6{font-family:'sans-serif-condensed';}a{color:#388E3C;text-decoration:underline;}img{height:auto;width:325px;margin:auto;}" + CSS_E;
     protected static final String HTML002_HEAD_WITH_STYLE_LIGHT = CSS_S + "html,body{color:#303030;}blockquote{color:#73747d;}" + CSS_E;
     protected static final String HTML002_HEAD_WITH_STYLE_DARK = CSS_S + "html,body{color:#ffffff;background-color:#303030;}a:visited{color:#dddddd;}blockquote{color:#cccccc;}" + CSS_E;
     protected static final String HTML003_RIGHT_TO_LEFT = CSS_S + "body{text-align:" + TOKEN_TEXT_DIRECTION + ";direction:rtl;}" + CSS_E;
     protected static final String HTML100_HEADER_WITHOUT_UNDERLINE = CSS_S + ".header_no_underline { text-decoration: none; color: " + TOKEN_BW_INVERSE_OF_THEME + "; }" + CSS_E;
     protected static final String HTML101_BLOCKQUOTE_VERTICAL_LINE = CSS_S + "blockquote{padding:0px 14px;border-" + TOKEN_TEXT_DIRECTION + ":3.5px solid #dddddd;margin:4px 0}" + CSS_E;
-    protected static final String HTML500_BODY = "</head><body onload='onPageLoaded();'>\n\n\n";
+    protected static final String HTML500_BODY = "</head><body onload='onPageLoaded1();'>\n\n\n";
     protected static final String HTML990_BODY_END = "</body></html>";
+
+    protected static final String HTML_KATEX_HEADERS = "<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/katex.min.css\" integrity=\"sha384-D+9gmBxUQogRLqvARvNLmA9hS2x//eK1FhVb9PiU86gmcrBrJAQT8okdJ4LMp2uv\" crossorigin=\"anonymous\">\n" +
+            "<script defer src=\"https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/katex.min.js\" integrity=\"sha384-483A6DwYfKeDa0Q52fJmxFXkcPCFfnXMoXblOkJ4JcA8zATN6Tm78UNL72AKk+0O\" crossorigin=\"anonymous\"></script>\n" +
+            "<script defer src=\"https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/contrib/auto-render.min.js\" integrity=\"sha384-yACMu8JWxKzSp/C1YV86pzGiQ/l1YUfE8oPuahJQxzehAjEt2GiQuy/BIvl9KyeF\" crossorigin=\"anonymous\"></script>";
+    protected static final String HTML_TOC_HEADER = "<script src=\"http://projects.jga.me/toc/dist/common.js\"></script>";
+
+    protected static final String HTML_ON_PAGE_LOAD_S = "<script>\n" +
+            "    function onPageLoaded1 () {\n";
+    protected static final String HTML_ON_PAGE_LOAD_E = "onPageLoaded(); }\n" +
+            "</script>";
+    protected static final String HTML_KATEX_JS = "renderMathInElement(document.body, {\n" +
+            "            \"delimiters\": [\n" +
+            "                { left: \"$\", right: \"$\", display: false },\n" +
+            "                { left: \"$$\", right: \"$$\", display: true }\n" +
+            "            ]\n" +
+            "        });";
+    protected static final String HTML_TOC_JS = "$('#toc').toc();";
+    protected static final String HTML_TOC_BODY = "<div id=\"toc\"></div>";
 
     //########################
     //## Methods
@@ -50,7 +68,7 @@ public abstract class TextConverter {
     /**
      * Convert markup to target format and show the result in a WebView
      *
-     * @param document The document containting the contents
+     * @param document The document containing the contents
      * @param webView  The WebView content to be shown in
      * @return Copy of converted html
      */
@@ -80,17 +98,36 @@ public abstract class TextConverter {
 
     protected String putContentIntoTemplate(Context context, String content) {
         AppSettings as = new AppSettings(context);
-        String html = HTML001_HEAD_WITH_BASESTYLE + (as.isDarkThemeEnabled() ? HTML002_HEAD_WITH_STYLE_DARK : HTML002_HEAD_WITH_STYLE_LIGHT);
+        String html = HTML_DOCTYPE + HTML001_HEAD_WITH_BASESTYLE + (as.isDarkThemeEnabled() ? HTML002_HEAD_WITH_STYLE_DARK : HTML002_HEAD_WITH_STYLE_LIGHT);
         if (as.isRenderRtl()) {
             html += HTML003_RIGHT_TO_LEFT;
         }
         html += HTML100_HEADER_WITHOUT_UNDERLINE + HTML101_BLOCKQUOTE_VERTICAL_LINE + as.getInjectedHeader();
+        if (as.renderMath()) {
+            html += HTML_KATEX_HEADERS;
+        }
+        if (as.showTOC()) {
+            html += HTML_TOC_HEADER;
+        }
+
+        html += HTML_ON_PAGE_LOAD_S;
+        if (as.renderMath()) {
+            html += HTML_KATEX_JS;
+        }
+        if (as.showTOC()) {
+            html += HTML_TOC_JS;
+        }
+        html += HTML_ON_PAGE_LOAD_E;
 
         // Remove duplicate style blocks
         html = html.replace(CSS_E + CSS_S, "");
 
         // Load content
         html += HTML500_BODY;
+        if (as.showTOC()) {
+            html += HTML_TOC_BODY;
+        }
+        html += as.getInjectedBody();
         html += content;
         html += HTML990_BODY_END;
 

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -155,6 +155,14 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
         return getBool(R.string.pref_key__is_render_rtl, false);
     }
 
+    public boolean renderMath() {
+        return getBool(R.string.pref_key__render_math, false);
+    }
+
+    public boolean showTOC() {
+        return getBool(R.string.pref_key__show_toc, false);
+    }
+
     public boolean isEditorStatusBarHidden() {
         return getBool(R.string.pref_key__is_editor_statusbar_hidden, false);
     }
@@ -301,6 +309,10 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
 
     public String getInjectedHeader() {
         return getString(R.string.pref_key__inject_to_head, rstr(R.string.inject_to_head_default));
+    }
+
+    public String getInjectedBody() {
+        return getString(R.string.pref_key__inject_to_body, "");
     }
 
     public boolean isEditorHistoryEnabled() {

--- a/app/src/main/res/drawable/ic_sigma.xml
+++ b/app/src/main/res/drawable/ic_sigma.xml
@@ -1,0 +1,4 @@
+<vector android:height="24dp" android:viewportHeight="500"
+    android:viewportWidth="400" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M6,5L6.407,20.353L194.732,255.106L4.318,481.647L3.768,495.914L373,494C376.606,448.306 386.512,401.054 395,356L383,353C371.817,378.228 363.867,405.207 340,421.958C313.834,440.322 279.304,438 249,438L79,438L252.288,228.681L96.043,33.362L187,33C245.309,33 328.257,18.917 351.329,89C355.273,100.98 358.007,113.421 359,126L372,126L362,5L6,5L6,5L6,5L6,5L6,5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_toc_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_toc_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,9h14L17,7L3,7v2zM3,13h14v-2L3,11v2zM3,17h14v-2L3,15v2zM19,17h2v-2h-2v2zM19,7v2h2L21,7h-2zM19,13h2v-2h-2v2z"/>
+</vector>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -170,6 +170,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__popular_documents" translatable="false">pref_key__popular_documents</string>
     <string name="pref_key__share_into__open_in_browser" translatable="false">pref_key__share_into__open_in_browser</string>
     <string name="pref_key__inject_to_head" translatable="false">pref_key__inject_to_head</string>
+    <string name="pref_key__inject_to_body" translatable="false">pref_key__inject_to_body</string>
     <string name="pref_key__editor_history_enabled" translatable="false">pref_key__editor_history_enabled</string>
 
 
@@ -189,4 +190,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="tmaid_markdown_insert_image" translatable="false">tmaid_markdown_insert_image</string>
     <string name="tmaid_markdown_insert_link" translatable="false">tmaid_markdown_insert_link</string>
     <string name="tmaid_general_special_key" translatable="false">tmaid_general_special_key</string>
+    <string name="pref_key__render_math">pref_key__render_math</string>
+    <string name="pref_key__show_toc">pref_key__show_toc</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,5 +248,10 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="enable_undo_and_redo_be_patient">Enable undo and redo actions. Only suited for advanced use, be patient to not delete something important. Close and open editor to clear history.</string>
     <string name="description">Description</string>
     <string name="edit_picture">Edit picture</string>
+    <string name="render_math">Render Math using katex (requires internet)</string>
+    <string name="math_rendering">Math rendering</string>
+    <string name="show_table_of_contents">Show table of contents (requires internet)</string>
+    <string name="show_toc">Show TOC</string>
+    <string name="inject_to_body">Inject -> body</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -172,6 +172,23 @@
             android:key="@string/pref_key__inject_to_head"
             android:summary="@string/js_css"
             android:title="@string/inject_to_head" />
+        <android.support.v7.preference.EditTextPreference
+            android:defaultValue=""
+            android:icon="@drawable/ic_add_white_24dp"
+            android:key="@string/pref_key__inject_to_body"
+            android:title="@string/inject_to_body" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:icon="@drawable/ic_sigma"
+            android:key="@string/pref_key__render_math"
+            android:summary="@string/render_math"
+            android:title="@string/math_rendering" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:icon="@drawable/ic_toc_black_24dp"
+            android:key="@string/pref_key__show_toc"
+            android:summary="@string/show_table_of_contents"
+            android:title="@string/show_toc" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:icon="@drawable/ic_format_textdirection_r_to_l_black_24dp"


### PR DESCRIPTION
Addresses issues #326, #192.

Added preference options to render math and show TOC, also an `EditText` preference to inject to body.
Rendering math, showing TOC is done by Javascript libraries so they would work only with internet (mentioned this in the preference summaries)

Demo:
![demo](https://user-images.githubusercontent.com/35289454/45340112-da88ba80-b5b2-11e8-913e-2b2a9cdf08f0.gif)





<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
