### PR TITLE
Avoid showing permission denied warning when editing files on private storage

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/util/ShareUtil.java
+++ b/app/src/main/java/net/gsantner/opoc/util/ShareUtil.java
@@ -999,7 +999,8 @@ public class ShareUtil {
     public boolean canWriteFile(File file, boolean isDir) {
         if (file == null) {
             return false;
-        } else if (file.getAbsolutePath().startsWith(Environment.getExternalStorageDirectory().getAbsolutePath())) {
+        } else if (file.getAbsolutePath().startsWith(Environment.getExternalStorageDirectory().getAbsolutePath())
+                || file.getAbsolutePath().startsWith(_context.getFilesDir().getAbsolutePath())) {
             boolean s1 = isDir && file.getParentFile().canWrite();
             return !isDir && file.getParentFile() != null ? file.getParentFile().canWrite() : file.canWrite();
         } else {


### PR DESCRIPTION
In some cases users may choose to store notes on the internal storage (/data/user/0 for instance), which adds protection against apps reading /data/media/0. 

ShareUtil.java mistakenly marks this location as non-writable, forcing the warning dialog to be shown in error. This patch adds private storage as a writable location.