### PR TITLE
Improved auto insert list prefix

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
@@ -227,6 +227,9 @@ public class CommonTextActions {
         Editable text = _hlEditor.getText();
 
         int[] selection = StringUtils.getSelection(_hlEditor);
+        final int[] lStart = StringUtils.getLineOffsetFromIndex(text, selection[0]);
+        final int[] lEnd = StringUtils.getLineOffsetFromIndex(text, selection[1]);
+
         int selectionStart = selection[0];
         int selectionEnd = selection[1];
 
@@ -254,6 +257,10 @@ public class CommonTextActions {
             // Get next line
             lineStart = StringUtils.getLineEnd(text, lineStart, selectionEnd) + 1;
         }
+
+        _hlEditor.setSelection(
+                StringUtils.getIndexFromLineOffset(text, lStart),
+                StringUtils.getIndexFromLineOffset(text, lEnd));
     }
 
     public void moveLineBy1(boolean up) {

--- a/app/src/main/java/net/gsantner/markor/format/markdown/ListHandler.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/ListHandler.java
@@ -37,24 +37,17 @@ public class ListHandler implements TextWatcher {
         // Detects if enter pressed on empty list (correctly handles indent) and marks line for deletion.
         if (count > 0 && start > -1 && start < s.length() && s.charAt(start) == '\n') {
 
-            int iStart = StringUtils.getLineStart(s, start);
-            int iEnd = StringUtils.getNextNonWhitespace(s, iStart);
+            final Spannable sSpan = (Spannable) s;
 
-            String previousLine = s.subSequence(iEnd, start).toString();
-            Spannable sSpan = (Spannable) s;
+            final MarkdownAutoFormat.OrderedListLine oMatch = new MarkdownAutoFormat.OrderedListLine(s, start);
+            final MarkdownAutoFormat.UnOrderedListLine uMatch = new MarkdownAutoFormat.UnOrderedListLine(s, start);
 
-            Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(previousLine);
-            if (uMatch.find() && previousLine.equals(uMatch.group() + " ")) {
-                sSpan.setSpan(this, iStart, start + 1, Spanned.SPAN_COMPOSING);
+            if (oMatch.isOrderedList && oMatch.lineEnd == oMatch.groupEnd) {
+                sSpan.setSpan(this, oMatch.lineStart, oMatch.lineEnd + 1, Spanned.SPAN_COMPOSING);
+            } else if (uMatch.isUnorderedList && uMatch.lineEnd == uMatch.groupEnd) {
+                sSpan.setSpan(this, uMatch.lineStart, uMatch.lineEnd + 1, Spanned.SPAN_COMPOSING);
             } else {
-                Matcher oMatch = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(previousLine);
-                if (oMatch.find()) {
-                    if (previousLine.equals(oMatch.group(1) + ". ")) {
-                        sSpan.setSpan(this, iStart, start + 1, Spanned.SPAN_COMPOSING);
-                    } else {
-                        reorderPosition = start;
-                    }
-                }
+                reorderPosition = start;
             }
         }
     }

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -282,9 +282,12 @@ public class MarkdownAutoFormat implements InputFilter {
 
                     // Update numbering if needed
                     if (line.isOrderedList) {
-                        // Will not renumber if this line is the head
-                        if (levels.peek() != line) {
-                            String number = Integer.toString(levels.peek().value + 1);
+
+                        // Restart numbering if list changes
+                        final OrderedListLine peek = levels.peek();
+                        final int newValue = (line == peek) ? 1 : peek.value + 1;
+                        if (newValue != line.value) {
+                            String number = Integer.toString(newValue);
                             text.replace(line.numStart, line.numEnd, number);
 
                             // Re-create line as it has changed

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -26,7 +26,7 @@ public class MarkdownAutoFormat implements InputFilter {
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
         try {
             if (start < source.length() && dstart <= dest.length() && StringUtils.isNewLine(source, start, end)) {
-                return autoIndent(source, dest, dstart, dend);
+                return autoIndent(source, dest, dstart);
             }
         } catch (IndexOutOfBoundsException | NullPointerException e) {
             e.printStackTrace();
@@ -35,7 +35,8 @@ public class MarkdownAutoFormat implements InputFilter {
     }
 
     @SuppressLint("DefaultLocale")
-    private CharSequence autoIndent(CharSequence source, Spanned dest, int dstart, int dend) {
+    private CharSequence autoIndent(final CharSequence source, final Spanned dest, final int dstart) {
+
         final String checkSymbol = "[ ] ";
 
         final OrderedListLine oLine = new OrderedListLine(dest, dstart);
@@ -199,7 +200,7 @@ public class MarkdownAutoFormat implements InputFilter {
     /**
      * Find the topmost orderd list item which is a parent of the current
      *
-     * @param text Editable
+     * @param text     Editable
      * @param position Position within current line
      * @return OrderedListLine corresponding to top of current list
      */

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -9,6 +9,7 @@
 #########################################################*/
 package net.gsantner.markor.format.markdown;
 
+import android.annotation.SuppressLint;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.Spanned;
@@ -24,10 +25,7 @@ public class MarkdownAutoFormat implements InputFilter {
     @Override
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
         try {
-            if (start < source.length()
-                    && dstart <= dest.length()
-                    && isNewLine(source, start, end)) {
-
+            if (start < source.length() && dstart <= dest.length() && isNewLine(source, start, end)) {
                 return autoIndent(source, dest, dstart, dend);
             }
         } catch (IndexOutOfBoundsException | NullPointerException e) {
@@ -40,47 +38,26 @@ public class MarkdownAutoFormat implements InputFilter {
         return ((source.charAt(start) == '\n') || (source.charAt(end - 1) == '\n'));
     }
 
+    @SuppressLint("DefaultLocale")
     private CharSequence autoIndent(CharSequence source, Spanned dest, int dstart, int dend) {
         int iStart = StringUtils.getLineStart(dest, dstart);
 
-        // append white space of previous line and new indent
-        return source + createIndentForNextLine(dest, dend, iStart);
-    }
+        final String result;
 
-    private String createIndentForNextLine(Spanned dest, int dend, int istart) {
+        final OrderedListLine oLine = new OrderedListLine(dest, dstart);
+        final UnOrderedListLine uLine = new UnOrderedListLine(dest, dstart);
+        final String indent = source + StringUtils.repeatChars(' ', oLine.indent);
 
-        // Determine leading whitespace
-        int iEnd = StringUtils.getNextNonWhitespace(dest, istart);
-
-        // Construct whitespace
-        String indentString = StringUtils.repeatChars(' ', iEnd - istart);
-
-        String previousLine = dest.toString().substring(iEnd, dend);
-
-        Matcher uMatch = MarkdownHighlighterPattern.LIST_UNORDERED.pattern.matcher(previousLine);
-        if (uMatch.find()) {
-            String bullet = uMatch.group() + " ";
-            boolean emptyList = previousLine.equals(bullet);
-            return indentString + (emptyList ? "" : bullet);
+        if (oLine.isOrderedList && oLine.lineEnd != oLine.groupEnd) {
+            result = indent + String.format("%d%c ", oLine.value + 1, oLine.delimiter);
+        } else if (uLine.isUnorderedList && uLine.lineEnd != uLine.groupEnd) {
+            final String checkString = uLine.isCheckboxList ? "[ ] " : "";
+            result = indent + String.format("%c %s", uLine.listChar, checkString);
+        } else {
+            result = indent;
         }
 
-        Matcher oMatch = MarkdownHighlighterPattern.LIST_ORDERED.pattern.matcher(previousLine);
-        if (oMatch.find()) {
-            boolean emptyList = previousLine.equals(oMatch.group(1) + ". ");
-            return indentString + (emptyList ? "" : addNumericListItemIfNeeded(oMatch.group(1)));
-        }
-
-        return indentString;
-    }
-
-    private String addNumericListItemIfNeeded(String itemNumStr) {
-        try {
-            int nextC = Integer.parseInt(itemNumStr) + 1;
-            return nextC + ". ";
-        } catch (NumberFormatException e) {
-            // This should never ever happen
-            return "";
-        }
+        return result;
     }
 
     public static class ListLine {
@@ -123,12 +100,14 @@ public class MarkdownAutoFormat implements InputFilter {
      * Class to parse a line of text and extract useful information
      */
     public static class OrderedListLine extends ListLine {
+        private static final int FULL_GROUP = 2;
         private static final int VALUE_GROUP = 3;
         private static final int DELIM_GROUP = 4;
 
         public final boolean isOrderedList;
         public final char delimiter;
         public final int numStart, numEnd;
+        public final int groupStart, groupEnd;
         public final int value;
 
         public OrderedListLine(CharSequence text, int position) {
@@ -141,8 +120,10 @@ public class MarkdownAutoFormat implements InputFilter {
                 numStart = match.start(VALUE_GROUP) + lineStart;
                 numEnd = match.end(VALUE_GROUP) + lineStart;
                 value = Integer.parseInt(match.group(VALUE_GROUP));
+                groupStart = lineStart + match.start(FULL_GROUP);
+                groupEnd = lineStart + match.end(FULL_GROUP);
             } else {
-                numStart = numEnd = value = -1;
+                groupEnd = groupStart = numStart = numEnd = value = -1;
                 delimiter = 0;
             }
         }

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -25,17 +25,13 @@ public class MarkdownAutoFormat implements InputFilter {
     @Override
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
         try {
-            if (start < source.length() && dstart <= dest.length() && isNewLine(source, start, end)) {
+            if (start < source.length() && dstart <= dest.length() && StringUtils.isNewLine(source, start, end)) {
                 return autoIndent(source, dest, dstart, dend);
             }
         } catch (IndexOutOfBoundsException | NullPointerException e) {
             e.printStackTrace();
         }
         return source;
-    }
-
-    private static Boolean isNewLine(CharSequence source, int start, int end) {
-        return ((source.charAt(start) == '\n') || (source.charAt(end - 1) == '\n'));
     }
 
     @SuppressLint("DefaultLocale")

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -40,18 +40,17 @@ public class MarkdownAutoFormat implements InputFilter {
 
     @SuppressLint("DefaultLocale")
     private CharSequence autoIndent(CharSequence source, Spanned dest, int dstart, int dend) {
-        int iStart = StringUtils.getLineStart(dest, dstart);
-
-        final String result;
+        final String checkSymbol = "[ ] ";
 
         final OrderedListLine oLine = new OrderedListLine(dest, dstart);
         final UnOrderedListLine uLine = new UnOrderedListLine(dest, dstart);
         final String indent = source + StringUtils.repeatChars(' ', oLine.indent);
 
+        final String result;
         if (oLine.isOrderedList && oLine.lineEnd != oLine.groupEnd) {
             result = indent + String.format("%d%c ", oLine.value + 1, oLine.delimiter);
         } else if (uLine.isUnorderedList && uLine.lineEnd != uLine.groupEnd) {
-            final String checkString = uLine.isCheckboxList ? "[ ] " : "";
+            final String checkString = uLine.isCheckboxList ? checkSymbol : "";
             result = indent + String.format("%c %s", uLine.listChar, checkString);
         } else {
             result = indent;

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
@@ -191,7 +191,11 @@ public class MarkdownTextActions extends TextActions {
                     });
                     return true;
                 }
-                case R.string.tmaid_common_indent:
+                case R.string.tmaid_common_indent: {
+                    if (_appSettings.isMarkdownAutoUpdateList()) {
+                        runPrefixReplaceAction(PREFIX_ORDERED_LIST, "$0", "$11$4 ");
+                    }
+                }
                 case R.string.tmaid_common_deindent: {
                     runCommonTextAction(_context.getString(_action));
                     runRenumberOrderedListIfRequired();

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
@@ -191,11 +191,7 @@ public class MarkdownTextActions extends TextActions {
                     });
                     return true;
                 }
-                case R.string.tmaid_common_indent: {
-                    if (_appSettings.isMarkdownAutoUpdateList()) {
-                        runPrefixReplaceAction(PREFIX_ORDERED_LIST, "$0", "$11$4 ");
-                    }
-                }
+                case R.string.tmaid_common_indent:
                 case R.string.tmaid_common_deindent: {
                     runCommonTextAction(_context.getString(_action));
                     runRenumberOrderedListIfRequired();

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -339,12 +339,19 @@ public abstract class TextActions {
                 Matcher matcher = pattern.searchPattern.matcher(line);
                 if (matcher.find()) {
 
-                    String newLine;
-                    if (pattern.replaceAll) newLine = matcher.replaceAll(pattern.replacePattern);
-                    else newLine = matcher.replaceFirst(pattern.replacePattern);
+                    // Optimization. Don't replace if the replace pattern is the pattern itself.
+                    if (!pattern.replacePattern.equals("$0")) {
 
-                    text.replace(lineStart, lineEnd, newLine);
-                    selEnd += newLine.length() - line.length();
+                        final String newLine;
+                        if (pattern.replaceAll) {
+                            newLine = matcher.replaceAll(pattern.replacePattern);
+                        } else {
+                            newLine = matcher.replaceFirst(pattern.replacePattern);
+                        }
+
+                        text.replace(lineStart, lineEnd, newLine);
+                        selEnd += newLine.length() - line.length();
+                    }
 
                     if (!matchAll) break; // Exit after first match
                 }

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -324,6 +324,8 @@ public abstract class TextActions {
 
         Editable text = _hlEditor.getText();
         int[] selection = StringUtils.getSelection(_hlEditor);
+        final int[] lStart = StringUtils.getLineOffsetFromIndex(text, selection[0]);
+        final int[] lEnd = StringUtils.getLineOffsetFromIndex(text, selection[1]);
 
         int lineStart = StringUtils.getLineStart(text, selection[0]);
         int selEnd = StringUtils.getLineEnd(text, selection[1]);
@@ -350,6 +352,10 @@ public abstract class TextActions {
 
             lineStart = StringUtils.getLineEnd(text, lineStart, selEnd) + 1;
         }
+
+        _hlEditor.setSelection(
+                StringUtils.getIndexFromLineOffset(text, lStart),
+                StringUtils.getIndexFromLineOffset(text, lEnd));
     }
 
     protected void runInlineAction(String _action) {

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -11,6 +11,8 @@ package net.gsantner.opoc.util;
 
 import android.widget.TextView;
 
+import com.vladsch.flexmark.util.sequence.CharSubSequence;
+
 import java.util.Arrays;
 
 public final class StringUtils {
@@ -75,8 +77,7 @@ public final class StringUtils {
             selectionStart = text.getSelectionEnd();
         }
 
-        int[] selection = {selectionStart, selectionEnd};
-        return selection;
+        return new int[] {selectionStart, selectionEnd};
     }
 
     public static String repeatChars(char character, int count) {
@@ -85,4 +86,57 @@ public final class StringUtils {
         return new String(stringChars);
     }
 
+    /**
+     * Convert a char index to a line index + offset from end of line
+     * @param s text to parse
+     * @param p position in text
+     * @return int[2] where index 0 is line and index 1 is position from end of line
+     */
+    public static int[] getLineOffsetFromIndex(final CharSequence s, int p) {
+        p = Math.min(Math.max(p, 0), s.length());
+        final int line = countChar(s, '\n', 0, p);
+        final int offset = getLineEnd(s, p) - p;
+
+        return new int[]{line, offset};
+    }
+
+    public static int getIndexFromLineOffset(final CharSequence s, final int[] le) {
+        return getIndexFromLineOffset(s, le[0], le[1]);
+
+    }
+
+    /**
+     * Convert a line index and offset from end of line to absolute position
+     * @param s text to parse
+     * @param l line index
+     * @param e offset from end of line
+     * @return index in s
+     */
+    public static int getIndexFromLineOffset(final CharSequence s, final int l, final int e) {
+        int i = 0, count = 0;
+        for (; i < s.length(); i++) {
+            if (s.charAt(i) == '\n') {
+                count++;
+            }
+            if (count == l) {
+                break;
+            }
+        }
+        if (i < s.length()) {
+            return getLineEnd(s, i + 1) - e;
+        }
+        return i;
+    }
+
+    public static int countChar(final CharSequence s, final char c, int start, int end) {
+        int count = 0;
+        start = Math.max(0, start);
+        end = Math.min(end, s.length());
+        for (int i = start; i < end; i++) {
+            if (s.charAt(i) == c) {
+                count++;
+            }
+        }
+        return count;
+    }
 }

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -128,6 +128,14 @@ public final class StringUtils {
         return i;
     }
 
+    /**
+     * Count instances of char 'c' between start and end
+     * @param s Sequence to count in
+     * @param c Char to count
+     * @param start start of section to count within
+     * @param end end of section to count within
+     * @return number of instances of c in c between start and end
+     */
     public static int countChar(final CharSequence s, final char c, int start, int end) {
         int count = 0;
         start = Math.max(0, start);

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -147,4 +147,8 @@ public final class StringUtils {
         }
         return count;
     }
+
+    public static boolean isNewLine(CharSequence source, int start, int end) {
+        return ((source.charAt(start) == '\n') || (source.charAt(end - 1) == '\n'));
+    }
 }


### PR DESCRIPTION
In this PR, I address #990. 

The new ListLine constructs are use to improve the way list prefixes are auto-inserted / auto removed in markdown.

Note: re-created PR as some commits were not showing up on the first PR (?!)