### PR TITLE
Improve scrollbar grab width on hidpi devices

### DIFF
--- a/app/src/main/java/net/gsantner/markor/ui/DraggableScrollbarScrollView.java
+++ b/app/src/main/java/net/gsantner/markor/ui/DraggableScrollbarScrollView.java
@@ -15,7 +15,7 @@ public class DraggableScrollbarScrollView extends ScrollView {
     private boolean _fastScrollEnabled = true;
     private boolean _ltr = true;
     private int _thumbHeight;
-    private int _scrollbarWidth;
+    private int _grabWidth;
 
     public DraggableScrollbarScrollView(Context context) {
         super(context);
@@ -38,8 +38,8 @@ public class DraggableScrollbarScrollView extends ScrollView {
             return true;
         }
         if (ev.getActionMasked() == MotionEvent.ACTION_DOWN &&
-                ((_ltr && getWidth() - _scrollbarWidth < ev.getX())
-                        || (!_ltr && _scrollbarWidth > ev.getX()))) {
+                ((_ltr && getWidth() - _grabWidth < ev.getX())
+                        || (!_ltr && _grabWidth > ev.getX()))) {
             computeThumbHeight();
             awakenScrollBars();
             float scrollbarStartPos = (float) computeVerticalScrollOffset() / computeVerticalScrollRange() * (getHeight());
@@ -82,7 +82,7 @@ public class DraggableScrollbarScrollView extends ScrollView {
             _ltr = getLayoutDirection() == View.LAYOUT_DIRECTION_LTR;
         }
         final DisplayMetrics displayMetrics = getContext().getResources().getDisplayMetrics();
-        _scrollbarWidth = (int) (2.0 * (float) getVerticalScrollbarWidth() * displayMetrics.density);
+        _grabWidth = (int) (2.0 * (float) getVerticalScrollbarWidth() * displayMetrics.density);
     }
 
     public void setFastScrollEnabled(boolean fastScrollEnabled) {

--- a/app/src/main/java/net/gsantner/markor/ui/DraggableScrollbarScrollView.java
+++ b/app/src/main/java/net/gsantner/markor/ui/DraggableScrollbarScrollView.java
@@ -3,6 +3,7 @@ package net.gsantner.markor.ui;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
+import android.util.DisplayMetrics;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ScrollView;
@@ -80,7 +81,8 @@ public class DraggableScrollbarScrollView extends ScrollView {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
             _ltr = getLayoutDirection() == View.LAYOUT_DIRECTION_LTR;
         }
-        _scrollbarWidth = getVerticalScrollbarWidth();
+        final DisplayMetrics displayMetrics = getContext().getResources().getDisplayMetrics();
+        _scrollbarWidth = (int) (2.0 * (float) getVerticalScrollbarWidth() * displayMetrics.density);
     }
 
     public void setFastScrollEnabled(boolean fastScrollEnabled) {

--- a/app/src/main/java/net/gsantner/markor/ui/DraggableScrollbarWebView.java
+++ b/app/src/main/java/net/gsantner/markor/ui/DraggableScrollbarWebView.java
@@ -3,6 +3,7 @@ package net.gsantner.markor.ui;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
+import android.util.DisplayMetrics;
 import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.WebView;
@@ -79,7 +80,8 @@ public class DraggableScrollbarWebView extends WebView {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
             _ltr = getLayoutDirection() == View.LAYOUT_DIRECTION_LTR;
         }
-        _scrollbarWidth = getVerticalScrollbarWidth();
+        final DisplayMetrics displayMetrics = getContext().getResources().getDisplayMetrics();
+        _scrollbarWidth = (int) (2.0 * (float) getVerticalScrollbarWidth() * displayMetrics.density);
     }
 
     public void setFastScrollEnabled(boolean fastScrollEnabled) {

--- a/app/src/main/java/net/gsantner/markor/ui/DraggableScrollbarWebView.java
+++ b/app/src/main/java/net/gsantner/markor/ui/DraggableScrollbarWebView.java
@@ -15,7 +15,7 @@ public class DraggableScrollbarWebView extends WebView {
     private boolean _fastScrollEnabled = true;
     private boolean _ltr = true;
     private int _thumbHeight;
-    private int _scrollbarWidth;
+    private int _grabWidth;
 
     public DraggableScrollbarWebView(Context context) {
         super(context);
@@ -38,8 +38,8 @@ public class DraggableScrollbarWebView extends WebView {
             return true;
         }
         if (ev.getActionMasked() == MotionEvent.ACTION_DOWN &&
-                ((_ltr && getWidth() - _scrollbarWidth < ev.getX())
-                        || (!_ltr && _scrollbarWidth > ev.getX()))) {
+                ((_ltr && getWidth() - _grabWidth < ev.getX())
+                        || (!_ltr && _grabWidth > ev.getX()))) {
             computeThumbHeight();
             awakenScrollBars();
             float scrollbarStartPos = (float) computeVerticalScrollOffset() / computeVerticalScrollRange() * (getHeight());
@@ -81,7 +81,7 @@ public class DraggableScrollbarWebView extends WebView {
             _ltr = getLayoutDirection() == View.LAYOUT_DIRECTION_LTR;
         }
         final DisplayMetrics displayMetrics = getContext().getResources().getDisplayMetrics();
-        _scrollbarWidth = (int) (2.0 * (float) getVerticalScrollbarWidth() * displayMetrics.density);
+        _grabWidth = (int) (2.0 * (float) getVerticalScrollbarWidth() * displayMetrics.density);
     }
 
     public void setFastScrollEnabled(boolean fastScrollEnabled) {


### PR DESCRIPTION
Currently, the draggable scrollbar grab width uses the raw pixel width of the scoll bar. On higher DPI devices (which is most devices these days) the grab region can be too small.

For example, the default on my pixel 3 XL is 0.7mm.

This PR uses a better heuristic which accounts for DPI