### PR TITLE
Fix for correct file not opened from shortcut

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentActivity.java
@@ -81,9 +81,11 @@ public class DocumentActivity extends AppActivityBase {
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && new AppSettings(activity).isMultiWindowEnabled()) {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+        } else {
+            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         }
-        activity.startActivity(intent);
         nextLaunchTransparentBg = (activity instanceof MainActivity);
+        activity.startActivity(intent);
     }
 
     public static Object[] checkIfLikelyTextfileAndGetExt(File file) {
@@ -165,6 +167,12 @@ public class DocumentActivity extends AppActivityBase {
         _fragManager = getSupportFragmentManager();
 
         handleLaunchingIntent(getIntent());
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        handleLaunchingIntent(intent);
     }
 
     private void handleLaunchingIntent(Intent intent) {


### PR DESCRIPTION
When multi document is turned off and markor is already running, sometimes shortcuts to a file will fail to open the correct file (instead the previously open file will be shown).

This PR improves the launch behavior. Now the correct file is opened correctly.