### PR TITLE
Add file description customization for file browser entries (#524)

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/SettingsActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/SettingsActivity.java
@@ -26,6 +26,7 @@ import android.support.v7.preference.PreferenceScreen;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.widget.RemoteViews;
+import android.widget.Toast;
 
 import net.gsantner.markor.R;
 import net.gsantner.markor.ui.FilesystemViewerCreator;
@@ -39,6 +40,8 @@ import net.gsantner.opoc.preference.SharedPreferencesPropertyBackend;
 import net.gsantner.opoc.ui.FilesystemViewerData;
 
 import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -189,6 +192,11 @@ public class SettingsActivity extends AppActivityBase {
             updateSummary(R.string.pref_key__exts_to_always_open_in_this_app, _appSettings.getString(R.string.pref_key__exts_to_always_open_in_this_app, ""));
             updateSummary(R.string.pref_key__todotxt__alternative_naming_context_project,
                     getString(R.string.category_to_context_project_to_tag, getString(R.string.context), getString(R.string.category), getString(R.string.project), getString(R.string.tag)));
+            if (_appSettings.getString(R.string.pref_key__file_description_format, "").equals("")) {
+                updateSummary(R.string.pref_key__file_description_format, getString(R.string.default_));
+            } else {
+                updateSummary(R.string.pref_key__file_description_format, _appSettings.getString(R.string.pref_key__file_description_format, ""));
+            }
 
             setPreferenceVisible(R.string.pref_key__is_multi_window_enabled, Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
             setPreferenceVisible(R.string.pref_key__default_encryption_password, Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT);
@@ -238,6 +246,13 @@ public class SettingsActivity extends AppActivityBase {
                 prefs.edit().remove(key).commit();
                 ((EditTextPreference) findPreference(key)).setText("");
                 _as.setPasswordHasBeenSetOnce(true);
+            } else if (eq(key, R.string.pref_key__file_description_format)) {
+                try {
+                    new SimpleDateFormat(prefs.getString(key, ""), Locale.getDefault());
+                } catch (IllegalArgumentException e) {
+                    Toast.makeText(getContext(), e.getLocalizedMessage() + getString(R.string.error_file_description_format), Toast.LENGTH_SHORT).show();
+                    prefs.edit().putString(key, "").commit();
+                }
             }
         }
 

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -722,4 +722,8 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
     public File getFileBrowserLastBrowsedFolder() {
         return new File(getString(R.string.pref_key__file_browser_last_browsed_folder, getNotebookDirectoryAsStr()));
     }
+
+    public String getFileDescriptionFormat() {
+        return getString(R.string.pref_key__file_description_format, "");
+    }
 }

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -290,4 +290,5 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__new_file_dialog_lastused_type" translatable="false">pref_key__new_file_dialog_lastused_type</string>
     <string name="pref_key__file_browser_last_browsed_folder" translatable="false">pref_key__file_browser_last_browsed_folder</string>
     <string name="select_current_line" translatable="false">Select current line(s)</string>
+    <string name="pref_key__file_description_format" translatable="false">pref_key__file_description_format</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,5 +393,13 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="code_block">Code block</string>
     <string name="add_completion_date">Add completion date</string>
     <string name="add_completion_date_for_todos_when_marking_them_as_done">Add completion date for todos when marking them as done</string>
+    <string name="file_description_format">File description format</string>
+    <string name="file_description_format_dialog">Format for the description under each file in the file browser. Follows Android\'s SimpleDateFormat rules, with the addition of FS for showing file size. Leave blank to use the default format for your locale.\n\nExample input:\nFS yyyy MMM dd hh:mm:ss aa\nOutput format:\n30KB 2020 Mar 20 11:24:52 PM</string>
+    <string name="error_file_description_format">\n\nReverting to locale default format.</string>
 
+    <string name="bytes_abbreviated">B</string>
+    <string name="kilobytes_abbreviated">KB</string>
+    <string name="megabytes_abbreviated">MB</string>
+    <string name="gigabytes_abbreviated">GB</string>
+    <string name="terabytes_abbreviated">TB</string>
 </resources>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -68,6 +68,12 @@
                 android:title="@string/app_start_folder" />
             <android.support.v7.preference.EditTextPreference
                 android:defaultValue="@string/empty_string"
+                android:dialogMessage="@string/file_description_format_dialog"
+                android:icon="@android:drawable/ic_menu_info_details"
+                android:key="@string/pref_key__file_description_format"
+                android:title="@string/file_description_format" />
+            <android.support.v7.preference.EditTextPreference
+                android:defaultValue="@string/empty_string"
                 android:icon="@drawable/ic_lock_outline_black_24dp"
                 android:inputType="textVisiblePassword"
                 android:key="@string/pref_key__default_encryption_password"


### PR DESCRIPTION
Suggested in #524.

Added a settings entry to allow a customizable file description. If no format string is configured it uses the locale default date format like before. New format string uses the built-in formatting rules of SimpleDateFormat, just filters for a new entry FS and replaces it with a quoted string including the file size, then passes the format string to SimpleDateFormat directly.

I think it'd be nice if we could default the configured string to locale date format, but I didn't see a way to set that up without manually creating a list of all the formats for each locale. For now, default configuration is an empty string, which shows "Default" on the settings screen.

<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
