### PR TITLE
This commit corrects the filename in the file dialog (see #549)

### DIFF
--- a/app/src/main/java/net/gsantner/markor/ui/FileInfoDialog.java
+++ b/app/src/main/java/net/gsantner/markor/ui/FileInfoDialog.java
@@ -71,7 +71,7 @@ public class FileInfoDialog extends DialogFragment {
         dialogBuilder.setView(root);
 
         ((TextView) root.findViewById(R.id.ui__fileinfodialog__name))
-                .setText(file.getParentFile().getName());
+                .setText(file.getName());
 
 
         ((TextView) root.findViewById(R.id.ui__fileinfodialog__location))


### PR DESCRIPTION
There was a `getParentFile()` too many,