### PR TITLE
Option to disable code block highlight

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,3 +41,4 @@ Where:
 * **[Kyle Phelps](kyle.phelps757@gmail.com)**<br/>~° Added functionality to chare multiple files from file browser
 * **[Vladislav Glinsky](https://github.com/cl0ne)**<br/>~° Ukrainian/Russian translations
 * **[David Hebbeker](https://david.hebbeker.info/)**<br/>~° Added tooltips for text actions.
+* **[Harshad Srinivasan](https://github.com/harshad1)**<br/>~° Added functionality to handle leading spaces in lists.

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighter.java
@@ -27,6 +27,7 @@ public class MarkdownHighlighter extends Highlighter {
     private final boolean _highlightLineEnding;
     private final boolean _highlightCodeChangeFont;
     private final boolean _highlightBiggerHeadings;
+    private final boolean _highlightDisableCodeBlock;
 
     private static final int MD_COLOR_HEADING = 0xffef6D00;
     private static final int MD_COLOR_LINK = 0xff1ea3fe;
@@ -42,6 +43,7 @@ public class MarkdownHighlighter extends Highlighter {
         _highlightLineEnding = _appSettings.isMarkdownHighlightLineEnding();
         _highlightCodeChangeFont = _appSettings.isMarkdownHighlightCodeFontMonospaceAllowed();
         _highlightBiggerHeadings = _appSettings.isMarkdownBiggerHeadings();
+        _highlightDisableCodeBlock = _appSettings.isMarkdownDisableCodeBlockHighlight();
     }
 
     @Override
@@ -85,7 +87,9 @@ public class MarkdownHighlighter extends Highlighter {
                 createMonospaceSpanForMatches(editable, MarkdownHighlighterPattern.CODE.pattern);
             }
             _profiler.restart("Code - bgcolor");
-            createColorBackgroundSpan(editable, MarkdownHighlighterPattern.CODE.pattern, MD_COLOR_CODEBLOCK);
+            if (!_highlightDisableCodeBlock) {
+                createColorBackgroundSpan(editable, MarkdownHighlighterPattern.CODE.pattern, MD_COLOR_CODEBLOCK);
+            }
 
             _profiler.end();
             _profiler.printProfilingGroup();

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -166,6 +166,9 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
         return getBool(R.string.pref_key__markdown__monospace_some_parts, false);
     }
 
+    public boolean isMarkdownDisableCodeBlockHighlight() {
+        return getBool(R.string.pref_key__markdown__disable_code_block_highlight, false);
+    }
 
     public int getHighlightingDelayTodoTxt() {
         return getInt(R.string.pref_key__todotxt__hl_delay, 870);

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -120,6 +120,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__quicknote_filepath" translatable="false">pref_key__quicknote_filepath</string>
     <string name="pref_key__markdown__highlight_lineending_two_or_more_space" translatable="false">pref_key__markdown__highlight_lineending_two_or_more_space</string>
     <string name="pref_key__markdown__monospace_some_parts" translatable="false">pref_key__markdown__monospace_some_parts</string>
+    <string name="pref_key__markdown__disable_code_block_highlight" translatable="false">pref_key__markdown__disable_code_block_highlight</string>
     <string name="pref_key__todotxt__hl_delay" translatable="false">pref_key__todotxt__hl_delay</string>
     <string name="pref_key__todo_filepath" translatable="false">pref_key__todo_filepath</string>
     <string name="pref_key__todotxt__start_new_tasks_with_todays_date" translatable="false">pref_key__todotxt__start_new_tasks_with_todays_date</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="highlight_line_ending">Highlight line ending</string>
     <string name="highlight_line_ending_if_two_or_more_spaces">Highlight spaces at the end of lines containing two or more spaces</string>
     <string name="use_monospace_for_code">Use monospace font for code</string>
+    <string name="disable_code_block_highlight">Disable highlighting for code blocks</string>
     <string name="use_different_fonttype_slow_down">Make use of a different font type. Changing it dynamically impacts app performance.</string>
     <string name="general">General</string>
     <string name="resources">Resources</string>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -391,6 +391,12 @@
                     android:key="@string/pref_key__markdown__monospace_some_parts"
                     android:summary="@string/use_different_fonttype_slow_down"
                     android:title="@string/use_monospace_for_code" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:icon="@drawable/ic_code_black_24dp"
+                    android:key="@string/pref_key__markdown__disable_code_block_highlight"
+                    android:summary="@string/use_different_fonttype_slow_down"
+                    android:title="@string/disable_code_block_highlight" />
             </PreferenceCategory>
             <PreferenceCategory android:title="@string/view_mode">
                 <CheckBoxPreference

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -395,7 +395,6 @@
                     android:defaultValue="false"
                     android:icon="@drawable/ic_code_black_24dp"
                     android:key="@string/pref_key__markdown__disable_code_block_highlight"
-                    android:summary="@string/use_different_fonttype_slow_down"
                     android:title="@string/disable_code_block_highlight" />
             </PreferenceCategory>
             <PreferenceCategory android:title="@string/view_mode">


### PR DESCRIPTION
This PR adds an option to disable indented code block highlight. This will serve as a zero-performance-overhead workaround for #250. 

ToDo:
- [ ] Confirm wording.
- [ ] Do we need a description for this option.
- [ ] Are translations needed? If so, how what can I do to get them?