### PR TITLE
Disable saving of empty files, fixes #689

### DIFF
--- a/app/src/main/java/net/gsantner/markor/util/DocumentIO.java
+++ b/app/src/main/java/net/gsantner/markor/util/DocumentIO.java
@@ -118,6 +118,9 @@ public class DocumentIO {
     }
 
     public static synchronized boolean saveDocument(final Document document, final String text, final ShareUtil shareUtil) {
+        if (text != null && text.trim().isEmpty() && text.length() < 5) {
+            return false;
+        }
         boolean ret;
         String filename = DocumentIO.normalizeTitleForFilename(document, text) + document.getFileExtension();
         document.setDoHistory(true);


### PR DESCRIPTION
The updates remove the existing content in quicknote.md so the content is lost.

this aims to fix this issue.