### PR TITLE
WIP: Improve editor cursor.

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -582,6 +582,26 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
 
         setHorizontalScrollMode(wrapText);
         _hlEditor.setHighlightingEnabled(highlightText);
+        setLastPostOrBottom();
+    }
+
+    private void setLastPostOrBottom() {
+        final boolean initPreview = _appSettings.getDocumentPreviewState(getPath());
+        if (_savedInstanceState == null || !_savedInstanceState.containsKey(SAVESTATE_CURSOR_POS) && _hlEditor.length() > 0) {
+            int lastPos;
+            if (_appSettings.isEditorStartOnBottom()) {
+                if (!initPreview) {
+                    _hlEditor.requestFocus();
+                }
+                _hlEditor.setSelection(_hlEditor.length());
+            } else if (_document != null && _document.getFile() != null && (lastPos = _appSettings.getLastEditPositionChar(_document.getFile())) >= 0 && lastPos <= _hlEditor.length()) {
+                if (!initPreview) {
+                    _hlEditor.requestFocus();
+                }
+                _hlEditor.setSelection(lastPos);
+                _hlEditor.scrollTo(0, _appSettings.getLastEditPositionScroll(_document.getFile()));
+            }
+        }
     }
 
     private void setToggleState() {
@@ -732,22 +752,7 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
 
     @Override
     public void onFragmentFirstTimeVisible() {
-        final boolean initPreview = _appSettings.getDocumentPreviewState(getPath());
-        if (_savedInstanceState == null || !_savedInstanceState.containsKey(SAVESTATE_CURSOR_POS) && _hlEditor.length() > 0) {
-            int lastPos;
-            if (_document != null && _document.getFile() != null && (lastPos = _appSettings.getLastEditPositionChar(_document.getFile())) >= 0 && lastPos <= _hlEditor.length()) {
-                if (!initPreview) {
-                    _hlEditor.requestFocus();
-                }
-                _hlEditor.setSelection(lastPos);
-                _hlEditor.scrollTo(0, _appSettings.getLastEditPositionScroll(_document.getFile()));
-            } else if (_appSettings.isEditorStartOnBotttom()) {
-                if (!initPreview) {
-                    _hlEditor.requestFocus();
-                }
-                _hlEditor.setSelection(_hlEditor.length());
-            }
-        }
+        setLastPostOrBottom();
     }
 
     public void setDocumentViewVisibility(boolean show) {

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -281,7 +281,7 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
         return getString(R.string.pref_key__todotxt__last_used_archive_filename, "todo.archive.txt");
     }
 
-    public boolean isEditorStartOnBotttom() {
+    public boolean isEditorStartOnBottom() {
         return getBool(R.string.pref_key__editor_start_editing_on_bottom, true);
     }
 
@@ -343,9 +343,12 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
         if (file == null || !file.exists()) {
             return;
         }
-        if (!file.equals(getTodoFile()) && !file.equals(getQuickNoteFile())) {
+        if (!isEditorStartOnBottom()) {
             setInt(PREF_PREFIX_EDIT_POS_CHAR + file.getAbsolutePath(), pos, _prefCache);
             setInt(PREF_PREFIX_EDIT_POS_SCROLL + file.getAbsolutePath(), scrolloffset, _prefCache);
+        } else {
+            setInt(PREF_PREFIX_EDIT_POS_CHAR + file.getAbsolutePath(), -2, _prefCache);
+            setInt(PREF_PREFIX_EDIT_POS_SCROLL + file.getAbsolutePath(), -2, _prefCache);
         }
     }
 
@@ -399,9 +402,6 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
     public int getLastEditPositionChar(File file) {
         if (file == null || !file.exists()) {
             return -1;
-        }
-        if (file.equals(getTodoFile()) || file.equals(getQuickNoteFile())) {
-            return -2;
         }
         return getInt(PREF_PREFIX_EDIT_POS_CHAR + file.getAbsolutePath(), -3, _prefCache);
     }


### PR DESCRIPTION
Improve editor cursor.

ToDo/QuickNote tabs and files use the last position based on app setting first, position second.

Partial fix for #1242.