### PR TITLE
Prevent onSelectionChanged from triggering a bug with larger files

### DIFF
--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -276,7 +276,12 @@ public class HighlightingEditor extends AppCompatEditText {
 
     @Override
     protected void onSelectionChanged(int selStart, int selEnd) {
-        super.onSelectionChanged(selStart, selEnd);
+        // super.onSelectionChanged triggers some accessibility service code.
+        // This appears to cause an exception with larger files
+        // Possible android bug? Commenting out.
+
+        // super.onSelectionChanged(selStart, selEnd);
+
         if (MainActivity.IS_DEBUG_ENABLED) {
             AppSettings.appendDebugLog("Selection changed: " + selStart + "->" + selEnd);
         }


### PR DESCRIPTION
The fundamental issue in https://github.com/gsantner/markor/issues/1128 appears to be that the `onSelectionChange` code in the `TextView` base class calls some accessibility service. The _whole text of the document_ is passed to this service through an intent. The whole document can exceed the intent size limit, causing a crash which sometimes propagates back to markor.

Blocking the call prevents this