### PR TITLE
Fix cursor placement at Regex replace etc

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -155,7 +155,7 @@ public final class StringUtils {
                     }
                 }
             }
-            if (i < s.length() - 1) {
+            if (i < s.length()) {
                 final int start = (l == 0) ? 0 : i + 1;
                 final int end = getLineEnd(s, start);
                 // Prevent selection from moving to previous line


### PR DESCRIPTION
Without this change, sometimes the wrong line can be selected after a change.

for example, without this fix (where `|` represents the cursor)
```
foo
|           <-- Last line
```
followed by decrease indent

results in

```
foo|

```

The i.e. the selection is incorrectly moved to the previous line