### PR TITLE
PATTERN_PROJECTS PATTERN_CONTEXT regex modified

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/format/todotxt/SttCommander.java
+++ b/app/src/main/java/net/gsantner/opoc/format/todotxt/SttCommander.java
@@ -46,8 +46,8 @@ public class SttCommander {
             " )?" + // End of prefix
             "((a|.)*)" // Take whats left
     );
-    public static final Pattern PATTERN_PROJECTS = Pattern.compile("\\B(?:\\++)(\\S+)");
-    public static final Pattern PATTERN_CONTEXTS = Pattern.compile("\\B(?:\\@+)(\\S+)");
+    public static final Pattern PATTERN_PROJECTS = Pattern.compile("\\s\\+(\\+*\\S+)");
+    public static final Pattern PATTERN_CONTEXTS = Pattern.compile("\\s\\@(\\@*\\S+)");
     public static final Pattern PATTERN_DONE = Pattern.compile("(?m)(^[Xx]) (.*)$");
     public static final Pattern PATTERN_DATE = Pattern.compile("(?:^|\\s|:)(" + PT_DATE + ")(?:$|\\s)");
     public static final Pattern PATTERN_KEY_VALUE_PAIRS__TAG_ONLY = Pattern.compile("(?i)([a-z]+):([a-z0-9_-]+)");

--- a/app/src/main/java/net/gsantner/opoc/format/todotxt/SttCommander.java
+++ b/app/src/main/java/net/gsantner/opoc/format/todotxt/SttCommander.java
@@ -46,8 +46,8 @@ public class SttCommander {
             " )?" + // End of prefix
             "((a|.)*)" // Take whats left
     );
-    public static final Pattern PATTERN_PROJECTS = Pattern.compile("\\s\\+(\\+*\\S+)");
-    public static final Pattern PATTERN_CONTEXTS = Pattern.compile("\\s\\@(\\@*\\S+)");
+    public static final Pattern PATTERN_PROJECTS = Pattern.compile("(?:^|\\n|\\s)\\+(\\+*\\S+)");
+    public static final Pattern PATTERN_CONTEXTS = Pattern.compile("(?:^|\\n|\\s)\\@(\\@*\\S+)");
     public static final Pattern PATTERN_DONE = Pattern.compile("(?m)(^[Xx]) (.*)$");
     public static final Pattern PATTERN_DATE = Pattern.compile("(?:^|\\s|:)(" + PT_DATE + ")(?:$|\\s)");
     public static final Pattern PATTERN_KEY_VALUE_PAIRS__TAG_ONLY = Pattern.compile("(?i)([a-z]+):([a-z0-9_-]+)");


### PR DESCRIPTION
fixes #957 

current definition:

    public static final Pattern PATTERN_PROJECTS = Pattern.compile("\\B(?:\\++)(\\S+)");
    public static final Pattern PATTERN_CONTEXTS = Pattern.compile("\\B(?:\\@+)(\\S+)");

I am not really sure what the `Patter.compile` does, but from my understanding there is some tranformation, maybe the final regex is `\B(?:\@+)(\S+)`

I testerd here: [Online regex tester and debugger: PHP, PCRE, Python, Golang and JavaScript](https://regex101.com/) or here [RegExr: Learn, Build, &amp; Test RegEx](https://regexr.com/)

Test cases:

```
@aaa
qwert @bbb
asd @@ccc
ghi @@@ddd
jkl a@bbb
mno c@@ddd
```

`\B(?:@+)(\S+)`

current definition, has issues

`\B\@(\@*\S+)`

issues with

> mno c@@ddd

`\s\@(\@*\S+)`

works best
