### PR TITLE
Remove debug editor syntax highlighter settings option, always enable for debug flavor builds

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -467,8 +467,7 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
                 return true;
             }
             case R.id.action_send_debug_log: {
-                String text = "Hello!\nThanks for developing this app.\nI'm sending this debug log to you to improve the app. The debug log is below.\nI also looked at the FAQ \nhttps://gsantner.net/project/" + getString(R.string.app_name_real).toLowerCase() + ".html\nand checked if it resolves my issue. This debug log allows to analyze and improve performance, but it doesn't give information about crashes! If the app crashes, I will add all steps to reproduce the issue. \n\n\n\n------------------------\n\n\n\n";
-                text += AppSettings.getDebugLog() + "\n\n------------------------\n\n\n\n" + DocumentIO.getMaskedContent(_document);
+                final String text = AppSettings.getDebugLog() + "\n\n------------------------\n\n\n\n" + DocumentIO.getMaskedContent(_document);
                 _shareUtil.draftEmail("Debug Log " + getString(R.string.app_name_real), text, new StringBuilder(getString(R.string.app_contact_email_reverse)).reverse().toString());
                 return true;
             }

--- a/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
@@ -192,7 +192,7 @@ public class MainActivity extends AppActivityBase implements FilesystemViewerFra
     protected void onResume() {
         //new AndroidSupportMeWrapper(this).mainOnResume();
         super.onResume();
-        IS_DEBUG_ENABLED = BuildConfig.IS_TEST_BUILD || _appSettings.isDebugLogEnabled();
+        IS_DEBUG_ENABLED = BuildConfig.IS_TEST_BUILD;
         if (_appSettings.isRecreateMainRequired()) {
             // recreate(); // does not remake fragments
             Intent intent = getIntent();

--- a/app/src/main/java/net/gsantner/markor/activity/SettingsActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/SettingsActivity.java
@@ -214,7 +214,6 @@ public class SettingsActivity extends AppActivityBase {
                     R.string.pref_key__tab_width_v2,
                     R.string.pref_key__editor_line_spacing,
                     R.string.pref_key__todotxt__start_new_tasks_with_huuid_v3,
-                    R.string.pref_key__is_debug_log_enabled,
             };
             for (final int keyId : experimentalKeys) {
                 setPreferenceVisible(keyId, _as.isExperimentalFeaturesEnabled());

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -809,10 +809,6 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
         return extSettingCache.contains(ext) || extSettingCache.contains(".*");
     }
 
-    public boolean isDebugLogEnabled() {
-        return getBool(R.string.pref_key__is_debug_log_enabled, BuildConfig.IS_TEST_BUILD);
-    }
-
     public boolean isExperimentalFeaturesEnabled() {
         return getBool(R.string.pref_key__is_enable_experimental_features, BuildConfig.IS_TEST_BUILD);
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">فتح الملفات دائما مع هذا التطبيق عندما تحتوي القائمة على امتداد الملف. استخدم \'لا شيء، .html. .js\' على سبيل المثال إذا كنت ترغب في تحرير ملفات الويب وتلك التي ليس لها امتداد للملف.</string>
     <string name="template">النموذج</string>
     <string name="send_debug_log">إرسال سِجل للأخطاء</string>
-    <string name="help_by_sending_debug_information_to_the_developer">المساعدة عن طريق إرسال معلومات التصحيح إلى المطورين. يتم إرسال البيانات عن طريق البريد الإلكتروني عبر تطبيق البريد الإلكتروني الخاص بك ويمكنك رؤية جميع البيانات المرسلة قبل الإرسال. سوف تجد خيار \"إرسال سجل التصحيح\" إضافي في القائمة العليا عند التمكين. يقوم بإنشاء مسودة البريد الإلكتروني.</string>
     <string name="print_pdf">طباعة/PDF</string>
     <string name="bigger_headings">عناوين أكبر</string>
     <string name="increase_text_size_of_headings_according_to_level">زيادة حجم النص للرؤوس وفقا للمستوى (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Datoteke uvijek otvori u ovoj aplikaciji kad popis sadržava ekstenziju. Koristi \'None, .html, .css, .js\' i slično za uređivanje web-datoteka i datoteka bez ekstenzije.</string>
     <string name="template">Šablon</string>
     <string name="send_debug_log">Pošalji izvještaj za ispravljanje grešaka</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Pomozite razvojnom timu šaljući informacije o greškama. Podaci se šalju putem Vaše email aplikacije i možete ih pregledati prije slanja. U gornjem ćete meniju pronaći \"Pošalji izvještaj za ispravljanje grešaka\" opciju kad je aktivna. Ona će kreirati novi email.</string>
     <string name="print_pdf">Štampaj / PDF</string>
     <string name="bigger_headings">Veći naslovi</string>
     <string name="increase_text_size_of_headings_according_to_level">Povećaj veličinu slova u naslovima, prema nivou (# h1, ## h2, ### h3…)</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Obre sempre els fitxers amb aquesta aplicació quan la llista conté l\'extensió del fitxer. Utilitzeu «None, .html, .css , .js» per exemple, si voleu editar fitxers web i aquells que no tinguin extensió de fitxer.</string>
     <string name="template">Plantilla</string>
     <string name="send_debug_log">Envia registre de depuració</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Ajudeu-nos enviant informació de depuració als desenvolupadors. Les dades s\'envien per correu a través de l\'aplicació de correu i podeu veure totes les dades que s\'enviaran abans d\'enviar-les. Trobareu una opció addicional «Envia registre de depuració» al menú superior quan estigui activada. Crea l\'esborrany de correu.</string>
     <string name="print_pdf">Imprimeix / PDF</string>
     <string name="bigger_headings">Capçaleres més grans</string>
     <string name="increase_text_size_of_headings_according_to_level">Incrementa la mida de les capçaleres segons el nivell (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Vždy otvírat soubory touto aplikací, pokud mají příponu souboru z následujícího seznamu. Použijte \'None, .html, .css , .js\' pokud například chcete upravovat webové soubory a soubory bez přípony souboru.</string>
     <string name="template">Šablona</string>
     <string name="send_debug_log">Odeslat protokol ladění</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Pomoc odesláním informací o ladění aplikace vývojářům. Data jsou odesílána e-mailem přes vaši e-mailovou aplikaci a před odesláním si můžete prohlédnout všechna odeslaná data. Další možnost \"Odeslat ladící protokol\" najdete v horní nabídce, pokud je povoleno. Vytváří koncept e-mailu.</string>
     <string name="print_pdf">Tisk / PDF</string>
     <string name="bigger_headings">Větší nadpisy</string>
     <string name="increase_text_size_of_headings_according_to_level">Zvětšit velikost nadpisů podle úrovně (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Åbn altid filer med denne app, når listen indeholder filtypen. Brug \'Ingen, .html, . Ss, .js\' for eksempel, hvis du ønsker at redigere web-filer og dem uden filtypenavn.</string>
     <string name="template">Skabelon</string>
     <string name="send_debug_log">Send Fejlsøgningslog</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Hjælp ved at sende debug information til udvikler(er). Data sendes via e-mail via din e-mail-app, og du kan se alle sendte data, før du sender. Du vil finde en ekstra \"Send debug log\" indstilling i top menuen, når aktiveret. Det opretter e-mail-kladden.</string>
     <string name="print_pdf">Print / PDF</string>
     <string name="bigger_headings">Større overskrifter</string>
     <string name="increase_text_size_of_headings_according_to_level">Forøg tekststørrelsen for overskrifter efter niveau (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Dateien immer mit dieser App öffnen wenn die Liste die Dateiendung enthält. Nutze z. B. \'None, .html, .css, .js\' wenn du Web-Dateien und Dateien ohne Endung editieren möchtest.</string>
     <string name="template">Vorlage</string>
     <string name="send_debug_log">Debug-Log senden</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Hilf indem du Debug-Informationen an Entwickler sendest. Daten werden per E-Mail mit deiner E-Mail App gesendet und es können alle Daten vor Versand betrachtet werden. Eine zusätzliche Option \"Debug-Log senden\" im oberen Menü wird hinzugefügt wenn diese Option aktiviert ist. Sie erstellt den E-Mail-Entwurf.</string>
     <string name="print_pdf">Drucken / PDF</string>
     <string name="bigger_headings">Größere Überschriften</string>
     <string name="increase_text_size_of_headings_according_to_level">Erhöhe die Textgröße der Header nach Level (# h1, ## h2. ## h3…)</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -321,7 +321,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Πάντα να ανοίγετε αρχεία με αυτήν την εφαρμογή, όταν η λίστα περιέχει την επέκταση αρχείου. Χρησιμοποιήστε \'Κανένα, .html, . ss , .js\' για παράδειγμα, αν θέλετε να επεξεργαστείτε τα αρχεία web και αυτά χωρίς επέκταση αρχείου.</string>
     <string name="template">Πρότυπο</string>
     <string name="send_debug_log">Αποστολή Καταγραφής Αποσφαλμάτωσης</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Βοήθεια με την αποστολή πληροφοριών αποσφαλμάτωσης στους προγραμματιστές. Τα δεδομένα αποστέλλονται μέσω email μέσω της εφαρμογής email σας και μπορείτε να δείτε όλα τα απεσταλμένα δεδομένα πριν από την αποστολή. Θα βρείτε μια πρόσθετη επιλογή \"Αποστολή αρχείου καταγραφής σφαλμάτων\" στο επάνω μενού όταν ενεργοποιηθεί. Δημιουργεί πρόχειρο μήνυμα ηλεκτρονικού ταχυδρομείου.</string>
     <string name="print_pdf">Print / PDF</string>
     <string name="bigger_headings">Μεγαλύτερες επικεφαλίδες</string>
     <string name="increase_text_size_of_headings_according_to_level">Αύξηση του μεγέθους κειμένου των κεφαλίδων ανάλογα με το επίπεδο (# h1, ## h2. ## h3…)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Siempre abra archivos con esta aplicación cuando la lista contiene la extensión de archivo. Use \'Ninguno, .html, .css , .js\' por ejemplo si desea editar archivos web y aquellos sin extensión de archivo.</string>
     <string name="template">Plantilla</string>
     <string name="send_debug_log">Enviar registro de depuración</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Ayuda enviando información de depuración a desarrollador(es). Los datos se envían por correo electrónico a través de tu aplicación de correo electrónico y puedes ver todos los datos enviados antes de enviar. Encontrarás una opción adicional de \"Enviar registro de depuración\" en el menú superior cuando esté activado. Crea el borrador de correo electrónico.</string>
     <string name="print_pdf">Imprimir / PDF</string>
     <string name="bigger_headings">Encabezados mayores</string>
     <string name="increase_text_size_of_headings_according_to_level">Incrementa el tamaño de texto de las cabeceras según el nivel (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Avaa aina tiedostoja tällä sovelluksella, kun lista sisältää tiedostopäätteen. Käytä \'Ei mitään, .html, . ss , .js esimerkiksi jos haluat muokata web-tiedostoja ja niitä ilman tiedostopäätettä.</string>
     <string name="template">Malli</string>
     <string name="send_debug_log">Lähetä Vianetsintäloki</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Auta lähettämällä vianetsintätietoja kehittäjille tai kehittäjille. Tiedot lähetetään sähköpostitse sähköpostin kautta ja näet kaikki lähetetyt tiedot ennen lähettämistä. Löydät ylimääräisen \"Lähetä debug loki\" -vaihtoehdon ylävalikosta, kun se on käytössä. Se luo sähköpostin luonnoksen.</string>
     <string name="print_pdf">Print / PDF</string>
     <string name="bigger_headings">Suurempi otsikko</string>
     <string name="increase_text_size_of_headings_according_to_level">Lisää otsikoiden tekstikokoa tason mukaan (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Toujours ouvrir avec cette application les fichiers dont l\'extension est contenue dans la liste. Utilisez \'None\', \'.html\', \'.css\', \'.js\' par exemple si vous voulez éditer des fichiers web ainsi que les fichiers sans extension.</string>
     <string name="template">Modèle</string>
     <string name="send_debug_log">Envoyer un journal de débogage</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Aide en envoyant des informations de débogage aux développeurs. Les données sont envoyées par email par l\'intermédiaire de votre application e-mail et vous pouvez voir toutes les données envoyées avant l\'envoi. Vous trouverez une option supplémentaire \"Envoyer un journal de débogage\" dans le menu supérieur lorsque activé. Elle crée le brouillon d\'email.</string>
     <string name="print_pdf">Imprimer / PDF</string>
     <string name="bigger_headings">Titres plus grands</string>
     <string name="increase_text_size_of_headings_according_to_level">Augmenter la taille du texte des en-têtes selon le niveau (# h1, ## h2. ## h3…)</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -314,7 +314,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Mindig ezzel az alkalmazással nyissa meg a fájlt, ha a kiterjesztése szerepel a listában. Például ha webfájlokat és kiterjesztés nélkülieket szeretnél szerkeszteni: \'None, .html, .css , .js\'</string>
     <string name="template">Sablon</string>
     <string name="send_debug_log">Debug információ küldése</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Segíts a fejlesztőknek debug információ küldésével! Az adatok az email alkalmazáson keresztül kerülnek elküldésre, és mindent látsz küldés előtt. Egy \'Debug információ küldése\' menüpont fog megjelenni a felső menüben, az készíti el az emailt.</string>
     <string name="print_pdf">Nyomtatás / PDF</string>
     <string name="bigger_headings">Nagyobb címsorok</string>
     <string name="increase_text_size_of_headings_according_to_level">Betűméret növelése a címsor száma szerint (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Apri sempre i file con questa app quando la lista contiene l\'estensione del file. Usa \'Nessuno, .html, .css , .js\' per esempio se si desidera modificare i file web e i file senza estensione.</string>
     <string name="template">Template</string>
     <string name="send_debug_log">Invia log di debug</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Aiutaci inviando informazioni di debug agli sviluppatori. I dati vengono spediti tramite la tua app e-mail e puoi controllare tutti i dati inviati prima di spedire. Se abilitata, nel menù in alto troverai un\'opzione aggiuntiva \"Invia log di debug\", che crea la bozza di email.</string>
     <string name="print_pdf">Stampa / PDF</string>
     <string name="bigger_headings">Intestazioni più grandi</string>
     <string name="increase_text_size_of_headings_according_to_level">Aumenta la dimensione del testo delle intestazioni in base al livello (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">リストにファイル拡張子が含まれている場合は、常にこのアプリでファイルを開きます。 たとえば、Webファイルやファイル拡張子のないファイルを編集したい場合は、 \'なし, .html, .css , .js\' を使用してください。</string>
     <string name="template">テンプレート</string>
     <string name="send_debug_log">デバッグログを送信</string>
-    <string name="help_by_sending_debug_information_to_the_developer">開発者にデバッグ情報を送信して支援してください。 データはメールアプリを使用してメールで送信され、送信前にすべての送信データを確認できます。 有効にすると、トップメニューに \"デバッグログを送信\" オプションが追加されます。 メールの下書きを作成します。</string>
     <string name="print_pdf">印刷 / PDF</string>
     <string name="bigger_headings">見出しを大きくする</string>
     <string name="increase_text_size_of_headings_according_to_level">レベルに応じて見出しのテキストサイズを大きくします (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -313,7 +313,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">목록이 파일 확장자를 포함할 경우 항상 이 앱으로 파일을 열게 됩니다. 웹 파일 또는 확장자가 없는 파일을 편집하고자 할 때는 \'None, .html, .css, .js\'와 같은 예시를 사용하세요.</string>
     <string name="template">템플릿</string>
     <string name="send_debug_log">디버그 기록을 전송</string>
-    <string name="help_by_sending_debug_information_to_the_developer">디버그 정보를 개발자에게 보내 앱 개발에 기여하세요. 디버그 정보는 현재 사용중인 이메일 앱을 통해서 이메일 형태로 전송되며, 해당 정보의 상세 내역은 전송되기 전에 직접 확인하실 수 있습니다. 활성화되면 추가적인 \'디버그 기록 전송\' 옵션이 상단 메뉴에 표시됩니다. 이 옵션으로 디버그 정보 이메일 초안이 생성됩니다.</string>
     <string name="print_pdf">인쇄 / PDF</string>
     <string name="bigger_headings">더 큰 제목(머리말)</string>
     <string name="increase_text_size_of_headings_according_to_level">제목(머리말)의 단계에 맞춰 글자 크기를 키웁니다 (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Åpne alltid filer med denne appen når listen inneholder filutvidelsen. Bruk \'None, .html, . ss , .js\' for eksempel hvis du vil redigere nettfiler og de uten filutvidelse.</string>
     <string name="template">Mal</string>
     <string name="send_debug_log">Send debug-logg</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Hjelp ved å sende feilsøkingsinformasjon til utvikler(e). Data sendes via e-post via e-postappen, og du kan se alle data som er sendt før de sendes. Du vil finne et ekstra alternativ for \"Send feilsøkingslogg\" i toppmenyen når aktivert. Den skaper e-postutkastet.</string>
     <string name="print_pdf">Print / PDF</string>
     <string name="bigger_headings">Større overskrift</string>
     <string name="increase_text_size_of_headings_according_to_level">Øk tekststørrelsen i henhold til nivå (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Open altijd bestanden met deze app wanneer de lijst de bestandsextensie bevat. Gebruik \'Geen, .html, .css , .js\' bijvoorbeeld als u webbestanden en degenen zonder bestandsextensie wilt bewerken.</string>
     <string name="template">Sjabloon</string>
     <string name="send_debug_log">Stuur debug log</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Help door debug informatie te verzenden naar ontwikkelaar(s). Gegevens worden per e-mail verzonden via uw e-mail app en u kunt alle verzonden gegevens zien voordat u het versturen. U vindt een extra optie \"Stuur debug log\" in het bovenste menu wanneer dit is ingeschakeld. Het maakt het e-mailconcept.</string>
     <string name="print_pdf">Print / PDF</string>
     <string name="bigger_headings">Grotere rubrieken</string>
     <string name="increase_text_size_of_headings_according_to_level">Verhoog tekstgrootte van headers volgens niveau (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Åpne alltid filer med denne appen når listen inneholder filutvidelsen. Bruk \'None, .html, . ss , .js\' for eksempel hvis du vil redigere nettfiler og de uten filutvidelse.</string>
     <string name="template">Mal</string>
     <string name="send_debug_log">Send debug-logg</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Hjelp ved å sende feilsøkingsinformasjon til utvikler(e). Data sendes via e-post via e-postappen, og du kan se alle data som er sendt før de sendes. Du vil finne et ekstra alternativ for \"Send feilsøkingslogg\" i toppmenyen når aktivert. Den skaper e-postutkastet.</string>
     <string name="print_pdf">Print / PDF</string>
     <string name="bigger_headings">Større overskrift</string>
     <string name="increase_text_size_of_headings_according_to_level">Øk tekststørrelsen i henhold til nivå (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Zawsze otwieraj pliki z tą aplikacją, gdy lista zawiera rozszerzenie pliku. Użyj \'Brak, .html, . ss , .js, na przykład, jeśli chcesz edytować pliki internetowe i te bez rozszerzenia pliku.</string>
     <string name="template">Szablon</string>
     <string name="send_debug_log">Wyślij dziennik debugowania</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Pomóż wysyłając informacje debugowania do programisty. Dane są wysyłane pocztą elektroniczną za pośrednictwem aplikacji e-mail i można zobaczyć wszystkie wysłane dane przed wysłaniem. Po włączeniu w górnym menu znajdziesz dodatkową opcję \"Wyślij dziennik debugowania\". Tworzy to szkic e-mail.</string>
     <string name="print_pdf">Drukuj PDF</string>
     <string name="bigger_headings">Większe nagłówki</string>
     <string name="increase_text_size_of_headings_according_to_level">Zwiększ rozmiar tekstu nagłówków zgodnie z poziomem (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Utilizar sempre esse aplicativo se a extensão do arquivo estiver nesta lista. Utilize, por exemplo, \'None, .html, .css , .js\' se quiser editar arquivos web ou arquivos que não tenham extensão.</string>
     <string name="template">Modelo</string>
     <string name="send_debug_log">Enviar informações de depuração</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Ajude-nos enviando as informações de depuração para o programador(es). Os dados são enviados por e-mail e você pode ver todos os dados que serão submetidos antes de os enviar. Se a opção estiver ativa, encontrará a opção \"Enviar registo de debug\" no menu superior. Será criado um e-mail de rascunho.</string>
     <string name="print_pdf">Imprimir/PDF</string>
     <string name="bigger_headings">Cabeçalhos maiores</string>
     <string name="increase_text_size_of_headings_according_to_level">Aumentar o tamanho dos cabeçalhos de acordo com o nível (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Utilizar sempre esta aplicação se a wextensão do ficheiro estiver nesta lista. Utilize, por exemplo, \'None, .html, .css , .js\' se quiser editar ficheiros web ou ficheiros que não tenham extensão.</string>
     <string name="template">Modelo</string>
     <string name="send_debug_log">Enviar registos de debug</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Ajude-nos enviando as informações de depuração para o programador(es). Os dados são enviados por e-mail e você pode ver todos os dados que serão submetidos antes de os enviar. Se a opção estiver ativa, encontrará a opção \"Enviar registo de debug\" no menu superior. Será criado um e-mail de rascunho.</string>
     <string name="print_pdf">Imprimir/PDF</string>
     <string name="bigger_headings">Cabeçalho grande</string>
     <string name="increase_text_size_of_headings_according_to_level">Aumentar tamanho do texto dos cabeçalhos, de acordo com o nível (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Deschideți întotdeauna fișiere cu această aplicație atunci când lista conține extensia de fișiere. Folosiți \'Niciunul, .html, . ss , .js de exemplu dacă doriţi să editaţi fişiere web şi cele fără extensia fişierului.</string>
     <string name="template">Șablon</string>
     <string name="send_debug_log">Trimite jurnalul de depanare</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Ajutor prin trimiterea de informații de depanare către dezvoltator(i). Datele sunt trimise prin e-mail prin intermediul aplicației dvs. de e-mail și puteți vedea toate datele trimise înainte de a le trimite. Veţi găsi o opţiune suplimentară de \"Trimite jurnalul de depanare\" în meniul de sus când este activată. Aceasta creează schiţa de e-mail.</string>
     <string name="print_pdf">Print / PDF</string>
     <string name="bigger_headings">Titluri mai mari</string>
     <string name="increase_text_size_of_headings_according_to_level">Crește dimensiunea textului în funcție de nivel (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Всегда открывать файлы этим приложением, если расширение есть в списке. Используйте \'None, .html, .css , .js\', например, если вы хотите редактировать веб-файлы и файлы без расширения.</string>
     <string name="template">Шаблон</string>
     <string name="send_debug_log">Отправить журнал отладки</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Помогите разработчикам, отправляя отладочную информацию. Данные отправляются по электронной почте вашим приложением электронной почты, и вы можете просмотреть перед отправкой все отправляемые данные. Вы найдете дополнительный пункт \"Отправить журнал отладки\" в верхнем меню, когда включено. Он создает черновик письма.</string>
     <string name="print_pdf">Печать / PDF</string>
     <string name="bigger_headings">Увеличивать заголовки</string>
     <string name="increase_text_size_of_headings_according_to_level">Увеличивать размер текста заголовков в соответствии с уровнем (# h1, ## h2, ### h3…)</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Aberi semper sos documentos cun custa aplicatzione cando sa lista cuntenet s\'estensione de su documentu. Imprea \'Peruna, .html, .css , .js\' a esèmpiu si cheres modificare documentos web e cussos chene estensione.</string>
     <string name="template">Modellu</string>
     <string name="send_debug_log">Imbia unu registru de depuratzione (debug)</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Agiuda·nos imbiende informatziones a pitzu de sa depuratzione (debug) a sos isvilupadores. Sos datos benint imbiados pro mèdiu de s\'aplicatzione de pòsta eletrònica tua e podes pompiare totu sos datos imbiados in antis de s\'imbiu. As a agatare un\'optzione agiuntiva \"Imbia unu registru de depuratzione (debug)\" in su menù in artu, cando est abilitadu. At a creare sa botza de sa lìtera de imbiare.</string>
     <string name="print_pdf">Imprenta / PDF</string>
     <string name="bigger_headings">Intestatziones prus mannas</string>
     <string name="increase_text_size_of_headings_according_to_level">Ismànnia su testu de sas intestatziones in base a su livellu (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Öppna alltid filer av typen i listan med den här appen. Använd till exempel \'None, .html, .css , .js\' om du vill redigera webfiler och filer utan filändelse.</string>
     <string name="template">Mall</string>
     <string name="send_debug_log">Skicka felsökningslogg</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Hjälp genom att skicka felsökningsinformation till utvecklare. Data skickas via e-post via din e-postapp och du kan se alla skickade data innan du skickar. Du hittar ytterligare ett alternativ för \"Skicka felsökningslogg\" i toppmenyn när det är aktiverat. Det skapar ett e-postutkast.</string>
     <string name="print_pdf">Print / PDF</string>
     <string name="bigger_headings">Större rubriker</string>
     <string name="increase_text_size_of_headings_according_to_level">Öka textstorleken på rubriker enligt nivå (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -316,7 +316,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">இந்த பட்டியலில் உள்ள கோப்பு வகை நீட்சிகள் கொண்ட ஆவணங்களை இந்த செயலியை கொண்டே திறக்கவும். உதாரணமாக நீங்கள் வலை ஆவணங்களையும் மற்றும் எந்த நீட்சிகள் அற்ற ஆவணங்களையும் திருத்த விரும்பினால் \'None, .html, .css , .js\' ஆகியவற்றை பயன்படுத்துங்கள்.</string>
     <string name="template">வார்ப்புரு</string>
     <string name="send_debug_log">Debug பதிவை அனுப்பவும்</string>
-    <string name="help_by_sending_debug_information_to_the_developer">debug தகவலை இந்த செயலியின் நிரலை எழுதுபவர்களுக்கு அனுப்புவதன் மூலம் உதவுங்கள். உங்கள் மின்னஞ்சல் செயலியின் வழியாக தரவானது மின்னஞ்சலாக அனுப்பப்படும் மற்றும் அனுப்புவதற்கு முன்னதாக நீங்கள் அனுப்பப்போகிற தரவை காணலாம். இதை இயக்குவதன் மூலம் மேலே உள்ள பட்டியில் கூடுதலாக \"debug பதிவை அனுப்பவும்\" தேர்வை காணலாம். இது ஒரு மின்னஞ்சல் வரைவை உருவாக்கும்.</string>
     <string name="print_pdf">அச்சிடு / PDF ஆக மாற்று</string>
     <string name="bigger_headings">பெரிய தலைப்புகள்</string>
     <string name="increase_text_size_of_headings_according_to_level">தலைப்புகளின் உரையின் அளவை அது இருக்கும் நிலையின் படி அதிகரிக்கவும் (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -319,7 +319,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Liste dosya uzantısını içerdiğinde dosyaları her zaman bu uygulamayla aç. Örneğin web dosyalarını ve dosya uzantısı olmayan dosyaları düzenlemek istiyorsanız \'Yok, .html, .css, .js\' seçeneğini kullanın.</string>
     <string name="template">Şablon</string>
     <string name="send_debug_log">Hata Ayıklama Günlüğü Gönder</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Geliştiricilere hata ayıklama bilgisi göndererek yardım edin. Veri, e-posta uygulamanız aracılığıyla e-posta ile gönderilir ve gönderilmeden önce tüm gönderilen verileri görebilirsiniz. Etkinleştirildiğinde, üst menüde ek bir \"Hata ayıklama günlüğü gönder\" seçeneğini bulabilirsiniz. E-posta taslağını oluşturur.</string>
     <string name="print_pdf">Yazdır / PDF</string>
     <string name="bigger_headings">Daha büyük başlıklar</string>
     <string name="increase_text_size_of_headings_according_to_level">Başlıkların metin boyutunu seviyeye göre artırın (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Завжди відкривати файли цією програмою, якщо розширення є у списку. Наприклад, додайте \'None, .html, .css , .js\' для редагування веб-файлів і файлів без розширення.</string>
     <string name="template">Шаблон</string>
     <string name="send_debug_log">Надсилати Debug-журнал</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Допоможіть розробникам, надсилаючи зневаджувальну інформацію. Дані надсилаються по e-mail за допомогою вашого додатку електронної пошти і ви можете переглянути ці дані перед надсиланням. Коли це налаштування увімкнено, у верхньому меню з\'явиться додатковий пункт \"Надіслати журнал зневадження\", який створює чернетку листа.</string>
     <string name="print_pdf">Друк / PDF</string>
     <string name="bigger_headings">Збільшити заголовки</string>
     <string name="increase_text_size_of_headings_according_to_level">Збільшувати розмір тексту заголовків відповідно до рівня (# h1, ## h2, ### h3…)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -320,7 +320,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">当列表包含文件扩展名时总是使用此应用打开文件。例如如果您想编辑网页文件和无扩展名文件，请使用 \'None, .html, .css , .js\' 。</string>
     <string name="template">模板</string>
     <string name="send_debug_log">发送调试日志</string>
-    <string name="help_by_sending_debug_information_to_the_developer">向开发者发送调试信息以提供帮助。数据将通过电子邮件应用发送，您可以在发送前查看所有数据。如果启用此选项，您将在顶部菜单中找到额外的“发送调试日志”选项。它将创建一个草稿邮件。</string>
     <string name="print_pdf">打印/PDF</string>
     <string name="bigger_headings">大标题</string>
     <string name="increase_text_size_of_headings_according_to_level">根据标题级别(# h1, ## h2, ### h3…) 增加标题文字大小</string>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -279,7 +279,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__tab_width_v2" translatable="false">pref_key__tab_width_v2</string>
     <string name="pref_key__editor_enable_line_breaking" translatable="false">pref_key__editor_enable_line_breaking</string>
     <string name="pref_key__exts_to_always_open_in_this_app" translatable="false">pref_key__exts_to_always_open_in_this_app</string>
-    <string name="pref_key__is_debug_log_enabled" translatable="false">pref_key__is_debug_log_enabled</string>
     <string name="pref_key__view_font_size" translatable="false">pref_key__view_font_size</string>
     <string name="pref_key__view_mode_link_color" translatable="false">pref_key__view_mode_link_color</string>
     <string name="pref_key__todotxt__start_new_tasks_with_huuid_v3" translatable="false">pref_key__todotxt__start_new_tasks_with_huuid_v3</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,7 +335,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Always open files with this app when the list contains the file extension. Use \'None, .html, .css , .js\' for example if you want to edit web files and those without file extension.</string>
     <string name="template">Template</string>
     <string name="send_debug_log">Send Debug Log</string>
-    <string name="help_by_sending_debug_information_to_the_developer">Help by sending debug information to developer(s). Data is sent by email via your email app and you can see all sent data prior to sending. You will find an additional \"Send debug log\" option in top menu when enabled. It creates the email draft.</string>
     <string name="print_pdf">Print / PDF</string>
     <string name="bigger_headings">Bigger headings</string>
     <string name="increase_text_size_of_headings_according_to_level">Increase text size of headers according to level (# h1, ## h2. ### h3…)</string>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -112,12 +112,6 @@
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:icon="@drawable/ic_bug_report_black_24dp"
-                android:key="@string/pref_key__is_debug_log_enabled"
-                android:summary="@string/help_by_sending_debug_information_to_the_developer"
-                android:title="@string/debug" />
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:icon="@drawable/ic_bug_report_black_24dp"
                 android:key="@string/pref_key__is_enable_experimental_features"
                 android:title="@string/experimental_features" />
         </PreferenceCategory>


### PR DESCRIPTION
I regular receive emails like below. I can't see a SINGLE email where a user actually read it and let me know what the problem IS. Even more, if I ask back what their problem is, usually I don't receive a answer - thus this functionality mostly generates spam that don't help Markor at all.

So, removed the settings option, description text. Keep functionality and enable it for debug flavor builds.

![grafik](https://user-images.githubusercontent.com/6735650/124366667-a72ae500-dc51-11eb-9ba2-880ef28c12fc.png)
