### PR TITLE
Fix renaming overwriting existing file/folder

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="create_new_document">Create new document</string>
     <string name="move">Move</string>
     <string name="info">Info</string>
+    <string name="file_folder_already_exists_please_use_a_different_name">File/folder already exists! Please use a different name</string>
 
     <string name="import_from_device">Import from device</string>
     <string name="import_">Import</string>

--- a/app/thirdparty/java/other/writeily/ui/WrRenameDialog.java
+++ b/app/thirdparty/java/other/writeily/ui/WrRenameDialog.java
@@ -20,6 +20,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.EditText;
+import android.widget.TextView;
 import android.text.TextWatcher;
 import android.text.Editable;
 
@@ -79,7 +80,7 @@ public class WrRenameDialog extends DialogFragment {
                 _filenameChanged = true;
                 if (_filenameClash) {
                     ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
-                    dialog.setMessage("");
+                    ((TextView) dialog.findViewById(R.id.dialog_message)).setText("");
                     _filenameClash = false;
                 }
             }
@@ -99,7 +100,8 @@ public class WrRenameDialog extends DialogFragment {
             } else {
                 File newFile = new File(file.getParent(), newFileName);
                 if (_filenameChanged && newFile.exists()) {
-                    dialog.setMessage("File already exists! Please enter a different filename");
+                    //dialog.setMessage("File already exists! Please enter a different filename");
+                    ((TextView) dialog.findViewById(R.id.dialog_message)).setText("File already exists! Please enter a different filename");
                     dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
                     _filenameClash = true;
                 } else {
@@ -119,8 +121,6 @@ public class WrRenameDialog extends DialogFragment {
 
         dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener(view -> dialog.dismiss());
 
-        //dialog.show();
-
         return dialog;
     }
 
@@ -133,7 +133,6 @@ public class WrRenameDialog extends DialogFragment {
         root = inflater.inflate(R.layout.rename__dialog, null);
 
         dialogBuilder.setTitle(getResources().getString(R.string.rename));
-        dialogBuilder.setMessage("");
         dialogBuilder.setView(root);
 
         EditText editText = root.findViewById(R.id.new_name);

--- a/app/thirdparty/java/other/writeily/ui/WrRenameDialog.java
+++ b/app/thirdparty/java/other/writeily/ui/WrRenameDialog.java
@@ -55,7 +55,7 @@ public class WrRenameDialog extends DialogFragment {
     private EditText _newNameField;
     private Callback.a1<File> _callback;
     private boolean _filenameClash;
-    private boolean _filenameChanged;
+    private String _origFilename;
 
     @NonNull
     @Override
@@ -70,14 +70,17 @@ public class WrRenameDialog extends DialogFragment {
         _newNameField = dialog.findViewById(R.id.new_name);
         _newNameField.addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                if (_origFilename == null) {
+                    _origFilename = s.toString();
+                }
+            }
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {}
 
             @Override
             public void afterTextChanged(Editable s) {
-                _filenameChanged = true;
                 if (_filenameClash) {
                     ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
                     ((TextView) dialog.findViewById(R.id.dialog_message)).setText("");
@@ -99,9 +102,8 @@ public class WrRenameDialog extends DialogFragment {
                 }
             } else {
                 File newFile = new File(file.getParent(), newFileName);
-                if (_filenameChanged && newFile.exists()) {
-                    //dialog.setMessage("File already exists! Please enter a different filename");
-                    ((TextView) dialog.findViewById(R.id.dialog_message)).setText("File already exists! Please enter a different filename");
+                if (_origFilename != null && !_origFilename.equals(newFileName) && newFile.exists()) {
+                    ((TextView) dialog.findViewById(R.id.dialog_message)).setText(R.string.file_folder_already_exists_please_use_a_different_name);
                     dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
                     _filenameClash = true;
                 } else {
@@ -109,7 +111,7 @@ public class WrRenameDialog extends DialogFragment {
                 }
             }
 
-            if (renamed || !_filenameChanged) {
+            if (renamed || _origFilename == null) {
                 AppCast.VIEW_FOLDER_CHANGED.send(getContext(), file.getParent(), true);
                 if (_callback != null) {
                     _callback.callback(file);

--- a/app/thirdparty/res/layout/rename__dialog.xml
+++ b/app/thirdparty/res/layout/rename__dialog.xml
@@ -16,6 +16,14 @@
     android:orientation="vertical"
     android:padding="16dp">
 
+    <TextView
+        android:id="@+id/dialog_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:textColor="@color/accent"
+        android:textSize="16sp" />
+
     <EditText
         android:id="@+id/new_name"
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes issue #620 

Modifications made to check for filename clash, and if filenames clash the 'OK' button is disabled and a red text error is displayed informing the user that the file/folder names clash, which disappears when the filename is changed again. Error string added to strings.xml.