### PR TITLE
Archive Todo: Add line break between old/new tasks

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
@@ -199,7 +199,7 @@ public class TodoTxtTextActions extends TextActions {
                                 if (doneFile.exists() && doneFile.canRead()) {
                                     doneFileContents = FileUtils.readTextFileFast(doneFile).trim() + "\n";
                                 }
-                                doneFileContents += TextUtils.join("\n", move);
+                                doneFileContents += TextUtils.join("\n", move).trim() + "\n";
                                 if (FileUtils.writeFile(doneFile, doneFileContents)) {
                                     // All went good
                                     _hlEditor.setText(TextUtils.join("\n", keep));

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
@@ -197,7 +197,7 @@ public class TodoTxtTextActions extends TextActions {
                                 File doneFile = new File(todoFile.getParentFile(), callbackPayload);
                                 String doneFileContents = "";
                                 if (doneFile.exists() && doneFile.canRead()) {
-                                    doneFileContents = FileUtils.readTextFileFast(doneFile).trim();
+                                    doneFileContents = FileUtils.readTextFileFast(doneFile).trim() + "\n";
                                 }
                                 doneFileContents += TextUtils.join("\n", move);
                                 if (FileUtils.writeFile(doneFile, doneFileContents)) {


### PR DESCRIPTION
trim removes the trailing new line character from the archive file. Therefore the new tasks are glued directly to the last task of the archive:

x 2019-05-02 2019-05-02 Spargel holenx 2019-04-22 2019-05-04 Unterhose wechseln