### PR TITLE
Reduce flicker from creating and removing scroll views repeatedly

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -555,7 +555,6 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     private void setupAppearancePreferences(View fragmentView) {
         _hlEditor.setTextSize(TypedValue.COMPLEX_UNIT_SP, _appSettings.getFontSize());
         _hlEditor.setTypeface(FontPreferenceCompat.typeface(getContext(), _appSettings.getFontFamily(), Typeface.NORMAL));
-        initDocState();
 
         _hlEditor.setBackgroundColor(_appSettings.getEditorBackgroundColor());
         _hlEditor.setTextColor(_appSettings.getEditorForegroundColor());


### PR DESCRIPTION
This PR removes a redundant `initDocState()`. `initDocState()` is called in onResume() anyway.