### PR TITLE
Markdown: Add option for "newline = new paragraph"

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
@@ -195,6 +195,10 @@ public class MarkdownTextConverter extends TextConverter {
         // Notable: They use a home brewed syntax for referencing attachments: @attachment/f.png = ../attachements/f.jpg -- https://github.com/gsantner/markor/issues/1252
         markup = markup.replace("](@attachment/", "](../attachements/");
 
+        if (appSettings.isMarkdownNewlineNewparagraphEnabled()) {
+            markup = markup.replace("\n", "  \n");
+        }
+
         ////////////
         // Markup parsing - afterwards = HTML
         converted = flexmarkRenderer.withOptions(options).render(flexmarkParser.parse(markup));
@@ -219,7 +223,6 @@ public class MarkdownTextConverter extends TextConverter {
                 converted = converted.replace(HTML_PRESENTATION_BEAMER_SLIDE_START_DIV.replace("NO", Integer.toString(c - 1)), "</div></div> <!-- Final presentation slide -->");
             }
         }
-
 
         // Deliver result
         return putContentIntoTemplate(context, converted, isExportInLightMode, file, onLoadJs, head);

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -187,6 +187,10 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
         return getBool(R.string.pref_key__markdown_render_math, false);
     }
 
+    public boolean isMarkdownNewlineNewparagraphEnabled() {
+        return getBool(R.string.pref_key__markdown_newline_newparagraph, false);
+    }
+
     public boolean isMarkdownTableOfContentsEnabled() {
         return getBool(R.string.pref_key__markdown_show_toc, false);
     }

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -195,6 +195,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__inject_to_head" translatable="false">pref_key__inject_to_head</string>
     <string name="pref_key__inject_to_body" translatable="false">pref_key__inject_to_body</string>
     <string name="pref_key__markdown_render_math" translatable="false">pref_key__markdown_render_math</string>
+    <string name="pref_key__markdown_newline_newparagraph" translatable="false">pref_key__markdown_newline_newparagraph</string>
     <string name="pref_key__markdown_show_toc" translatable="false">pref_key__markdown_show_toc</string>
     <string name="pref_key__is_launcher_for_special_files_enabled" translatable="false">pref_key__is_launcher_for_special_files_enabled</string>
     <string name="pref_key__editor_basic_color_scheme__bg_light" translatable="false">pref_key__editor_basic_color_scheme__bg_light</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -410,4 +410,5 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="replace_all">Replace all</string>
     <string name="matches">Matches</string>
     <string name="search_replace_pattern_error_message">Search or replace pattern error.</string>
+    <string name="newline_is_new_paragraph">Newline = new paragraph</string>
 </resources>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -411,6 +411,11 @@
                     android:title="@string/use_monospace_for_code" />
                 <CheckBoxPreference
                     android:defaultValue="false"
+                    android:icon="@drawable/ic_baseline_keyboard_return_24"
+                    android:key="@string/pref_key__markdown_newline_newparagraph"
+                    android:title="@string/newline_is_new_paragraph" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
                     android:icon="@drawable/ic_code_black_24dp"
                     android:key="@string/pref_key__markdown__disable_code_block_highlight"
                     android:title="@string/disable_code_block_highlight" />


### PR DESCRIPTION
* Add settings open to opt-in for automatic finishing all paragraphs by newline, i.e. adding `__\n` two spaces to every newline.
* Closes #1259 
* Closes #875 
* Closes #516
* Closes #189