### PR TITLE
Bugfix: Delete empty list correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Recent changes
+- Markdown: Correctly insert or remove list item on press enter at empty list item
+
 ### v2.3 [Blog Post](https://gsantner.net/blog/2020/07/25/markor-v2.3-outline-action-custom-order-todotxt-markdown-plaintext.html?source=changelog)
 - Add action to Move current selected line(s)/cursor text up/down
 - Add settings option for View-Mode link color
@@ -28,7 +31,6 @@
 - Vertical Scrollbar now draggable at view & edit mode
 - todo.txt: Date&Time selection dialogs
 - Markdown: Auto update ordered list numbers
-- Markdown: Correctly insert or remove list item on press enter
 
 
 ### v2.2 [Blog Post](https://gsantner.net/blog/2019/10/27/markor-v2.2-markdown-presentations-voicenotes-audiorecord-tables.html?source=changelog)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Vertical Scrollbar now draggable at view & edit mode
 - todo.txt: Date&Time selection dialogs
 - Markdown: Auto update ordered list numbers
+- Markdown: Correctly insert or remove list item on press enter
 
 
 ### v2.2 [Blog Post](https://gsantner.net/blog/2019/10/27/markor-v2.2-markdown-presentations-voicenotes-audiorecord-tables.html?source=changelog)

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownAutoFormat.java
@@ -26,7 +26,7 @@ public class MarkdownAutoFormat implements InputFilter {
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
         try {
             if (start < source.length() && dstart <= dest.length() && StringUtils.isNewLine(source, start, end)) {
-                return autoIndent(source, dest, dstart);
+                return autoIndent(source, dest, dstart, dend);
             }
         } catch (IndexOutOfBoundsException | NullPointerException e) {
             e.printStackTrace();
@@ -35,7 +35,7 @@ public class MarkdownAutoFormat implements InputFilter {
     }
 
     @SuppressLint("DefaultLocale")
-    private CharSequence autoIndent(final CharSequence source, final Spanned dest, final int dstart) {
+    private CharSequence autoIndent(final CharSequence source, final Spanned dest, final int dstart, final int dend) {
 
         final String checkSymbol = "[ ] ";
 
@@ -44,9 +44,9 @@ public class MarkdownAutoFormat implements InputFilter {
         final String indent = source + StringUtils.repeatChars(' ', oLine.indent);
 
         final String result;
-        if (oLine.isOrderedList && oLine.lineEnd != oLine.groupEnd) {
+        if (oLine.isOrderedList && oLine.lineEnd != oLine.groupEnd && dend >= oLine.groupEnd) {
             result = indent + String.format("%d%c ", oLine.value + 1, oLine.delimiter);
-        } else if (uLine.isUnorderedList && uLine.lineEnd != uLine.groupEnd) {
+        } else if (uLine.isUnorderedList && uLine.lineEnd != uLine.groupEnd && dend >= uLine.groupEnd) {
             final String checkString = uLine.isCheckboxList ? checkSymbol : "";
             result = indent + String.format("%c %s", uLine.listChar, checkString);
         } else {

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -22,6 +22,10 @@ public final class StringUtils {
         throw new AssertionError();
     }
 
+    public static boolean isValidIndex(final CharSequence s, final int i) {
+        return s != null && i < s.length();
+    }
+
     public static int getLineStart(CharSequence s, int start) {
         return getLineStart(s, start, 0);
     }
@@ -29,7 +33,7 @@ public final class StringUtils {
     public static int getLineStart(CharSequence s, int start, int minRange) {
         int i = start;
         for (; i > minRange; i--) {
-            if (s.charAt(i - 1) == '\n') {
+            if (isValidIndex(s, i-1) && s.charAt(i - 1) == '\n') {
                 break;
             }
         }
@@ -44,7 +48,7 @@ public final class StringUtils {
     public static int getLineEnd(CharSequence s, int start, int maxRange) {
         int i = start;
         for (; i < maxRange && i < s.length(); i++) {
-            if (s.charAt(i) == '\n') {
+            if (isValidIndex(s, i) && s.charAt(i) == '\n') {
                 break;
             }
         }
@@ -58,7 +62,7 @@ public final class StringUtils {
 
     public static int getNextNonWhitespace(CharSequence s, int start, int maxRange) {
         int i = start;
-        for (; i < maxRange && i < s.length(); i++) {
+        for (; i < maxRange && i < s.length() && isValidIndex(s, i); i++) {
             char c = s.charAt(i);
             if (c != ' ' && c != '\t') {
                 break;
@@ -114,7 +118,7 @@ public final class StringUtils {
      */
     public static int getIndexFromLineOffset(final CharSequence s, final int l, final int e) {
         int i = 0, count = 0;
-        for (; i < s.length(); i++) {
+        for (; i < s.length() && isValidIndex(s, i); i++) {
             if (s.charAt(i) == '\n') {
                 count++;
             }
@@ -140,7 +144,7 @@ public final class StringUtils {
         int count = 0;
         start = Math.max(0, start);
         end = Math.min(end, s.length());
-        for (int i = start; i < end; i++) {
+        for (int i = start; i < end && isValidIndex(s, i); i++) {
             if (s.charAt(i) == c) {
                 count++;
             }
@@ -149,6 +153,6 @@ public final class StringUtils {
     }
 
     public static boolean isNewLine(CharSequence source, int start, int end) {
-        return ((source.charAt(start) == '\n') || (source.charAt(end - 1) == '\n'));
+        return (isValidIndex(source, start) && source.charAt(start) == '\n') || (isValidIndex(source, end -1) && source.charAt(end - 1) == '\n');
     }
 }


### PR DESCRIPTION
Currently, if the cursor is between the list prefix and the start of the line and enter is pressed, the list prefix is incorrectly deleted.

---
i.e. (`|` used to show cursor)
```
1. |foo
```
becomes
```
2. foo
```
---
Desired behavior is 
```
1. |foo
```
becomes
```
1. 
2. foo
```
---

This change fixes this issue. Deletion of truly empty lines is still handled correctly
```
1. foo
2. |
```
becomes
```
1. foo
|
```
This now works correctly