### PR TITLE
Markdown: Don't match extra spaces at ordered-list regex

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownReplacePatternGenerator.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownReplacePatternGenerator.java
@@ -21,7 +21,7 @@ public class MarkdownReplacePatternGenerator {
 
     // TODO: write tests
 
-    public static final Pattern PREFIX_ORDERED_LIST = Pattern.compile("^(\\s*)((\\d+)(\\.|\\))(\\s+))");
+    public static final Pattern PREFIX_ORDERED_LIST = Pattern.compile("^(\\s*)((\\d+)(\\.|\\))(\\s))");
     public static final Pattern PREFIX_ATX_HEADING = Pattern.compile("^(\\s{0,3})(#{1,6}\\s)");
     public static final Pattern PREFIX_QUOTE = Pattern.compile("^(>\\s)");
     public static final Pattern PREFIX_CHECKED_LIST = Pattern.compile("^(\\s*)((-|\\*|\\+)\\s\\[(x|X)]\\s)");


### PR DESCRIPTION
Small bugfix