### PR TITLE
Disable fallback spacing

### DIFF
--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -71,6 +71,10 @@ public class HighlightingEditor extends AppCompatEditText {
             highlightWithoutChange();
         };
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            setFallbackLineSpacing(false);
+        }
+
         addTextChangedListener(new TextWatcher() {
             @Override
             public void afterTextChanged(Editable e) {


### PR DESCRIPTION
Fallback spacing causes the text height to change annoyingly when I am editing text. This is especially apparent in todo.txt with the extra ascent.