### PR TITLE
Use correct plurals in delete confirmation dialog

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerFragment.java
@@ -560,7 +560,7 @@ public class FilesystemViewerFragment extends GsFragmentBase
     ///////////////
     public void askForDeletingFilesRecursive(WrConfirmDialog.ConfirmDialogCallback confirmCallback) {
         final ArrayList<File> itemsToDelete = new ArrayList<>(_filesystemViewerAdapter.getCurrentSelection());
-        StringBuilder message = new StringBuilder(String.format(getString(R.string.do_you_really_want_to_delete_this_witharg), getResources().getQuantityString(R.plurals.documents, itemsToDelete.size())) + "\n\n");
+        StringBuilder message = new StringBuilder(getResources().getQuantityString(R.plurals.do_you_really_want_to_delete_this_document, itemsToDelete.size()) + "\n\n");
 
         for (File f : itemsToDelete) {
             message.append("\n").append(f.getAbsolutePath());

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">المظهر</string>
     <string name="rename">إعادة التسمية</string>
     <string name="confirm_delete">تأكيد الحذف</string>
-    <string name="do_you_really_want_to_delete_this_witharg">هل تريد حقا حذف %s؟</string>
     <string name="confirm_overwrite">تأكيد التعديل</string>
     <string name="file_already_exists_overwerite">الملف موجود بالفعل، استبدال ؟</string>
     <string name="browse_filesystem">تصفح الملفات</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Izgled</string>
     <string name="rename">Preimenuj</string>
     <string name="confirm_delete">Potvrdi brisanje</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Želite li zaista obrisati %s?</string>
     <string name="confirm_overwrite">Potvrdi prepisivanje</string>
     <string name="file_already_exists_overwerite">Datoteka već postoji. Prepisati?</string>
     <string name="browse_filesystem">Pregledaj datoteke</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Aparença</string>
     <string name="rename">Canvia el nom</string>
     <string name="confirm_delete">Confirma la supressió</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Segur que voleu suprimir aquest %s?</string>
     <string name="confirm_overwrite">Confirma la sobreescriptura</string>
     <string name="file_already_exists_overwerite">El fitxer ja existeix, voleu sobreescriure\'l?</string>
     <string name="browse_filesystem">Navega pel sistema de fitxers</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Vzhled</string>
     <string name="rename">Přejmenovat</string>
     <string name="confirm_delete">Potvrdit odstranění</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Opravdu chcete smazat %s?</string>
     <string name="confirm_overwrite">Potvrdit přepsání</string>
     <string name="file_already_exists_overwerite">Soubor již existuje, přepsat?</string>
     <string name="browse_filesystem">Procházet souborový systém</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Udseende</string>
     <string name="rename">Omdøb</string>
     <string name="confirm_delete">Godkend sletning</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Er du sikker på at du vil slette %s?</string>
     <string name="confirm_overwrite">Godkend overskrivning</string>
     <string name="file_already_exists_overwerite">Filen eksisterer allerede, vil du overskrive?</string>
     <string name="browse_filesystem">Gennemse filsystem</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Erscheinungsbild</string>
     <string name="rename">Umbenennen</string>
     <string name="confirm_delete">Löschen bestätigen</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Möchtest du %s wirklich löschen?</string>
     <string name="confirm_overwrite">Überschreiben bestätigen</string>
     <string name="file_already_exists_overwerite">Datei existiert bereits. Überschreiben?</string>
     <string name="browse_filesystem">Dateisystem durchsuchen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Apariencia</string>
     <string name="rename">Cambiar nombre</string>
     <string name="confirm_delete">Confirmar borrado</string>
-    <string name="do_you_really_want_to_delete_this_witharg">¿Realmente deseas borrar este %s?</string>
     <string name="confirm_overwrite">Confirmar sobrescritura</string>
     <string name="file_already_exists_overwerite">El archivo ya existe, ¿sobrescribir?</string>
     <string name="browse_filesystem">Navegar carpetas</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">ظاهر</string>
     <string name="rename">تغییر نام</string>
     <string name="confirm_delete">تایید حذف</string>
-    <string name="do_you_really_want_to_delete_this_witharg">آیا حقیقتاً میخواهید %s را حذف کنید؟</string>
     <string name="confirm_overwrite">تایید جایگزینی</string>
     <string name="file_already_exists_overwerite">این فایل اکنون وجود دارد، جایگزین شود؟</string>
     <string name="browse_filesystem">مرور فایل‌ها</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Ulkoasu</string>
     <string name="rename">Nimeä uudelleen</string>
     <string name="confirm_delete">Vahvista poisto</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Haluatko varmasti poistaa tämän %s?</string>
     <string name="confirm_overwrite">Vahvista ylikirjoitus</string>
     <string name="file_already_exists_overwerite">Tiedosto on jo olemassa, korvataanko?</string>
     <string name="browse_filesystem">Selaa tiedostojärjestelmää</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Hitsura</string>
     <string name="rename">I-rename</string>
     <string name="confirm_delete">Tiyakin Alisin</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Sigurado ka bang gusto mong burahin ang %s?</string>
     <string name="confirm_overwrite">Tiyaking I-o-overwrite</string>
     <string name="file_already_exists_overwerite">Mayroon nang ganitong file, i-overwrite?</string>
     <string name="browse_filesystem">Mag-browse sa filesystem</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Apparence</string>
     <string name="rename">Renommer</string>
     <string name="confirm_delete">Confirmez la suppression</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Voulez-vous vraiment supprimer ça %s?</string>
     <string name="confirm_overwrite">Confirmer écrasement</string>
     <string name="file_already_exists_overwerite">Un fichier portant le même nom existe déjà : faut-il l\'écraser ?</string>
     <string name="browse_filesystem">Parcourir le système de fichiers</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Aparencia</string>
     <string name="rename">Renomear</string>
     <string name="confirm_delete">Confirmar borrado</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Realmente queres eliminar este %s?</string>
     <string name="confirm_overwrite">Confirmar sobrescritura</string>
     <string name="file_already_exists_overwerite">O arquivo xa existe. Sobreescribir?</string>
     <string name="browse_filesystem">Navegar por cartafoles</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">दिखावट</string>
     <string name="rename">नाम बदलने</string>
     <string name="confirm_delete">हटाने की पुष्टि करें</string>
-    <string name="do_you_really_want_to_delete_this_witharg">क्या आप वास्तव में %s हटाना चाहते हैं?</string>
     <string name="confirm_overwrite">ओवरराइट की पुष्टि करें</string>
     <string name="file_already_exists_overwerite">फ़ाइल पहले से मौजूद है, अधिलेखित?</string>
     <string name="title">शीर्षक</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Megjelenés</string>
     <string name="rename">Átnevezés</string>
     <string name="confirm_delete">Törlés Megerősítése</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Biztosan törölni szeretnéd ezt: %s?</string>
     <string name="confirm_overwrite">Felülírás megerősítése</string>
     <string name="file_already_exists_overwerite">A fájl már létezik, felülírja?</string>
     <string name="browse_filesystem">Tallózás</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Tampilan</string>
     <string name="rename">Ubah Nama</string>
     <string name="confirm_delete">Konfirmasi Hapus</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Apakah Anda yakin ingin menghapus %s?</string>
     <string name="confirm_overwrite">Konfirmasi Timpa</string>
     <string name="file_already_exists_overwerite">Berkas sudah ada, timpa?</string>
     <string name="browse_filesystem">Rambah filesystem</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Aspetto</string>
     <string name="rename">Rinomina</string>
     <string name="confirm_delete">Conferma eliminazione</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Eliminare veramente questo %s?</string>
     <string name="confirm_overwrite">Conferma sovrascrittura</string>
     <string name="file_already_exists_overwerite">File già esistente, sovrascrivere?</string>
     <string name="browse_filesystem">Esplora i file</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">מראה</string>
     <string name="rename">שינוי שם</string>
     <string name="confirm_delete">אשר מחיקה</string>
-    <string name="do_you_really_want_to_delete_this_witharg">האם אתה באמת רוצה למחוק את %s?</string>
     <string name="confirm_overwrite">אשר דריסה</string>
     <string name="file_already_exists_overwerite">הקובץ קיים, לדרוס?</string>
     <string name="browse_filesystem">עיין במערכת הקבצים</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">外観</string>
     <string name="rename">名前を変更</string>
     <string name="confirm_delete">削除の確認</string>
-    <string name="do_you_really_want_to_delete_this_witharg">この %s を削除してもよろしいですか?</string>
     <string name="confirm_overwrite">上書きの確認</string>
     <string name="file_already_exists_overwerite">ファイルはすでに存在します。上書きしますか?</string>
     <string name="browse_filesystem">ファイルシステムを参照</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Udem</string>
     <string name="rename">Beddel isem</string>
     <string name="confirm_delete">Sentem tukksa</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Tebɣiḍ ad tekkseḍ aya %s?</string>
     <string name="confirm_overwrite">Sentem asfeɛj</string>
     <string name="file_already_exists_overwerite">Afaylu s yisem-agi yella yakan : tebɣiḍ ad tesfeɛjeḍ-t ?</string>
     <string name="browse_filesystem">Snirem anagraw n ifuyla</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">രൂപം</string>
     <string name="rename">പേര് തിരുത്തുക</string>
     <string name="confirm_delete">നീക്കം ചെയ്യുന്നത് ഉറപ്പുവരുത്തുക</string>
-    <string name="do_you_really_want_to_delete_this_witharg">ഉറപ്പായും നീക്കം ചെയ്യാമല്ലോ ഈ %s?</string>
     <string name="confirm_overwrite">ഓവർറൈറ്റ് ഉറപ്പുവരുത്തുക</string>
     <string name="file_already_exists_overwerite">നിലവിൽ മറ്റൊരു ഫയൽ ഉണ്ട്, അത് ഓവർറൈറ്റ് ചെയ്യണോ?</string>
     <string name="browse_filesystem">ഫയൽ സിസ്റ്റത്തിൽ തിരയുക</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Utseende</string>
     <string name="rename">Gi nytt navn</string>
     <string name="confirm_delete">Bekreft sletting</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Ønsker du virkelig å slette denne %s?</string>
     <string name="confirm_overwrite">Bekreft overskriving</string>
     <string name="file_already_exists_overwerite">Filen finnes allerede, overskriv?</string>
     <string name="browse_filesystem">Utforsk filsystem</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Vormgeving</string>
     <string name="rename">Hernoemen</string>
     <string name="confirm_delete">Bevestig verwijderen</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Weet je zeker dat je dit %s wilt verwijderen?</string>
     <string name="confirm_overwrite">Bestand bestaat al, overschrijven?</string>
     <string name="file_already_exists_overwerite">Bestand bestaat al, overschrijven?</string>
     <string name="browse_filesystem">Bekijk bestandssysteem</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Wygląd</string>
     <string name="rename">Zmień nazwę</string>
     <string name="confirm_delete">Potwierdź usunięcie</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Czy na pewno chcesz usunąć ten %s?</string>
     <string name="confirm_overwrite">Potwierdź nadpisanie</string>
     <string name="file_already_exists_overwerite">Plik już istnieje, nadpisać?</string>
     <string name="browse_filesystem">Przeglądaj system plików</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Aparência</string>
     <string name="rename">Renomear</string>
     <string name="confirm_delete">Confirmar exclusão</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Você realmente deseja excluir essa %s?</string>
     <string name="confirm_overwrite">O arquivo já existe. Sobrescrever?</string>
     <string name="file_already_exists_overwerite">O arquivo já existe. Sobrescrever?</string>
     <string name="browse_filesystem">Navegar no SD</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Aparência</string>
     <string name="rename">Renomear</string>
     <string name="confirm_delete">Confirmação</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Tem a certeza de que deseja apagar %s?</string>
     <string name="confirm_overwrite">Confirmação</string>
     <string name="file_already_exists_overwerite">Ficheiro já existe, substituir?</string>
     <string name="browse_filesystem">Explorar sistema de ficheiros</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Aspect</string>
     <string name="rename">Redenumiți</string>
     <string name="confirm_delete">Confirmă Ștergerea</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Ești sigur că vrei să ștergi acest %s?</string>
     <string name="confirm_overwrite">Confirmați Înlocuirea</string>
     <string name="file_already_exists_overwerite">Fișierul există deja, înlocuiți?</string>
     <string name="title">Titlu</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Внешний вид</string>
     <string name="rename">Переименовать</string>
     <string name="confirm_delete">Подтвердить удаление</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Вы действительно хотите удалить этот %s?</string>
     <string name="confirm_overwrite">Подтвердить перезапись</string>
     <string name="file_already_exists_overwerite">Файл уже существует, перезаписать?</string>
     <string name="browse_filesystem">Просмотр файлов</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Aparèntzia</string>
     <string name="rename">Muda su nùmene</string>
     <string name="confirm_delete">Cinfirma s\'iscantzellamentu</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Cheres a beru a iscantzellare custu %s?</string>
     <string name="confirm_overwrite">Cunfirma sa subraiscritura</string>
     <string name="file_already_exists_overwerite">Su documentu esist giai, lu cheres subraiscrìere?</string>
     <string name="browse_filesystem">Esplora su sistema de documentos</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Utseende</string>
     <string name="rename">Byt namn</string>
     <string name="confirm_delete">Bekräfta radering</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Vill du verkligen radera den här %s?</string>
     <string name="confirm_overwrite">Skriva över?</string>
     <string name="file_already_exists_overwerite">Filen finns redan, skriva över?</string>
     <string name="browse_filesystem">Bläddra i filsystemet</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Görünüm</string>
     <string name="rename">Yeniden Adlandır</string>
     <string name="confirm_delete">Silmeyi Onayla</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Bu %syi gerçekten silmek istiyor musunuz?</string>
     <string name="confirm_overwrite">Üzerine Yazmayı Onayla</string>
     <string name="file_already_exists_overwerite">Dosya zaten var, üzerine yazılsın mı?</string>
     <string name="browse_filesystem">Dosya sistemine göz at</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Вигляд</string>
     <string name="rename">Перейменувати</string>
     <string name="confirm_delete">Підтвердіть видалення</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Ви справді бажаєте видалити %s?</string>
     <string name="confirm_overwrite">Підтвердіть перезапис</string>
     <string name="file_already_exists_overwerite">Файл уже існує, перезаписати?</string>
     <string name="browse_filesystem">Перегляд файлів</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Xuất hiện</string>
     <string name="rename">Đổi tên</string>
     <string name="confirm_delete">Xác nhận xóa bỏ</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Bạn có thực sự muốn xoá này %s?</string>
     <string name="confirm_overwrite">Xác nhận ghi đè</string>
     <string name="file_already_exists_overwerite">Tệp đã tồn tại, ghi đè lên?</string>
     <string name="browse_filesystem">Trình duyệt hệ thống tập tin</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">外观样式</string>
     <string name="rename">重命名</string>
     <string name="confirm_delete">确认删除</string>
-    <string name="do_you_really_want_to_delete_this_witharg">您确定要删除 %s 吗？</string>
     <string name="confirm_overwrite">确认替换</string>
     <string name="file_already_exists_overwerite">文件已存在，是否替换？</string>
     <string name="browse_filesystem">浏览文件系统</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -18,7 +18,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">外觀</string>
     <string name="rename">重新命名</string>
     <string name="confirm_delete">確定刪除</string>
-    <string name="do_you_really_want_to_delete_this_witharg">您真的要刪除這個 %s 嗎？</string>
     <string name="confirm_overwrite">確認覆寫</string>
     <string name="file_already_exists_overwerite">檔案已經存在，要覆寫嗎？</string>
     <string name="browse_filesystem">瀏覽檔案系統</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,10 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="appearance">Appearance</string>
     <string name="rename">Rename</string>
     <string name="confirm_delete">Confirm Delete</string>
-    <string name="do_you_really_want_to_delete_this_witharg">Do you really want to delete this %s?</string>
+    <plurals name="do_you_really_want_to_delete_this_document">
+        <item quantity="one">Do you really want to delete this document?</item>
+        <item quantity="other">Do you really want to delete these documents?</item>
+    </plurals>
     <string name="confirm_overwrite">Confirm Overwrite</string>
     <string name="file_already_exists_overwerite">File already exists, overwrite?</string>
     <string name="browse_filesystem">Browse filesystem</string>


### PR DESCRIPTION
It fixes plural form in the delete confirmation dialog: _these_. It also makes possible to get consistent translation here.

Please avoid joining of UI strings from small pieces like the case was here, as it makes harder to localize them.


<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
