### PR TITLE
fix crashing file search dialog caused by null object

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/ui/SearchOrCustomTextDialog.java
+++ b/app/src/main/java/net/gsantner/opoc/ui/SearchOrCustomTextDialog.java
@@ -65,7 +65,7 @@ public class SearchOrCustomTextDialog {
     public static class DialogOptions {
         public Callback.a1<String> callback;
         public Callback.a2<String, Integer> withPositionCallback;
-        public List<? extends CharSequence> data = new ArrayList<>();
+        public List<? extends CharSequence> data;
         public List<? extends CharSequence> highlightData;
         public List<Integer> iconsForData;
         public String messageText = "";

--- a/app/src/main/java/net/gsantner/opoc/ui/SearchOrCustomTextDialog.java
+++ b/app/src/main/java/net/gsantner/opoc/ui/SearchOrCustomTextDialog.java
@@ -65,7 +65,7 @@ public class SearchOrCustomTextDialog {
     public static class DialogOptions {
         public Callback.a1<String> callback;
         public Callback.a2<String, Integer> withPositionCallback;
-        public List<? extends CharSequence> data;
+        public List<? extends CharSequence> data = new ArrayList<>();
         public List<? extends CharSequence> highlightData;
         public List<Integer> iconsForData;
         public String messageText = "";
@@ -187,7 +187,6 @@ public class SearchOrCustomTextDialog {
     }
 
     public static void showMultiChoiceDialogWithSearchFilterUI(final Activity activity, final DialogOptions dopt) {
-        final List<CharSequence> allItems = new ArrayList<>(dopt.data);
         final List<Pair<String, Integer>> filteredItems = new ArrayList<>();
         final AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(activity, dopt.isDarkDialog
                 ? android.support.v7.appcompat.R.style.Theme_AppCompat_Dialog


### PR DESCRIPTION
Commit 05c92f074e7b6af2a8b02e344e6fdedb143ba4a1 introduced a bug which made Markor crash when pressing the file search button in the explorer. The reason is that `dopt.data` is not initialized and remains null, but it is queried at several places in `SearchOrCustomTextDialog`, leading to `NullPointerException`s or `TargetInvocationException`s.

This PR fixes the problem.

(@harshad1 I am not sure about the other `DialogOptions` attributes which are not initialized any more since the commit, maybe they might cause hidden bugs at other places, too, but maybe not.)