### PR TITLE
Heading buttons change heading level

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
@@ -90,26 +90,23 @@ public class MarkdownTextActions extends TextActions {
             view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
             switch (_action) {
                 case R.string.tmaid_markdown_quote: {
-                    runMarkdownRegularPrefixAction("> ");
+                    runRegularPrefixAction("> ");
                     break;
                 }
                 case R.string.tmaid_markdown_h1: {
                     setHeadingAction(1);
-                    //runMarkdownRegularPrefixAction("# ");
                     break;
                 }
                 case R.string.tmaid_markdown_h2: {
                     setHeadingAction(2);
-                    //runMarkdownRegularPrefixAction("## ");
                     break;
                 }
                 case R.string.tmaid_markdown_h3: {
                     setHeadingAction(3);
-                    //runMarkdownRegularPrefixAction("### ");
                     break;
                 }
                 /*case R.string.tmaid_common_unordered_list_char: {
-                    runMarkdownRegularPrefixAction(_appSettings.getUnorderedListCharacter() + " ");
+                    runRegularPrefixAction(_appSettings.getUnorderedListCharacter() + " ");
                     break;
                 }*/
                 case R.string.tmaid_markdown_bold: {
@@ -202,5 +199,39 @@ public class MarkdownTextActions extends TextActions {
                 _hlEditor.simulateKeyPress(KeyEvent.KEYCODE_DPAD_UP);
             }
         };
+    }
+
+
+    /**
+     * Set/unset ATX heading level on each selected line
+     *
+     * This routine will make the following conditional changes
+     *
+     * Line is heading of same level as requested -> remove heading
+     * Line is heading of different level that that requested -> add heading of specified level
+     * Line is not heading -> add heading of specified level
+     *
+     * @param level ATX heading level
+     */
+    protected void setHeadingAction(int level) {
+        // Commonmark allows headings of level 1 - 6
+        assert(level >= 1);
+        assert(level <= 6);
+
+        char[] headerChars = new char[level];
+        Arrays.fill(headerChars, '#');
+        String header = new String(headerChars) + ' ';
+
+        ReplacePattern[] patterns = {
+                // Remove extant heading of matching level (preserves leading space)
+                // Commonmark allows up to 3 leading spaces
+                new ReplacePattern(String.format("^(\\s{0,3})#{%d}\\s", level), "$1"),
+                // Convert extant heading to requested level
+                new ReplacePattern("^(\\s{0,3})(#{1,6})\\s", "$1" + header),
+                // Add heading if not a heading
+                new ReplacePattern("^", header),
+        };
+
+        runRegexReplaceAction(Arrays.asList(patterns));
     }
 }

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
@@ -94,15 +94,18 @@ public class MarkdownTextActions extends TextActions {
                     break;
                 }
                 case R.string.tmaid_markdown_h1: {
-                    runMarkdownRegularPrefixAction("# ");
+                    setHeadingAction(1);
+                    //runMarkdownRegularPrefixAction("# ");
                     break;
                 }
                 case R.string.tmaid_markdown_h2: {
-                    runMarkdownRegularPrefixAction("## ");
+                    setHeadingAction(2);
+                    //runMarkdownRegularPrefixAction("## ");
                     break;
                 }
                 case R.string.tmaid_markdown_h3: {
-                    runMarkdownRegularPrefixAction("### ");
+                    setHeadingAction(3);
+                    //runMarkdownRegularPrefixAction("### ");
                     break;
                 }
                 /*case R.string.tmaid_common_unordered_list_char: {

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
@@ -110,23 +110,23 @@ public class MarkdownTextActions extends TextActions {
                     break;
                 }*/
                 case R.string.tmaid_markdown_bold: {
-                    runMarkdownInlineAction("**");
+                    runInlineAction("**");
                     break;
                 }
                 case R.string.tmaid_markdown_italic: {
-                    runMarkdownInlineAction("_");
+                    runInlineAction("_");
                     break;
                 }
                 case R.string.tmaid_markdown_strikeout: {
-                    runMarkdownInlineAction("~~");
+                    runInlineAction("~~");
                     break;
                 }
                 case R.string.tmaid_markdown_code_inline: {
-                    runMarkdownInlineAction("`");
+                    runInlineAction("`");
                     break;
                 }
                 case R.string.tmaid_markdown_horizontal_line: {
-                    runMarkdownInlineAction("----\n");
+                    runInlineAction("----\n");
                     break;
                 }
                 case R.string.tmaid_markdown_table_insert_columns: {

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtHighlighter.java
@@ -44,6 +44,7 @@ public class TodoTxtHighlighter extends Highlighter {
             createParagraphStyleSpanForMatches(editable, TodoTxtHighlighterPattern.LINE_OF_TEXT.getPattern(),
                     (matcher, iM) -> new FirstLineTopPaddedParagraphSpan(2f));
 
+
             _profiler.restart("Context");
             createColorSpanForMatches(editable, TodoTxtHighlighterPattern.CONTEXT.getPattern(), colors.getContextColor());
             _profiler.restart("Category");
@@ -73,6 +74,7 @@ public class TodoTxtHighlighter extends Highlighter {
             createColorSpanForMatches(editable, TodoTxtHighlighterPattern.DUE_DATE.getPattern(), colors.getPriorityColor(1), 1);
             //createColorSpanForMatches(editable, TodoTxtHighlighterPattern.CREATION_DATE.getPattern(), 0xff00ff00);
             //createColorSpanForMatches(editable, TodoTxtHighlighterPattern.COMPLETION_DATE.getPattern(), 0xff0000ff);
+
 
             // Paragraph divider
             _profiler.restart("Paragraph divider");

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtHighlighter.java
@@ -44,7 +44,6 @@ public class TodoTxtHighlighter extends Highlighter {
             createParagraphStyleSpanForMatches(editable, TodoTxtHighlighterPattern.LINE_OF_TEXT.getPattern(),
                     (matcher, iM) -> new FirstLineTopPaddedParagraphSpan(2f));
 
-
             _profiler.restart("Context");
             createColorSpanForMatches(editable, TodoTxtHighlighterPattern.CONTEXT.getPattern(), colors.getContextColor());
             _profiler.restart("Category");
@@ -74,7 +73,6 @@ public class TodoTxtHighlighter extends Highlighter {
             createColorSpanForMatches(editable, TodoTxtHighlighterPattern.DUE_DATE.getPattern(), colors.getPriorityColor(1), 1);
             //createColorSpanForMatches(editable, TodoTxtHighlighterPattern.CREATION_DATE.getPattern(), 0xff00ff00);
             //createColorSpanForMatches(editable, TodoTxtHighlighterPattern.COMPLETION_DATE.getPattern(), 0xff0000ff);
-
 
             // Paragraph divider
             _profiler.restart("Paragraph divider");

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -386,18 +386,6 @@ public abstract class TextActions {
         }
     }
 
-    //protected void runMarkdownRegexAction(@NonNull String search, @NonNull String replace) {
-    //    runMarkdownRegexAction(search, replace, false);
-    //}
-
-    //protected void runMarkdownRegexAction(@NonNull String search, @NonNull String replace, boolean onlySearch) {
-    //    runMarkdownRegexAction(Pattern.compile(search), replace, false);
-    //}
-
-    //protected void runMarkdownRegexAction(Pattern searchPattern, @NonNull String replace) {
-    //    runMarkdownRegexAction(searchPattern, replace, false);
-    //}
-
     /**
      * Set/unset ATX heading level on each selected line
      *
@@ -419,11 +407,11 @@ public abstract class TextActions {
         String header = new String(headerChars) + ' ';
 
         ReplacePattern[] patterns = {
-                // Remove extant heading of matching level
+                // Remove extant heading of matching level (preserves leading space)
                 // Commonmark allows up to 3 leading spaces
                 new ReplacePattern(String.format("^(\\s{0,3})#{%d}\\s", level), "$1"),
                 // Convert extant heading to requested level
-                new ReplacePattern("^(\\s{0,3})(#{0,6})\\s", "$1" + header),
+                new ReplacePattern("^(\\s{0,3})(#{1,6})\\s", "$1" + header),
                 // Add heading if not a heading
                 new ReplacePattern("^", header),
         };
@@ -466,9 +454,9 @@ public abstract class TextActions {
     }
 
     /**
-     * Runs through a sequence of regex search and replace actions on each selected line.
+     * Runs through a sequence of regex-search-and-replace actions on each selected line.
      *
-     * @param patterns An array of ReplacePatterns
+     * @param patterns An array of ReplacePattern
      * @param matchAll Whether to stop matching subsequent ReplacePatterns after first match+replace
      */
     protected void runMarkdownRegexAction(ReplacePattern[] patterns, boolean matchAll) {

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -247,89 +247,107 @@ public abstract class TextActions {
         }
     }
 
-    public static class TextSelection {
+    protected void runRegularPrefixAction(String action) {
+        runRegularPrefixAction(action, null, false);
+    }
 
-        private int _selectionStart;
-        private int _selectionEnd;
-        private Editable _editable;
+    protected void runRegularPrefixAction(String action, Boolean ignoreIndent) {
+        runRegularPrefixAction(action, null, ignoreIndent);
+    }
 
+    protected void runRegularPrefixAction(String action, String replaceString) {
+        runRegularPrefixAction(action, replaceString, false);
+    }
 
-        TextSelection(int start, int end, Editable editable) {
-            _selectionStart = start;
-            _selectionEnd = end;
-            _editable = editable;
+    protected void runRegularPrefixAction(String action, String replaceString, Boolean ignoreIndent) {
+
+        if (replaceString == null) replaceString = "";
+
+        String patternIndent = ignoreIndent ? "(^\\s*)" : "(^)";
+        String replaceIndent = "$1";
+
+        String escapedAction = String.format("\\Q%s\\E", action);
+        String escapedReplace = String.format("(\\Q%s\\E)?", replaceString);
+
+        ReplacePattern[] patterns = {
+                // Replace action with replacement
+                new ReplacePattern(patternIndent + escapedAction, replaceIndent + replaceString),
+                // Replace replacement or nothing with action
+                new ReplacePattern(patternIndent + escapedReplace, replaceIndent + action),
+        };
+
+        runRegexReplaceAction(Arrays.asList(patterns));
+    }
+
+    protected class ReplacePattern {
+        public Pattern searchPattern;
+        public String replacePattern;
+        public boolean replaceAll;
+
+        /**
+         * Construct a ReplacePattern
+         * @param searchPattern regex search pattern
+         * @param replacePattern replace string
+         * @param replaceAll whether to replace all or just the first
+         */
+        public ReplacePattern(Pattern searchPattern, String replacePattern, boolean replaceAll) {
+            this.searchPattern = searchPattern;
+            this.replacePattern = replacePattern;
+            this.replaceAll = replaceAll;
         }
 
-        private void insertText(int location, String text) {
-            _editable.insert(location, text);
-            _selectionEnd += text.length();
+        public ReplacePattern(String searchPattern, String replacePattern, boolean replaceAll) {
+            this(Pattern.compile(searchPattern), replacePattern, replaceAll);
         }
 
-        private void removeText(int location, String text) {
-            _editable.delete(location, location + text.length());
-            _selectionEnd -= text.length();
+        public ReplacePattern(Pattern searchPattern, String replacePattern) {
+            this(searchPattern, replacePattern, false);
         }
 
-        private int getSelectionStart() {
-            return _selectionStart;
-        }
-
-        private int getSelectionEnd() {
-            return _selectionEnd;
+        public ReplacePattern(String searchPattern, String replacePattern) {
+            this(Pattern.compile(searchPattern), replacePattern, false);
         }
     }
 
-    protected void runMarkdownRegularPrefixAction(String action) {
-        runMarkdownRegularPrefixAction(action, null, false);
+    protected void runRegexReplaceAction(List<ReplacePattern> patterns) {
+        runRegexReplaceAction(patterns, false);
     }
 
-    protected void runMarkdownRegularPrefixAction(String action, Boolean ignoreIndent) {
-        runMarkdownRegularPrefixAction(action, null, ignoreIndent);
-    }
+    /**
+     * Runs through a sequence of regex-search-and-replace actions on each selected line.
+     *
+     * @param patterns An array of ReplacePattern
+     * @param matchAll Whether to stop matching subsequent ReplacePatterns after first match+replace
+     */
+    protected void runRegexReplaceAction(List<ReplacePattern> patterns, boolean matchAll) {
 
-    protected void runMarkdownRegularPrefixAction(String action, String replaceString) {
-        runMarkdownRegularPrefixAction(action, replaceString, false);
-    }
-
-    protected void runMarkdownRegularPrefixAction(String action, String replaceString, Boolean ignoreIndent) {
-
-        String text = _hlEditor.getText().toString();
-
+        Editable text = _hlEditor.getText();
         int[] selection = StringUtils.getSelection(_hlEditor);
-        TextSelection textSelection = new TextSelection(selection[0], selection[1], _hlEditor.getText());
 
-        int lineStart = StringUtils.getLineStart(text, textSelection.getSelectionStart());
+        int lineStart = StringUtils.getLineStart(text, selection[0]);
+        int selEnd = StringUtils.getLineEnd(text, selection[1]);
 
-        while (lineStart <= textSelection.getSelectionEnd()) {
+        while (lineStart <= selEnd && lineStart <= text.length()) {
 
-            if (ignoreIndent) {
-                lineStart = StringUtils.getNextNonWhitespace(text, lineStart, textSelection.getSelectionEnd());
-            }
+            int lineEnd = StringUtils.getLineEnd(text, lineStart, selEnd);
+            CharSequence line = text.subSequence(lineStart, lineEnd);
 
-            int selEnd = StringUtils.getLineEnd(text, textSelection.getSelectionEnd());
-            String remainingString = text.substring(lineStart, selEnd);
+            for (ReplacePattern pattern : patterns) {
+                Matcher matcher = pattern.searchPattern.matcher(line);
+                if (matcher.find()) {
 
-            if (replaceString == null) {
-                if (remainingString.startsWith(action)) {
-                    textSelection.removeText(lineStart, action);
-                } else {
-                    textSelection.insertText(lineStart, action);
-                }
-            } else {
-                if (remainingString.startsWith(action)) {
-                    textSelection.removeText(lineStart, action);
-                    textSelection.insertText(lineStart, replaceString);
-                } else if (remainingString.startsWith(replaceString)) {
-                    textSelection.removeText(lineStart, replaceString);
-                    textSelection.insertText(lineStart, action);
-                } else {
-                    textSelection.insertText(lineStart, action);
+                    String newLine;
+                    if (pattern.replaceAll) newLine = matcher.replaceAll(pattern.replacePattern);
+                    else newLine = matcher.replaceFirst(pattern.replacePattern);
+
+                    text.replace(lineStart, lineEnd, newLine);
+                    selEnd += newLine.length() - line.length();
+
+                    if (!matchAll) break; // Exit after first match
                 }
             }
 
-            text = _hlEditor.getText().toString();
-            // Get next line
-            lineStart = StringUtils.getLineEnd(text, lineStart, textSelection.getSelectionEnd()) + 1;
+            lineStart = StringUtils.getLineEnd(text, lineStart, selEnd) + 1;
         }
     }
 
@@ -386,119 +404,6 @@ public abstract class TextActions {
         }
     }
 
-    /**
-     * Set/unset ATX heading level on each selected line
-     *
-     * This routine will make the following conditional changes
-     *
-     * Line is heading of same level as requested -> remove heading
-     * Line is heading of different level that that requested -> add heading of specified level
-     * Line is not heading -> add heading of specified level
-     *
-     * @param level ATX heading level
-     */
-    protected void setHeadingAction(int level) {
-        // Commonmark allows headings of level 1 - 6
-        assert(level >= 1);
-        assert(level <= 6);
-
-        char[] headerChars = new char[level];
-        Arrays.fill(headerChars, '#');
-        String header = new String(headerChars) + ' ';
-
-        ReplacePattern[] patterns = {
-                // Remove extant heading of matching level (preserves leading space)
-                // Commonmark allows up to 3 leading spaces
-                new ReplacePattern(String.format("^(\\s{0,3})#{%d}\\s", level), "$1"),
-                // Convert extant heading to requested level
-                new ReplacePattern("^(\\s{0,3})(#{1,6})\\s", "$1" + header),
-                // Add heading if not a heading
-                new ReplacePattern("^", header),
-        };
-
-        runMarkdownRegexAction(patterns);
-    }
-
-    protected class ReplacePattern {
-        public Pattern search;
-        public String replace;
-        public boolean onlyFirst;
-
-        /**
-         * Construct a ReplacePattern
-         * @param search regex search pattern
-         * @param replace replace string
-         * @param onlyFirst whether to replaceAll or replaceFirst is used
-         */
-        public ReplacePattern(Pattern search, String replace, boolean onlyFirst) {
-            this.search = search;
-            this.replace = replace;
-            this.onlyFirst = onlyFirst;
-        }
-
-        public ReplacePattern(String search, String replace, boolean onlyFirst) {
-            this(Pattern.compile(search), replace, onlyFirst);
-        }
-
-        public ReplacePattern(String search, String replace) {
-            this(Pattern.compile(search), replace);
-        }
-
-        public ReplacePattern(Pattern search, String replace) {
-            this(search, replace, true);
-        }
-    }
-
-    protected void runMarkdownRegexAction(ReplacePattern[] patterns) {
-        runMarkdownRegexAction(patterns, false);
-    }
-
-    /**
-     * Runs through a sequence of regex-search-and-replace actions on each selected line.
-     *
-     * @param patterns An array of ReplacePattern
-     * @param matchAll Whether to stop matching subsequent ReplacePatterns after first match+replace
-     */
-    protected void runMarkdownRegexAction(ReplacePattern[] patterns, boolean matchAll) {
-
-        StringBuilder text = new StringBuilder(_hlEditor.getText());
-        int[] selection = StringUtils.getSelection(_hlEditor);
-
-        int lineStart = StringUtils.getLineStart(text, selection[0]);
-        int selEnd = StringUtils.getLineEnd(text, selection[1]);
-
-        boolean changed = false;
-        while (lineStart <= selEnd && lineStart <= text.length()) {
-
-            int lineEnd = StringUtils.getLineEnd(text, lineStart, selEnd);
-            CharSequence line = text.subSequence(lineStart, lineEnd);
-
-            for (ReplacePattern pattern : patterns) {
-                Matcher matcher = pattern.search.matcher(line);
-                if (matcher.find()) {
-
-                    String newLine;
-                    if (pattern.onlyFirst) newLine = matcher.replaceFirst(pattern.replace);
-                    else newLine = matcher.replaceAll(pattern.replace);
-
-                    // Update text and selection
-                    text.replace(lineStart, lineEnd, newLine);
-                    selEnd += newLine.length() - line.length();
-
-                    changed = true; // Mark text as changed
-                    if (!matchAll) break; // Exit after first match
-                }
-            }
-
-            lineStart = StringUtils.getLineEnd(text, lineStart, selEnd) + 1;
-        }
-
-        if (changed) {
-            _hlEditor.setText(text.toString());
-            _hlEditor.setSelection(selEnd);
-        }
-    }
-
     //
     //
     //
@@ -549,15 +454,15 @@ public abstract class TextActions {
     protected boolean runCommonTextAction(String action) {
         switch (action) {
             case "tmaid_common_unordered_list_char": {
-                runMarkdownRegularPrefixAction(_appSettings.getUnorderedListCharacter() + " ", true);
+                runRegularPrefixAction(_appSettings.getUnorderedListCharacter() + " ", true);
                 return true;
             }
             case "tmaid_common_checkbox_list": {
-                runMarkdownRegularPrefixAction("- [ ] ", "- [x] ", true);
+                runRegularPrefixAction("- [ ] ", "- [x] ", true);
                 return true;
             }
             case "tmaid_common_ordered_list_number": {
-                runMarkdownRegularPrefixAction("1. ", true);
+                runRegularPrefixAction("1. ", true);
                 return true;
             }
             case "tmaid_common_time": {

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -259,19 +259,19 @@ public abstract class TextActions {
         runRegularPrefixAction(action, replaceString, false);
     }
 
-    protected void runRegularPrefixAction(String action, String replaceString, Boolean ignoreIndent) {
+    protected void runRegularPrefixAction(final String action, final String replaceString, final Boolean ignoreIndent) {
 
-        if (replaceString == null) replaceString = "";
+        String replacement = (replaceString == null)? "" : replaceString;
 
         String patternIndent = ignoreIndent ? "(^\\s*)" : "(^)";
         String replaceIndent = "$1";
 
         String escapedAction = String.format("\\Q%s\\E", action);
-        String escapedReplace = String.format("(\\Q%s\\E)?", replaceString);
+        String escapedReplace = String.format("(\\Q%s\\E)?", replacement);
 
         ReplacePattern[] patterns = {
                 // Replace action with replacement
-                new ReplacePattern(patternIndent + escapedAction, replaceIndent + replaceString),
+                new ReplacePattern(patternIndent + escapedAction, replaceIndent + replacement),
                 // Replace replacement or nothing with action
                 new ReplacePattern(patternIndent + escapedReplace, replaceIndent + action),
         };
@@ -319,7 +319,7 @@ public abstract class TextActions {
      * @param patterns An array of ReplacePattern
      * @param matchAll Whether to stop matching subsequent ReplacePatterns after first match+replace
      */
-    protected void runRegexReplaceAction(List<ReplacePattern> patterns, boolean matchAll) {
+    protected void runRegexReplaceAction(final List<ReplacePattern> patterns, final boolean matchAll) {
 
         Editable text = _hlEditor.getText();
         int[] selection = StringUtils.getSelection(_hlEditor);
@@ -351,7 +351,7 @@ public abstract class TextActions {
         }
     }
 
-    protected void runMarkdownInlineAction(String _action) {
+    protected void runInlineAction(String _action) {
         if (_hlEditor.getText() == null) {
             return;
         }


### PR DESCRIPTION
This PR updates the markdown heading buttons to have the following behavior: 

Line is heading of same level as requested -> remove heading
Line is heading of different level that that requested -> add heading of specified level
Line is not heading -> add heading of specified level

Also included is a regex based match and replace system which may have general utility beyond heading changes