### PR TITLE
Autoindent improvements

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
@@ -61,16 +61,15 @@ public class CommonTextActions {
     private final Activity _activity;
     private final HighlightingEditor _hlEditor;
 
-    protected AppSettings _appSettings;
     private int _tabWidth;
-    protected Context _context;
 
     public CommonTextActions(Activity activity, HighlightingEditor hlEditor) {
         _activity = activity;
         _hlEditor = hlEditor;
-        _context = activity != null ? activity : _hlEditor.getContext();
-        _appSettings = new AppSettings(_context);
-        _tabWidth = _appSettings.getTabWidth();
+
+        Context context = activity != null ? activity : _hlEditor.getContext();
+        AppSettings settings = new AppSettings(context);
+        _tabWidth = settings.getTabWidth();
     }
 
     private String rstr(@StringRes int resKey) {

--- a/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
@@ -219,7 +219,7 @@ public class CommonTextActions {
 
         Editable text = _hlEditor.getText();
 
-        int[] selection = getSelection();
+        int[] selection = StringUtils.getSelection(_hlEditor);
         int selectionStart = selection[0];
         int selectionEnd = selection[1];
 
@@ -250,20 +250,6 @@ public class CommonTextActions {
             // Get next line
             lineStart = StringUtils.getLineEnd(text, lineStart, selectionEnd) + 1;
         }
-    }
-
-    protected int[] getSelection() {
-
-        int selectionStart = _hlEditor.getSelectionStart();
-        int selectionEnd = _hlEditor.getSelectionEnd();
-
-        if (selectionEnd < selectionStart) {
-            selectionEnd = _hlEditor.getSelectionStart();
-            selectionStart = _hlEditor.getSelectionEnd();
-        }
-
-        int[] selection = {selectionStart, selectionEnd};
-        return selection;
     }
 
 

--- a/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
@@ -252,44 +252,6 @@ public class CommonTextActions {
         }
     }
 
-
-    public void indentCurrentLine() {
-        String text = _hlEditor.getText().toString();
-        int start = _hlEditor.getSelectionStart();
-
-        switch (_hlEditor.getShiftWidth(text)) {
-            case 4:
-                _hlEditor.getText().insert(start, "    ");
-                break;
-            case 2:
-                _hlEditor.getText().insert(start, "  ");
-                break;
-            case 8:
-                _hlEditor.getText().insert(start, "        ");
-                break;
-            default:
-                break;
-        }
-    }
-
-    public void deIndentCurrentLine() {
-        String text = _hlEditor.getText().toString();
-        int sw = _hlEditor.getShiftWidth(text);
-        int start = _hlEditor.getSelectionStart();
-        int end = _hlEditor.getSelectionStart() + sw;
-
-        if (end <= text.length()) {
-            text = text.substring(start, end);
-            if (sw == 4 && "    ".equals(text)) {
-                _hlEditor.getText().replace(start, end, "");
-            } else if (sw == 2 && "  ".equals(text)) {
-                _hlEditor.getText().replace(start, end, "");
-            } else if (sw == 8 && "        ".equals(text)) {
-                _hlEditor.getText().replace(start, end, "");
-            }
-        }
-    }
-
     public void moveLineBy1(boolean up) {
         selectWholeLine(true);
         selectWholeLine(false);

--- a/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
@@ -26,7 +26,7 @@ import net.gsantner.markor.R;
 import net.gsantner.markor.ui.SearchOrCustomTextDialogCreator;
 import net.gsantner.markor.ui.hleditor.HighlightingEditor;
 import net.gsantner.markor.util.AppSettings;
-import net.gsantner.markor.util.StringUtils;
+import net.gsantner.opoc.util.StringUtils;
 import net.gsantner.opoc.format.plaintext.PlainTextStuff;
 import net.gsantner.opoc.util.Callback;
 import net.gsantner.opoc.util.ContextUtils;

--- a/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
@@ -25,7 +25,6 @@ import com.flask.colorpicker.builder.ColorPickerDialogBuilder;
 import net.gsantner.markor.R;
 import net.gsantner.markor.ui.SearchOrCustomTextDialogCreator;
 import net.gsantner.markor.ui.hleditor.HighlightingEditor;
-import net.gsantner.markor.ui.hleditor.TextActions;
 import net.gsantner.markor.util.AppSettings;
 import net.gsantner.markor.util.StringUtils;
 import net.gsantner.opoc.format.plaintext.PlainTextStuff;
@@ -236,8 +235,9 @@ public class CommonTextActions {
                 int textStart = StringUtils.getNextNonWhitespace(text, lineStart, selectionEnd);
                 int spaceCount = textStart - lineStart;
                 int delCount = Math.min(_tabWidth, spaceCount);
-                if (delCount > 0) {
-                    text.delete(lineStart, delCount);
+                int delEnd = lineStart + delCount;
+                if (delCount > 0 && delEnd < text.length()) {
+                    text.delete(lineStart, delEnd);
                     selectionEnd -= delCount;
                 }
             }

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -15,7 +15,7 @@ import android.text.Spanned;
 import java.util.regex.Matcher;
 import java.util.Arrays;
 
-import net.gsantner.markor.util.StringUtils;
+import net.gsantner.opoc.util.StringUtils;
 
 public class MarkdownAutoFormat implements InputFilter {
     @Override

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -70,14 +70,16 @@ public class MarkdownAutoFormat implements InputFilter {
         Arrays.fill(indentChars, ' ');
         String indentString = new String(indentChars);
 
-        Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(dest.toString().substring(iend, dend));
+        String previousLine = dest.toString().substring(iend, dend);
+
+        Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(previousLine);
         if (uMatch.find()) {
-            indentString += uMatch.group() + " ";
-        } else {
-            Matcher oMatch = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(dest.toString().substring(iend, dend));
-            if (oMatch.find()) {
-                indentString += addNumericListItemIfNeeded(oMatch.group(1));
-            }
+            return indentString + uMatch.group() + " ";
+        }
+
+        Matcher oMatch = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(previousLine);
+        if (oMatch.find()) {
+            return indentString + addNumericListItemIfNeeded(oMatch.group(1));
         }
 
         return indentString;

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -11,6 +11,7 @@ package net.gsantner.markor.format.markdown;
 
 import android.text.InputFilter;
 import android.text.Spanned;
+import android.util.Log;
 
 import java.util.regex.Matcher;
 import java.util.Arrays;
@@ -75,12 +76,15 @@ public class MarkdownAutoFormat implements InputFilter {
 
         Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(previousLine);
         if (uMatch.find()) {
-            return indentString + uMatch.group() + " ";
+            String bullet = uMatch.group() + " ";
+            Boolean emptyList = previousLine.equals(bullet);
+            return indentString + (emptyList ? "" : bullet);
         }
 
         Matcher oMatch = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(previousLine);
         if (oMatch.find()) {
-            return indentString + addNumericListItemIfNeeded(oMatch.group(1));
+            Boolean emptyList = previousLine.equals(oMatch.group(1) + ". ");
+            return indentString + (emptyList ? "" : addNumericListItemIfNeeded(oMatch.group(1)));
         }
 
         return indentString;

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -11,7 +11,6 @@ package net.gsantner.markor.format.markdown;
 
 import android.text.InputFilter;
 import android.text.Spanned;
-import android.util.Log;
 
 import java.util.regex.Matcher;
 import java.util.Arrays;

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -19,10 +19,11 @@ public class MarkdownAutoFormat implements InputFilter {
     @Override
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
         try {
-            if (start < source.length() && dstart <= dest.length()) {
-                if (isNewLine(source, start, end)) {
-                    return autoIndent(source, dest, dstart, dend);
-                }
+            if (start < source.length()
+                    && dstart <= dest.length()
+                    && isNewLine(source, start, end)) {
+
+                return autoIndent(source, dest, dstart, dend);
             }
         } catch (IndexOutOfBoundsException | NullPointerException e) {
             e.printStackTrace();

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -20,7 +20,7 @@ public class MarkdownAutoFormat implements InputFilter {
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
         try {
             if (start < source.length() && dstart <= dest.length()) {
-                if (source.charAt(start) == '\n' || source.charAt(end - 1) == '\n') {
+                if ((source.charAt(start) == '\n') || (source.charAt(end - 1) == '\n')) {
                     return autoIndent(source, dest, dstart, dend);
                 }
             }
@@ -66,7 +66,6 @@ public class MarkdownAutoFormat implements InputFilter {
         Arrays.fill(indentChars, ' ');
         String indentString = new String(indentChars);
 
-        // Add appropriate list identifier
         Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(dest.toString().substring(iend, dend));
         if (uMatch.find()) {
             indentString += uMatch.group() + " ";

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -20,7 +20,7 @@ public class MarkdownAutoFormat implements InputFilter {
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
         try {
             if (start < source.length() && dstart <= dest.length()) {
-                if ((source.charAt(start) == '\n') || (source.charAt(end - 1) == '\n')) {
+                if (isNewLine(source, start, end)) {
                     return autoIndent(source, dest, dstart, dend);
                 }
             }
@@ -28,6 +28,10 @@ public class MarkdownAutoFormat implements InputFilter {
             e.printStackTrace();
         }
         return source;
+    }
+
+    private static Boolean isNewLine(CharSequence source, int start, int end) {
+        return ((source.charAt(start) == '\n') || (source.charAt(end - 1) == '\n'));
     }
 
     private CharSequence autoIndent(CharSequence source, Spanned dest, int dstart, int dend) {

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighterPattern.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighterPattern.java
@@ -17,7 +17,7 @@ public enum MarkdownHighlighterPattern {
     HEADING(Pattern.compile("(?m)((^#{1,6}[^\\S\\n][^\\n]+)|((\\n|^)[^\\s]+.*?\\n(-{2,}|={2,})[^\\S\\n]*$))")),
     HEADING_SIMPLE(Pattern.compile("(?m)(#{1,6}\\s.*$)")),
     LINK(Pattern.compile("\\[([^\\[]+)\\]\\(([^\\)]+)\\)")),
-    LIST_UNORDERED(Pattern.compile("(\\n|^)\\s{0,12}([*+-])( \\[[ xX]\\])?(?= )")),
+    LIST_UNORDERED(Pattern.compile("(\\n|^)\\s{1,16}([*+-])( \\[[ xX]\\])?(?= )")),
     LIST_ORDERED(Pattern.compile("(?m)^([0-9]+)(\\.)")),
     QUOTATION(Pattern.compile("(\\n|^)>")),
     STRIKETHROUGH(Pattern.compile("~{2}(.*?)\\S~{2}")),

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighterPattern.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighterPattern.java
@@ -17,7 +17,7 @@ public enum MarkdownHighlighterPattern {
     HEADING(Pattern.compile("(?m)((^#{1,6}[^\\S\\n][^\\n]+)|((\\n|^)[^\\s]+.*?\\n(-{2,}|={2,})[^\\S\\n]*$))")),
     HEADING_SIMPLE(Pattern.compile("(?m)(#{1,6}\\s.*$)")),
     LINK(Pattern.compile("\\[([^\\[]+)\\]\\(([^\\)]+)\\)")),
-    LIST_UNORDERED(Pattern.compile("(\\n|^)\\s{1,16}([*+-])( \\[[ xX]\\])?(?= )")),
+    LIST_UNORDERED(Pattern.compile("(\\n|^)\\s{0,16}([*+-])( \\[[ xX]\\])?(?= )")),
     LIST_ORDERED(Pattern.compile("(?m)^([0-9]+)(\\.)")),
     QUOTATION(Pattern.compile("(\\n|^)>")),
     STRIKETHROUGH(Pattern.compile("~{2}(.*?)\\S~{2}")),

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighterPattern.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighterPattern.java
@@ -18,7 +18,7 @@ public enum MarkdownHighlighterPattern {
     HEADING_SIMPLE(Pattern.compile("(?m)(#{1,6}\\s.*$)")),
     LINK(Pattern.compile("\\[([^\\[]+)\\]\\(([^\\)]+)\\)")),
     LIST_UNORDERED(Pattern.compile("(\\n|^)\\s{0,16}([*+-])( \\[[ xX]\\])?(?= )")),
-    LIST_ORDERED(Pattern.compile("(?m)^([0-9]+)(\\.)")),
+    LIST_ORDERED(Pattern.compile("(?m)^([0-9]+)(\\. )")),
     QUOTATION(Pattern.compile("(\\n|^)>")),
     STRIKETHROUGH(Pattern.compile("~{2}(.*?)\\S~{2}")),
     CODE(Pattern.compile("(?m)(`(?!`)(.*?)`)|(^[^\\S\\n]{4}(?![0-9\\-*+]).*$)")),

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -109,54 +109,7 @@ public class HighlightingEditor extends AppCompatEditText {
         });
 
         // This watcher detects and handles termination of lists when last item is empty
-        addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                // Not used
-            }
-
-            @Override
-            public void afterTextChanged(Editable e) {
-                Spannable eSpan = (Spannable) e;
-                for (Object span : eSpan.getSpans(0, e.length(), this.getClass())) {
-                    if ((eSpan.getSpanFlags(span) & Spanned.SPAN_COMPOSING) != 0) {
-                        e.delete(eSpan.getSpanStart(span), eSpan.getSpanEnd(span));
-                    }
-                }
-            }
-
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-
-                if ( count > 0 && start < s.length() && s.charAt(start) == '\n' ) {
-
-                    int iStart;
-                    for (iStart = start - 1; iStart > -1; iStart--) {
-                        if (s.charAt(iStart) == '\n') break;
-                    }
-
-                    int iEnd;
-                    for (iEnd = iStart + 1; iEnd < start; iEnd++) {
-                        char c = s.charAt(iEnd);
-                        if (c != ' ' && c != '\t') break;
-                    }
-
-                    String previousLine = s.subSequence(iEnd, start).toString();
-
-                    Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(previousLine);
-                    if (uMatch.find() && previousLine.equals(uMatch.group() + " ")) {
-                        ((Spannable) s).setSpan(this, iStart, start, Spanned.SPAN_COMPOSING);
-                        return;
-                    }
-
-                    Matcher oMatch = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(previousLine);
-                    if (oMatch.find() && previousLine.equals(oMatch.group(1) + ". ")) {
-                        ((Spannable) s).setSpan(this, iStart, start, Spanned.SPAN_COMPOSING);
-                        return;
-                    }
-                }
-            }
-        });
+        addTextChangedListener(new ListHandler());
     }
 
     public void setHighlighter(Highlighter newHighlighter) {

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -14,20 +14,16 @@ import android.os.Handler;
 import android.support.v7.widget.AppCompatEditText;
 import android.text.Editable;
 import android.text.InputFilter;
-import android.text.Spannable;
-import android.text.Spanned;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 
 import net.gsantner.markor.activity.MainActivity;
-import net.gsantner.markor.format.markdown.MarkdownHighlighterPattern;
 import net.gsantner.markor.model.Document;
 import net.gsantner.markor.util.AppSettings;
 import net.gsantner.markor.util.ContextUtils;
 
 import java.io.File;
-import java.util.regex.Matcher;
 
 
 @SuppressWarnings("UnusedReturnValue")

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -127,16 +127,14 @@ public class HighlightingEditor extends AppCompatEditText {
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
 
-                // This method is called to notify you that, within s,
-                // the count characters beginning at start have just replaced old text that had length before.
                 if ( count > 0 && start < s.length() && s.charAt(start) == '\n' ) {
-                    // Check if previous like matches
-                    int iStart, iEnd;
 
+                    int iStart;
                     for (iStart = start - 1; iStart > -1; iStart--) {
                         if (s.charAt(iStart) == '\n') break;
                     }
 
+                    int iEnd;
                     for (iEnd = iStart + 1; iEnd < start; iEnd++) {
                         char c = s.charAt(iEnd);
                         if (c != ' ' && c != '\t') break;
@@ -144,14 +142,14 @@ public class HighlightingEditor extends AppCompatEditText {
 
                     String previousLine = s.subSequence(iEnd, start).toString();
 
-                    Matcher match = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(previousLine);
-                    if (match.find() && previousLine.equals(match.group() + " ")) {
+                    Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(previousLine);
+                    if (uMatch.find() && previousLine.equals(uMatch.group() + " ")) {
                         ((Spannable) s).setSpan(this, iStart, start, Spanned.SPAN_COMPOSING);
                         return;
                     }
 
-                    match = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(previousLine);
-                    if (match.find() && previousLine.equals(match.group(1) + ". ")) {
+                    Matcher oMatch = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(previousLine);
+                    if (oMatch.find() && previousLine.equals(oMatch.group(1) + ". ")) {
                         ((Spannable) s).setSpan(this, iStart, start, Spanned.SPAN_COMPOSING);
                         return;
                     }

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -108,9 +108,12 @@ public class HighlightingEditor extends AppCompatEditText {
             }
         });
 
+        // This watcher detects and handles termination of lists when last item is empty
         addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                // Not used
+            }
 
             @Override
             public void afterTextChanged(Editable e) {

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -110,9 +110,7 @@ public class HighlightingEditor extends AppCompatEditText {
 
         addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                return;
-            }
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
 
             @Override
             public void afterTextChanged(Editable e) {

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/ListHandler.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/ListHandler.java
@@ -6,7 +6,7 @@ import android.text.Spanned;
 import android.text.TextWatcher;
 
 import net.gsantner.markor.format.markdown.MarkdownHighlighterPattern;
-import net.gsantner.markor.util.StringUtils;
+import net.gsantner.opoc.util.StringUtils;
 
 import java.util.regex.Matcher;
 
@@ -15,6 +15,7 @@ public class ListHandler implements TextWatcher {
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
 
+        // Detects if enter pressed on empty list (correctly handles indent) and marks line for deletion.
         if ( count > 0 && start > -1 && start < s.length() && s.charAt(start) == '\n' ) {
 
             int iStart = StringUtils.getLineStart(s, start);
@@ -38,6 +39,7 @@ public class ListHandler implements TextWatcher {
 
     @Override
     public void afterTextChanged(Editable e) {
+        // Deletes spans marked for deletion
         Spannable eSpan = (Spannable) e;
         for (Object span : eSpan.getSpans(0, e.length(), this.getClass())) {
             if ((eSpan.getSpanFlags(span) & Spanned.SPAN_COMPOSING) != 0) {

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/ListHandler.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/ListHandler.java
@@ -23,16 +23,14 @@ public class ListHandler implements TextWatcher {
             String previousLine = s.subSequence(iEnd, start).toString();
             Spannable sSpan = (Spannable) s;
 
-            if (start < s.length()) start++; // Include the newline
-
             Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(previousLine);
             if (uMatch.find() && previousLine.equals(uMatch.group() + " ")) {
-                sSpan.setSpan(this, iStart , start, Spanned.SPAN_COMPOSING);
+                sSpan.setSpan(this, iStart , start + 1, Spanned.SPAN_COMPOSING);
             }
             else {
                 Matcher oMatch = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(previousLine);
                 if (oMatch.find() && previousLine.equals(oMatch.group(1) + ". ")) {
-                    sSpan.setSpan(this, iStart , start, Spanned.SPAN_COMPOSING);
+                    sSpan.setSpan(this, iStart , start + 1, Spanned.SPAN_COMPOSING);
                 }
             }
         }

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/ListHandler.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/ListHandler.java
@@ -1,0 +1,56 @@
+package net.gsantner.markor.ui.hleditor;
+
+import android.text.Editable;
+import android.text.Spannable;
+import android.text.Spanned;
+import android.text.TextWatcher;
+
+import net.gsantner.markor.format.markdown.MarkdownHighlighterPattern;
+import net.gsantner.markor.util.StringUtils;
+
+import java.util.regex.Matcher;
+
+public class ListHandler implements TextWatcher {
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+        if ( count > 0 && start > -1 && start < s.length() && s.charAt(start) == '\n' ) {
+
+            int iStart = StringUtils.getLineStart(s, start);
+            int iEnd = StringUtils.getNextNonWhitespace(s, iStart);
+
+            String previousLine = s.subSequence(iEnd, start).toString();
+            Spannable sSpan = (Spannable) s;
+
+            if (start < s.length()) start++; // Include the newline
+
+            Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(previousLine);
+            if (uMatch.find() && previousLine.equals(uMatch.group() + " ")) {
+                sSpan.setSpan(this, iStart , start, Spanned.SPAN_COMPOSING);
+            }
+            else {
+                Matcher oMatch = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(previousLine);
+                if (oMatch.find() && previousLine.equals(oMatch.group(1) + ". ")) {
+                    sSpan.setSpan(this, iStart , start, Spanned.SPAN_COMPOSING);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void afterTextChanged(Editable e) {
+        Spannable eSpan = (Spannable) e;
+        for (Object span : eSpan.getSpans(0, e.length(), this.getClass())) {
+            if ((eSpan.getSpanFlags(span) & Spanned.SPAN_COMPOSING) != 0) {
+                e.delete(eSpan.getSpanStart(span), eSpan.getSpanEnd(span));
+            }
+        }
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+        // Not used
+    }
+}
+

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -31,7 +31,7 @@ import net.gsantner.markor.ui.AttachImageOrLinkDialog;
 import net.gsantner.markor.ui.SearchOrCustomTextDialogCreator;
 import net.gsantner.markor.util.ActivityUtils;
 import net.gsantner.markor.util.AppSettings;
-import net.gsantner.markor.util.StringUtils;
+import net.gsantner.opoc.util.StringUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -36,7 +36,6 @@ import net.gsantner.markor.util.StringUtils;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
-import java.util.Arrays;
 
 
 @SuppressWarnings("WeakerAccess")
@@ -211,44 +210,6 @@ public abstract class TextActions {
         }
     }
 
-    protected void runIndentLines(Boolean deIndent) {
-
-        String text = _hlEditor.getText().toString();
-
-        int[] selection = getSelection();
-        TextSelection textSelection = new TextSelection(selection[0], selection[1], _hlEditor.getText());
-
-        int lineStart = findLineStart(textSelection.getSelectionStart(), text);
-
-        char[] chars = new char[_tabWidth];
-        Arrays.fill(chars, ' ');
-        String tabString = new String(chars);
-
-        while (lineStart != -1) {
-
-            if (deIndent) {
-                int textStart = findWhitespaceEnd(lineStart, textSelection.getSelectionEnd(), text);
-                int spaceCount = textStart - lineStart;
-                if (spaceCount >= _tabWidth) {
-                    textSelection.removeText(lineStart, tabString);
-                }
-                else if (spaceCount > 0) {
-                    // Handle case where line is indented by less than tabWidth
-                    for (int i = 0; i < spaceCount; i++) {
-                        textSelection.removeText(lineStart, " ");
-                    }
-                }
-            }
-            else {
-                textSelection.insertText(lineStart, tabString);
-            }
-
-            text = _hlEditor.getText().toString();
-
-            lineStart = findNextLine(lineStart, textSelection.getSelectionEnd(), text);
-        }
-    }
-
     protected void runMarkdownInlineAction(String _action) {
         if (_hlEditor.getText() == null) {
             return;
@@ -365,14 +326,6 @@ public abstract class TextActions {
             }
             case "tmaid_common_time": {
                 DatetimeFormatDialog.showDatetimeFormatDialog(getActivity(), _hlEditor);
-                return true;
-            }
-            case "tmaid_common_indent": {
-                runIndentLines(false);
-                return true;
-            }
-            case "tmaid_common_deindent": {
-                runIndentLines(true);
                 return true;
             }
 

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -110,20 +110,6 @@ public abstract class TextActions {
         }
     }
 
-    protected int[] getSelection() {
-
-        int selectionStart = _hlEditor.getSelectionStart();
-        int selectionEnd = _hlEditor.getSelectionEnd();
-
-        if (selectionEnd < selectionStart) {
-            selectionEnd = _hlEditor.getSelectionStart();
-            selectionStart = _hlEditor.getSelectionEnd();
-        }
-
-        int[] selection = {selectionStart, selectionEnd};
-        return selection;
-    }
-
     public static class TextSelection {
 
         private int _selectionStart;
@@ -172,7 +158,7 @@ public abstract class TextActions {
 
         String text = _hlEditor.getText().toString();
 
-        int[] selection = getSelection();
+        int[] selection = StringUtils.getSelection(_hlEditor);
         TextSelection textSelection = new TextSelection(selection[0], selection[1], _hlEditor.getText());
 
         int lineStart = StringUtils.getLineStart(text, textSelection.getSelectionStart());

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -111,6 +111,20 @@ public abstract class TextActions {
         }
     }
 
+    protected int[] getSelection() {
+
+        int selectionStart = _hlEditor.getSelectionStart();
+        int selectionEnd = _hlEditor.getSelectionEnd();
+
+        if (selectionEnd < selectionStart) {
+            selectionEnd = _hlEditor.getSelectionStart();
+            selectionStart = _hlEditor.getSelectionEnd();
+        }
+
+        int[] selection = {selectionStart, selectionEnd};
+        return selection;
+    }
+
     public static class TextSelection {
 
         private int _selectionStart;
@@ -161,7 +175,7 @@ public abstract class TextActions {
 
         int[] selection = getSelection();
         TextSelection textSelection = new TextSelection(selection[0], selection[1], _hlEditor.getText());
-        
+
         int lineStart = StringUtils.getLineStart(text, textSelection.getSelectionStart());
 
         while (lineStart <= textSelection.getSelectionEnd()) {

--- a/app/src/main/java/net/gsantner/markor/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/markor/util/StringUtils.java
@@ -1,0 +1,57 @@
+package net.gsantner.markor.util;
+
+public final class StringUtils {
+
+    // Suppress default constructor for noninstantiability
+    private StringUtils() {
+        throw new AssertionError();
+    }
+
+    public static int getLineStart(CharSequence s, int start) {
+        return getLineStart(s, start, 0);
+    }
+
+    public static int getLineStart(CharSequence s, int start, int minRange) {
+        int i = start;
+        for (; i > minRange; i--) {
+             if (s.charAt(i - 1) == '\n') {
+                 break;
+             }
+        }
+
+        return i;
+    }
+
+    public static int getLineEnd(CharSequence s, int start) {
+        return getLineEnd(s, start, s.length());
+    }
+
+    public static int getLineEnd(CharSequence s, int start, int maxRange) {
+        maxRange = Math.max(maxRange, s.length());
+        int i = start;
+        for (; i < maxRange; i++) {
+            if (s.charAt(i) == '\n') {
+                break;
+            }
+        }
+
+        return i;
+    }
+
+    public static int getNextNonWhitespace(CharSequence s, int start) {
+        return getNextNonWhitespace(s, start, s.length());
+    }
+
+    public static int getNextNonWhitespace(CharSequence s, int start, int maxRange) {
+        maxRange = Math.max(maxRange, s.length());
+        int i = start;
+        for (; i < maxRange; i++) {
+            char c = s.charAt(i);
+            if (c != ' ' && c != '\t') {
+                break;
+            }
+        }
+        return i;
+    }
+
+}

--- a/app/src/main/java/net/gsantner/markor/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/markor/util/StringUtils.java
@@ -27,9 +27,8 @@ public final class StringUtils {
     }
 
     public static int getLineEnd(CharSequence s, int start, int maxRange) {
-        int limitedMaxRange = Math.max(maxRange, s.length());
         int i = start;
-        for (; i < limitedMaxRange; i++) {
+        for (; i < maxRange && i < s.length(); i++) {
             if (s.charAt(i) == '\n') {
                 break;
             }
@@ -43,9 +42,8 @@ public final class StringUtils {
     }
 
     public static int getNextNonWhitespace(CharSequence s, int start, int maxRange) {
-        maxRange = Math.max(maxRange, s.length());
         int i = start;
-        for (; i < maxRange; i++) {
+        for (; i < maxRange && i < s.length(); i++) {
             char c = s.charAt(i);
             if (c != ' ' && c != '\t') {
                 break;
@@ -53,5 +51,4 @@ public final class StringUtils {
         }
         return i;
     }
-
 }

--- a/app/src/main/java/net/gsantner/markor/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/markor/util/StringUtils.java
@@ -27,9 +27,9 @@ public final class StringUtils {
     }
 
     public static int getLineEnd(CharSequence s, int start, int maxRange) {
-        maxRange = Math.max(maxRange, s.length());
+        int limitedMaxRange = Math.max(maxRange, s.length());
         int i = start;
-        for (; i < maxRange; i++) {
+        for (; i < limitedMaxRange; i++) {
             if (s.charAt(i) == '\n') {
                 break;
             }

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -1,5 +1,8 @@
 package net.gsantner.opoc.util;
 
+import android.text.Editable;
+import android.widget.TextView;
+
 public final class StringUtils {
 
     // Suppress default constructor for noninstantiability
@@ -51,4 +54,19 @@ public final class StringUtils {
         }
         return i;
     }
+
+    public static int[] getSelection(TextView text) {
+
+        int selectionStart = text.getSelectionStart();
+        int selectionEnd = text.getSelectionEnd();
+
+        if (selectionEnd < selectionStart) {
+            selectionEnd = text.getSelectionStart();
+            selectionStart = text.getSelectionEnd();
+        }
+
+        int[] selection = {selectionStart, selectionEnd};
+        return selection;
+    }
+
 }

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -1,4 +1,4 @@
-package net.gsantner.markor.util;
+package net.gsantner.opoc.util;
 
 public final class StringUtils {
 

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -1,6 +1,5 @@
 package net.gsantner.opoc.util;
 
-import android.text.Editable;
 import android.widget.TextView;
 
 public final class StringUtils {

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -209,6 +209,8 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="tmaid_common_jump_to_bottom" translatable="false">tmaid_common_jump_to_bottom</string>
     <string name="tmaid_common_search_in_content_of_current_file" translatable="false">tmaid_common_search_in_content_of_current_file</string>
     <string name="tmaid_common_accordion" translatable="false">tmaid_common_accordion</string>
+    <string name="tmaid_common_indent" translatable="false">tmaid_common_indent</string>
+    <string name="tmaid_common_deindent" translatable="false">tmaid_common_deindent</string>
 
     <string name="tmaid_markdown_quote" translatable="false">tmaid_markdown_quote</string>
     <string name="tmaid_markdown_h1" translatable="false">tmaid_markdown_h1</string>

--- a/app/thirdparty/java/other/writeily/format/markdown/WrMarkdownHeaderSpanCreator.java
+++ b/app/thirdparty/java/other/writeily/format/markdown/WrMarkdownHeaderSpanCreator.java
@@ -47,7 +47,7 @@ public class WrMarkdownHeaderSpanCreator implements SpanCreator.ParcelableSpanCr
             final char[] charSequence = extractMatchingRange(m);
             float proportion = calculateProportionBasedOnHeaderType(charSequence);
             Float size = calculateAdjustedSize(proportion);
-            return new TextAppearanceSpan(_highlighter._fontType, Typeface.BOLD, (int) size.byteValue(),
+            return new TextAppearanceSpan(_highlighter._fontType, Typeface.BOLD, size.byteValue(),
                     ColorStateList.valueOf(_color), null);
         } else {
             return new ForegroundColorSpan(_color);

--- a/app/thirdparty/java/other/writeily/ui/WrFilesystemListAdapter.java
+++ b/app/thirdparty/java/other/writeily/ui/WrFilesystemListAdapter.java
@@ -123,7 +123,7 @@ public class WrFilesystemListAdapter extends ArrayAdapter<File> implements Filte
             StringBuilder sb = new StringBuilder();
             sb.append(_context.getResources().getQuantityString(R.plurals.documents, documentAmount));
             sb.append(": ");
-            sb.append(Integer.toString(documentAmount));
+            sb.append(documentAmount);
             if (filesAmount != documentAmount) {
                 sb.append(String.format(Locale.ROOT, " / %s: %d", _context.getString(R.string.files), filesAmount));
             }

--- a/app/thirdparty/java/other/writeily/ui/WrRenameDialog.java
+++ b/app/thirdparty/java/other/writeily/ui/WrRenameDialog.java
@@ -142,7 +142,7 @@ public class WrRenameDialog extends DialogFragment {
             @Override
             public void afterTextChanged(Editable s) {
                 if (_filenameClash) {
-                    ((AlertDialog) _dialog).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                    _dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
                     ((TextView) _dialog.findViewById(R.id.dialog_message)).setText("");
                     _filenameClash = false;
                 }

--- a/app/thirdparty/res/drawable/ic_format_indent_decrease_black_24dp.xml
+++ b/app/thirdparty/res/drawable/ic_format_indent_decrease_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M11,17h10v-2L11,15v2zM3,12l4,4L7,8l-4,4zM3,21h18v-2L3,19v2zM3,3v2h18L21,3L3,3zM11,9h10L21,7L11,7v2zM11,13h10v-2L11,11v2z"/>
+</vector>

--- a/app/thirdparty/res/drawable/ic_format_indent_increase_black_24dp.xml
+++ b/app/thirdparty/res/drawable/ic_format_indent_increase_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,21h18v-2L3,19v2zM3,8v8l4,-4 -4,-4zM11,17h10v-2L11,15v2zM3,3v2h18L21,3L3,3zM11,9h10L21,7L11,7v2zM11,13h10v-2L11,11v2z"/>
+</vector>


### PR DESCRIPTION
This PR addresses #882 and #336. #869 is partially addressed as well

Fixes / changes include:

1. Change unordered maximum leading spaces to 16
2. Handle case where last inserted character is a newline (this happens when android fixes a spelling)
3. Simplify handling of leading space in auto indent. Behavior is now like a text editor auto indent. The leading indent of the current line is always carried over. This automatically addresses indent in indented code block.
4. In a list, if <CR> (enter) is pressed in an empty list, that element is removed. (See https://github.com/gsantner/markor/issues/336#issuecomment-605091437) 

All of these changes only affect the markdown format as I found making all the necessary changes too hard to do.
