### PR TITLE
todo.txt: Fix trailing space resulting in contexts/projects/due-dates to be entered twice

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
@@ -388,7 +388,7 @@ public class TodoTxtTextActions extends TextActions {
                     // Replace due date
                     new ReplacePattern(TodoTxtTask.PATTERN_DUE_DATE, "$1" + newDue + "$4"),
                     // Add due date to end if none already exists. Will correctly handle trailing whitespace.
-                    new ReplacePattern("(\\s)*$", " " + newDue)
+                    new ReplacePattern("\\s*$", " " + newDue)
             );
         };
 

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -424,8 +424,8 @@ public abstract class TextActions {
                         final CharSequence oldRegion = line.subSequence(matchStart, matchEnd);
                         // Have to create a new matcher, unfortunately, as replace does not respect region
                         final Matcher replacer = pattern.searchPattern.matcher(oldRegion);
-                        // Replace first vs all handled in matchStart -> matchEnd search
-                        final String newRegion = replacer.replaceAll(pattern.replacePattern);
+                        // final String newRegion = pattern.replaceAll ? replacer.replaceAll(pattern.replacePattern) : replacer.replaceFirst(pattern.replacePattern);
+                        final String newRegion = pattern.replaceAll ? replacer.replaceAll(pattern.replacePattern) : replacer.replaceFirst(pattern.replacePattern);
                         text.replace(matchStart + lineStart, matchEnd + lineStart, newRegion);
                         // Change effective selection based on update
                         selEnd += newRegion.length() - oldRegion.length();

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -424,7 +424,6 @@ public abstract class TextActions {
                         final CharSequence oldRegion = line.subSequence(matchStart, matchEnd);
                         // Have to create a new matcher, unfortunately, as replace does not respect region
                         final Matcher replacer = pattern.searchPattern.matcher(oldRegion);
-                        // final String newRegion = pattern.replaceAll ? replacer.replaceAll(pattern.replacePattern) : replacer.replaceFirst(pattern.replacePattern);
                         final String newRegion = pattern.replaceAll ? replacer.replaceAll(pattern.replacePattern) : replacer.replaceFirst(pattern.replacePattern);
                         text.replace(matchStart + lineStart, matchEnd + lineStart, newRegion);
                         // Change effective selection based on update


### PR DESCRIPTION
i.e.
```
foo_  <- insert due date
```
results in
```
foo due:2021-03-13 due:2021-03-13
```
(`_` = space)