### PR TITLE
Fixed KaTeX line break

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
@@ -181,7 +181,7 @@ public class MarkdownTextConverter extends TextConverter {
         if (appSettings.isMarkdownMathEnabled() && markup.contains("$")) {
             head += HTML_KATEX_INCLUDE;
             onLoadJs += JS_KATEX;
-            markup = markup.replaceAll("(?m)^([$]{2}.*[$]{2})$", "<div>\n$1\n</div>");
+            markup = markup.replaceAll("(?ms)^([$]{2}.*?[$]{2})$", "<div>\n$1\n</div>");
         }
 
         // Enable View (block) code syntax highlighting


### PR DESCRIPTION
Just fixed `\\` in LaTeX. It was printing `\` instead of creating a line break. 

**KaTeX docs:**

> Hard line breaks are `\\` and `\newline`.

https://katex.org/docs/supported.html#line-breaks

**Related issue:** #1190 
