### PR TITLE
Fixed ArrayIndexOutOfBoundsException for WrFilesystemListFragment

### DIFF
--- a/app/thirdparty/java/other/writeily/activity/WrFilesystemListFragment.java
+++ b/app/thirdparty/java/other/writeily/activity/WrFilesystemListFragment.java
@@ -571,12 +571,16 @@ public class WrFilesystemListFragment extends GsFragmentBase {
                     finishActionMode();
                     return true;
                 case R.id.context_menu_rename:
-                    promptForNewName(_selectedItems.get(0));
+                    if (!_selectedItems.isEmpty()) {
+                        promptForNewName(_selectedItems.get(0));
+                    }
                     finishActionMode();
-                    return true;
+                    return true;`
                 case R.id.context_menu_info:
-                    FileInfoDialog fileInfoDialog = FileInfoDialog.newInstance(_selectedItems.get(0));
-                    fileInfoDialog.show(getFragmentManager(), FileInfoDialog.FRAGMENT_TAG);
+                    if (!_selectedItems.isEmpty()) {
+                        FileInfoDialog fileInfoDialog = FileInfoDialog.newInstance(_selectedItems.get(0));
+                        fileInfoDialog.show(getFragmentManager(), FileInfoDialog.FRAGMENT_TAG);
+                    }
                     return true;
                 default:
                     return false;

--- a/app/thirdparty/java/other/writeily/activity/WrFilesystemListFragment.java
+++ b/app/thirdparty/java/other/writeily/activity/WrFilesystemListFragment.java
@@ -575,7 +575,7 @@ public class WrFilesystemListFragment extends GsFragmentBase {
                         promptForNewName(_selectedItems.get(0));
                     }
                     finishActionMode();
-                    return true;`
+                    return true;
                 case R.id.context_menu_info:
                     if (!_selectedItems.isEmpty()) {
                         FileInfoDialog fileInfoDialog = FileInfoDialog.newInstance(_selectedItems.get(0));


### PR DESCRIPTION
Fixed the ArrayIndexOutOfBoundsException for onActionItemClicked, returning the default behavior in case of no item selected for context_menu_rename and context_menu_info

Issue : https://github.com/gsantner/markor/issues/378







<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
