### PR TITLE
WIP: File browser selection bugs

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerAdapter.java
+++ b/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerAdapter.java
@@ -361,6 +361,7 @@ public class FilesystemViewerAdapter extends RecyclerView.Adapter<FilesystemView
     public boolean goUp() {
         if (canGoUp()) {
             if (_currentFolder != null && _currentFolder.getAbsolutePath() != null && _currentFolder.getParentFile() != null && !_currentFolder.getParentFile().getAbsolutePath().equals(_currentFolder.getAbsolutePath())) {
+                unselectAll();
                 loadFolder(_currentFolder.getParentFile());
                 return true;
             }

--- a/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerFragment.java
@@ -555,6 +555,7 @@ public class FilesystemViewerFragment extends GsFragmentBase
                 super.onFsViewerSelected(request, file);
                 WrMarkorSingleton.getInstance().moveSelectedNotes(filesToMove, file.getAbsolutePath(), getContext());
                 _filesystemViewerAdapter.unselectAll();
+                _filesystemViewerAdapter.reloadCurrentFolder();
             }
 
             @Override

--- a/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerFragment.java
@@ -554,6 +554,7 @@ public class FilesystemViewerFragment extends GsFragmentBase
             public void onFsViewerSelected(String request, File file) {
                 super.onFsViewerSelected(request, file);
                 WrMarkorSingleton.getInstance().moveSelectedNotes(filesToMove, file.getAbsolutePath(), getContext());
+                _filesystemViewerAdapter.unselectAll();
             }
 
             @Override


### PR DESCRIPTION
Fixes #641 (mostly)

This PR fixes the issues described in #641 by clearing the current file selection at the appropriate times. 

**Files not deselected after directory switch**
This is fixed by deselecting everything when the user presses the back button while in selection mode.

**Files stay selected after moving and are still visible in origin**
Once the FileSystemViewerDialog completes(not canceled) the current selection is cleared and the selection mode terminated. The item is still visible in the original location but is crossed out.

Im still looking into hiding the moved files instantly.

I tested all changes locally.
