### PR TITLE
Bugfix - indent and linemove

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
@@ -244,14 +244,14 @@ public class CommonTextActions {
         final Editable text = _hlEditor.getText();
 
         final int[] sel = StringUtils.getSelection(_hlEditor);
-        final int lineStart = StringUtils.getLineStart(text, sel[0]);
-        final int lineEnd = StringUtils.getLineEnd(text, sel[1]);
+        final int linesStart = StringUtils.getLineStart(text, sel[0]);
+        final int linesEnd = StringUtils.getLineEnd(text, sel[1]);
 
-        if ((up && lineStart > 0) || (!up && lineEnd < text.length())) {
+        if ((up && linesStart > 0) || (!up && linesEnd < text.length())) {
 
-            final CharSequence line = text.subSequence(lineStart, lineEnd);
+            final CharSequence lines = text.subSequence(linesStart, linesEnd);
 
-            final int altStart = up ? StringUtils.getLineStart(text, lineStart - 1) : lineEnd + 1;
+            final int altStart = up ? StringUtils.getLineStart(text, linesStart - 1) : linesEnd + 1;
             final int altEnd = StringUtils.getLineEnd(text, altStart);
             final CharSequence altLine = text.subSequence(altStart, altEnd);
 
@@ -262,8 +262,8 @@ public class CommonTextActions {
                 final int[] selStart = StringUtils.getLineOffsetFromIndex(text, sel[0]);
                 final int[] selEnd = StringUtils.getLineOffsetFromIndex(text, sel[1]);
 
-                final String newPair = String.format("%s\n%s", up ? line : altLine, up ? altLine : line);
-                text.replace(Math.min(lineStart, altStart), Math.max(altEnd, lineEnd), newPair);
+                final String newPair = String.format("%s\n%s", up ? lines : altLine, up ? altLine : lines);
+                text.replace(Math.min(linesStart, altStart), Math.max(altEnd, linesEnd), newPair);
 
                 selStart[0] += up ? -1 : 1;
                 selEnd[0] += up ? -1 : 1;

--- a/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/general/CommonTextActions.java
@@ -83,6 +83,13 @@ public class CommonTextActions {
         final String origText = _hlEditor.getText().toString();
         switch (action) {
             case ACTION_SPECIAL_KEY: {
+
+                // Needed to prevent selection from being overwritten on refocus
+                final int[] sel = StringUtils.getSelection(_hlEditor);
+                _hlEditor.clearFocus();
+                _hlEditor.requestFocus();
+                _hlEditor.setSelection(sel[0], sel[1]);
+
                 SearchOrCustomTextDialogCreator.showSpecialKeyDialog(_activity, (callbackPayload) -> {
                     if (!_hlEditor.hasSelection() && _hlEditor.length() > 0) {
                         _hlEditor.requestFocus();
@@ -223,7 +230,6 @@ public class CommonTextActions {
     }
 
     protected void runIndentLines(Boolean deIndent) {
-
         if (deIndent) {
             final String leadingIndentPattern = String.format("^\\s{1,%d}", _tabWidth);
             TextActions.runRegexReplaceAction(_hlEditor, new TextActions.ReplacePattern(leadingIndentPattern, ""));
@@ -249,8 +255,8 @@ public class CommonTextActions {
             final int altEnd = StringUtils.getLineEnd(text, altStart);
             final CharSequence altLine = text.subSequence(altStart, altEnd);
 
-            // Prevents changes in text from triggering list prefix insert etc
             try {
+                // Prevents changes in text from triggering list prefix insert etc
                 _hlEditor.disableHighlighterAutoFormat();
 
                 final int[] selStart = StringUtils.getLineOffsetFromIndex(text, sel[0]);
@@ -263,7 +269,8 @@ public class CommonTextActions {
                 selEnd[0] += up ? -1 : 1;
                 _hlEditor.setSelection(
                         StringUtils.getIndexFromLineOffset(text, selStart),
-                        StringUtils.getIndexFromLineOffset(text, selEnd));
+                        StringUtils.getIndexFromLineOffset(text, selEnd)
+                );
 
             } finally {
                 _hlEditor.enableHighlighterAutoFormat();

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -20,6 +20,7 @@ import android.support.v7.widget.TooltipCompat;
 import android.text.Editable;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
 
@@ -36,6 +37,7 @@ import net.gsantner.opoc.util.StringUtils;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -279,7 +281,7 @@ public abstract class TextActions {
         runRegexReplaceAction(Arrays.asList(patterns));
     }
 
-    protected class ReplacePattern {
+    public static class ReplacePattern {
         public Pattern searchPattern;
         public String replacePattern;
         public boolean replaceAll;
@@ -310,8 +312,28 @@ public abstract class TextActions {
         }
     }
 
-    protected void runRegexReplaceAction(List<ReplacePattern> patterns) {
+    public void runRegexReplaceAction(ReplacePattern ... patterns) {
+        runRegexReplaceAction(Arrays.asList(patterns), false);
+    }
+
+    public void runRegexReplaceAction(List<ReplacePattern> patterns) {
         runRegexReplaceAction(patterns, false);
+    }
+
+    public void runRegexReplaceAction(final String pattern, final String replace) {
+        runRegexReplaceAction(Arrays.asList(new ReplacePattern(pattern, replace)), false);
+    }
+
+    public void runRegexReplaceAction(final List<ReplacePattern> patterns, final boolean matchAll) {
+        runRegexReplaceAction(_hlEditor, patterns, matchAll);
+    }
+
+    public static void runRegexReplaceAction(final EditText editor, final ReplacePattern pattern) {
+        runRegexReplaceAction(editor, pattern, false);
+    }
+
+    public static void runRegexReplaceAction(final EditText editor, final ReplacePattern pattern, final boolean matchAll) {
+        runRegexReplaceAction(editor, Collections.singletonList(pattern), matchAll);
     }
 
     /**
@@ -320,10 +342,10 @@ public abstract class TextActions {
      * @param patterns An array of ReplacePattern
      * @param matchAll Whether to stop matching subsequent ReplacePatterns after first match+replace
      */
-    protected void runRegexReplaceAction(final List<ReplacePattern> patterns, final boolean matchAll) {
+    public static void runRegexReplaceAction(final EditText editor, final List<ReplacePattern> patterns, final boolean matchAll) {
 
-        Editable text = _hlEditor.getText();
-        int[] selection = StringUtils.getSelection(_hlEditor);
+        Editable text = editor.getText();
+        int[] selection = StringUtils.getSelection(editor);
         final int[] lStart = StringUtils.getLineOffsetFromIndex(text, selection[0]);
         final int[] lEnd = StringUtils.getLineOffsetFromIndex(text, selection[1]);
 
@@ -341,14 +363,12 @@ public abstract class TextActions {
 
                     // Optimization. Don't replace if the replace pattern is the pattern itself.
                     if (!pattern.replacePattern.equals("$0")) {
-
                         final String newLine;
                         if (pattern.replaceAll) {
                             newLine = matcher.replaceAll(pattern.replacePattern);
                         } else {
                             newLine = matcher.replaceFirst(pattern.replacePattern);
                         }
-
                         text.replace(lineStart, lineEnd, newLine);
                         selEnd += newLine.length() - line.length();
                     }
@@ -360,7 +380,7 @@ public abstract class TextActions {
             lineStart = StringUtils.getLineEnd(text, lineStart, selEnd) + 1;
         }
 
-        _hlEditor.setSelection(
+        editor.setSelection(
                 StringUtils.getIndexFromLineOffset(text, lStart),
                 StringUtils.getIndexFromLineOffset(text, lEnd));
     }

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -142,16 +142,18 @@ public final class StringUtils {
     public static int getIndexFromLineOffset(final CharSequence s, final int l, final int e) {
         int i = 0, count = 0;
         if (s != null) {
-            for (; i < s.length(); i++) {
-                if (s.charAt(i) == '\n') {
-                    count++;
-                }
-                if (count == l) {
-                    break;
+            if (l > 0) {
+                for (; i < s.length(); i++) {
+                    if (s.charAt(i) == '\n') {
+                        count++;
+                    }
+                    if (count == l) {
+                        break;
+                    }
                 }
             }
             if (i < s.length() - 1) {
-                final int start = i + 1;
+                final int start = (l == 0) ? 0 : i + 1;
                 final int end = getLineEnd(s, start);
                 // Prevent selection from moving to previous line
                 return end - Math.min(e, end - start);

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -22,6 +22,10 @@ public final class StringUtils {
         throw new AssertionError();
     }
 
+    public static boolean isValidIndex(final CharSequence s, final int i) {
+        return s != null && i < s.length();
+    }
+
     public static int getLineStart(CharSequence s, int start) {
         return getLineStart(s, start, 0);
     }
@@ -29,7 +33,7 @@ public final class StringUtils {
     public static int getLineStart(CharSequence s, int start, int minRange) {
         int i = start;
         for (; i > minRange; i--) {
-            if (s.charAt(i - 1) == '\n') {
+            if (isValidIndex(s, i-1) && s.charAt(i - 1) == '\n') {
                 break;
             }
         }
@@ -44,7 +48,7 @@ public final class StringUtils {
     public static int getLineEnd(CharSequence s, int start, int maxRange) {
         int i = start;
         for (; i < maxRange && i < s.length(); i++) {
-            if (s.charAt(i) == '\n') {
+            if (isValidIndex(s, i) && s.charAt(i) == '\n') {
                 break;
             }
         }
@@ -58,7 +62,7 @@ public final class StringUtils {
 
     public static int getNextNonWhitespace(CharSequence s, int start, int maxRange) {
         int i = start;
-        for (; i < maxRange && i < s.length(); i++) {
+        for (; i < maxRange && i < s.length() && isValidIndex(s, i); i++) {
             char c = s.charAt(i);
             if (c != ' ' && c != '\t') {
                 break;
@@ -114,7 +118,7 @@ public final class StringUtils {
      */
     public static int getIndexFromLineOffset(final CharSequence s, final int l, final int e) {
         int i = 0, count = 0;
-        for (; i < s.length(); i++) {
+        for (; i < s.length() && isValidIndex(s, i); i++) {
             if (s.charAt(i) == '\n') {
                 count++;
             }
@@ -140,7 +144,7 @@ public final class StringUtils {
         int count = 0;
         start = Math.max(0, start);
         end = Math.min(end, s.length());
-        for (int i = start; i < end; i++) {
+        for (int i = start; i < end && isValidIndex(s, i); i++) {
             if (s.charAt(i) == c) {
                 count++;
             }
@@ -149,6 +153,6 @@ public final class StringUtils {
     }
 
     public static boolean isNewLine(CharSequence source, int start, int end) {
-        return ((source.charAt(start) == '\n') || (source.charAt(end - 1) == '\n'));
+        return (isValidIndex(source, start) && source.charAt(start) == '\n') || (isValidIndex(source, end -1) && source.charAt(end - 1) == '\n');
     }
 }

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -11,7 +11,10 @@ package net.gsantner.opoc.util;
 
 import android.widget.TextView;
 
+import java.util.ArrayList;
+
 import java.util.Arrays;
+import java.util.Collections;
 
 public final class StringUtils {
 
@@ -83,7 +86,7 @@ public final class StringUtils {
         return i;
     }
 
-    public static int[] getSelection(TextView text) {
+    public static int[] getSelection(final TextView text) {
 
         int selectionStart = text.getSelectionStart();
         int selectionEnd = text.getSelectionEnd();
@@ -93,7 +96,16 @@ public final class StringUtils {
             selectionStart = text.getSelectionEnd();
         }
 
-        return new int[] {selectionStart, selectionEnd};
+        return new int[]{selectionStart, selectionEnd};
+    }
+
+    public static int[] getLineSelection(final TextView text) {
+        final int[] sel = getSelection(text);
+        final CharSequence s = text.getText();
+        return new int[]{
+                getLineStart(s, sel[0]),
+                getLineEnd(s, sel[1])
+        };
     }
 
     public static String repeatChars(char character, int count) {
@@ -138,8 +150,11 @@ public final class StringUtils {
                     break;
                 }
             }
-            if (i < s.length()) {
-                return getLineEnd(s, i + 1) - e;
+            if (i < s.length() - 1) {
+                final int start = i + 1;
+                final int end = getLineEnd(s, start);
+                // Prevent selection from moving to previous line
+                return end - Math.min(e, end - start);
             }
         }
         return i;
@@ -169,5 +184,11 @@ public final class StringUtils {
 
     public static boolean isNewLine(CharSequence source, int start, int end) {
         return isValidIndex(source, start, end - 1) && (source.charAt(start) == '\n' || source.charAt(end - 1) == '\n');
+    }
+
+    public static <T> ArrayList<T> toArrayList(T[] array) {
+        ArrayList<T> list = new ArrayList<>();
+        Collections.addAll(list, array);
+        return list;
     }
 }


### PR DESCRIPTION
This PR fixes 2 bugs:

1. Indent / de-indent did not work correctly when the cursor was inside the leading whitespace
2. Line move up or down would incorrectly trigger auto formatting.

In addition, the line move functionality has been updated to preserve selection (can use linemove multiple times now) and supports more than 1 selected line.