### PR TITLE
Improve wording of Markdown table string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,7 +348,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="reading">Reading</string>
     <string name="read">Read</string>
     <string name="table">Table</string>
-    <string name="how_much_columns_press_table_button_long_to_start_table">How much columns? Press table button long to start a table (insert header), press short to add a row.</string>
+    <string name="how_much_columns_press_table_button_long_to_start_table">How many columns? Press table button long to start a table (insert header), press short to add a row.</string>
     <string name="example_of_a_markdown_table">Example of a Markdown table</string>
     <string name="delete_lines">Delete lines</string>
     <string name="unordered_list">Unordered list</string>


### PR DESCRIPTION
"Many" should be used instead of "much" because the columns can be counted (2,3,4,...).