### PR TITLE
Add option to view headings up to H6 in the table of contents

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
@@ -180,8 +180,7 @@ public class MarkdownTextConverter extends TextConverter {
             }
 
             head += CSS_TOC_STYLE;
-            final int levels = TocOptions.getLevels(appSettings.getMarkdownTableOfContentLevels());
-            options.set(TocExtension.LEVELS, levels)
+            options.set(TocExtension.LEVELS, TocOptions.getLevels(appSettings.getMarkdownTableOfContentLevels()))
                     .set(TocExtension.TITLE, context.getString(R.string.table_of_contents))
                     .set(TocExtension.DIV_CLASS, "markor-table-of-contents")
                     .set(TocExtension.LIST_CLASS, "markor-table-of-contents-list")

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
@@ -180,8 +180,7 @@ public class MarkdownTextConverter extends TextConverter {
             }
 
             head += CSS_TOC_STYLE;
-            final int levels = appSettings.isMarkdownSimpleTableOfContentsSelected() ?
-                    TocOptions.getLevels(1, 2, 3) : TocOptions.getLevels(1, 2, 3, 4, 5, 6);
+            final int levels = TocOptions.getLevels(appSettings.getMarkdownTableOfContentLevels());
             options.set(TocExtension.LEVELS, levels)
                     .set(TocExtension.TITLE, context.getString(R.string.table_of_contents))
                     .set(TocExtension.DIV_CLASS, "markor-table-of-contents")

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
@@ -180,7 +180,9 @@ public class MarkdownTextConverter extends TextConverter {
             }
 
             head += CSS_TOC_STYLE;
-            options.set(TocExtension.LEVELS, TocOptions.getLevels(1, 2, 3))
+            final int levels = appSettings.isMarkdownSimpleTableOfContentsSelected() ?
+                    TocOptions.getLevels(1, 2, 3) : TocOptions.getLevels(1, 2, 3, 4, 5, 6);
+            options.set(TocExtension.LEVELS, levels)
                     .set(TocExtension.TITLE, context.getString(R.string.table_of_contents))
                     .set(TocExtension.DIV_CLASS, "markor-table-of-contents")
                     .set(TocExtension.LIST_CLASS, "markor-table-of-contents-list")

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -197,7 +197,17 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
     }
 
     public boolean isMarkdownTableOfContentsEnabled() {
-        return getBool(R.string.pref_key__markdown_show_toc, false);
+        return isMarkdownSimpleTableOfContentsSelected() || isMarkdownExtendedTableOfContentsSelected();
+    }
+
+    public boolean isMarkdownSimpleTableOfContentsSelected() {
+        String selection = getString(R.string.pref_key__markdown_table_of_contents, "");
+        return selection.equals("simple");
+    }
+
+    public boolean isMarkdownExtendedTableOfContentsSelected() {
+        String selection = getString(R.string.pref_key__markdown_table_of_contents, "");
+        return selection.equals("extended");
     }
 
     public boolean isEditorStatusBarHidden() {

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -32,11 +32,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
-import java.util.Set;
 
 import other.de.stanetz.jpencconverter.PasswordStore;
 
@@ -203,14 +201,12 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
     }
 
     public int[] getMarkdownTableOfContentLevels() {
-        Set<String> selection = getDefaultPreferences().getStringSet(
-                rstr(R.string.pref_key__markdown_table_of_contents), Collections.emptySet());
-        int[] levels = new int[selection.size()];
-        Iterator<String> it = selection.iterator();
-        for (int i=0; i<selection.size(); i++) {
-            levels[i] = Integer.parseInt(it.next());
+        final List<String> v = getStringSet(R.string.pref_key__markdown_table_of_contents_enabled_levels, Collections.emptyList());
+        int[] ret = new int[v.size()];
+        for (int i = 0; i < v.size(); i++) {
+            ret[i] = Integer.parseInt(v.get(i));
         }
-        return levels;
+        return ret;
     }
 
     public boolean isEditorStatusBarHidden() {

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -32,9 +32,11 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
+import java.util.Set;
 
 import other.de.stanetz.jpencconverter.PasswordStore;
 
@@ -197,17 +199,18 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
     }
 
     public boolean isMarkdownTableOfContentsEnabled() {
-        return isMarkdownSimpleTableOfContentsSelected() || isMarkdownExtendedTableOfContentsSelected();
+        return getMarkdownTableOfContentLevels().length > 0;
     }
 
-    public boolean isMarkdownSimpleTableOfContentsSelected() {
-        String selection = getString(R.string.pref_key__markdown_table_of_contents, "");
-        return selection.equals("simple");
-    }
-
-    public boolean isMarkdownExtendedTableOfContentsSelected() {
-        String selection = getString(R.string.pref_key__markdown_table_of_contents, "");
-        return selection.equals("extended");
+    public int[] getMarkdownTableOfContentLevels() {
+        Set<String> selection = getDefaultPreferences().getStringSet(
+                rstr(R.string.pref_key__markdown_table_of_contents), Collections.emptySet());
+        int[] levels = new int[selection.size()];
+        Iterator<String> it = selection.iterator();
+        for (int i=0; i<selection.size(); i++) {
+            levels[i] = Integer.parseInt(it.next());
+        }
+        return levels;
     }
 
     public boolean isEditorStatusBarHidden() {

--- a/app/src/main/java/net/gsantner/opoc/preference/SharedPreferencesPropertyBackend.java
+++ b/app/src/main/java/net/gsantner/opoc/preference/SharedPreferencesPropertyBackend.java
@@ -48,6 +48,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashSet;
 import java.util.List;
 
 
@@ -444,6 +445,18 @@ public class SharedPreferencesPropertyBackend implements PropertyBackend<String,
         }
     }
 
+    public List<String> getStringSet(@StringRes int keyResourceId, List<String> defaultValue, final SharedPreferences... pref) {
+        return getStringSet(rstr(keyResourceId), defaultValue);
+    }
+
+    public List<String> getStringSet(String key, List<String> defaultValue, final SharedPreferences... pref) {
+        try {
+            return new ArrayList<>(gp(pref).getStringSet(key, new HashSet<>(defaultValue)));
+        } catch (ClassCastException e) {
+            return defaultValue;
+        }
+    }
+
     //
     // Getter & Setter for Color
     //
@@ -476,6 +489,10 @@ public class SharedPreferencesPropertyBackend implements PropertyBackend<String,
     @Override
     public boolean getBool(String key, boolean defaultValue) {
         return getBool(key, defaultValue, _prefApp);
+    }
+
+    public List<String> getStringSet(String key, List<String> defaultValue) {
+        return getStringSet(key, defaultValue, _prefApp);
     }
 
     @Override

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -124,4 +124,16 @@
         <item translatable="false">*</item>
         <item translatable="false">+</item>
     </string-array>
+
+    <string-array name="pref_arrdisp__markdown_toc" translatable="false">
+        <item translatable="false">@string/no_toc</item>
+        <item translatable="false">@string/simple_toc</item>
+        <item translatable="false">@string/extended_toc</item>
+    </string-array>
+    <string-array name="pref_arrkeys__markdown_toc" translatable="false">
+        <item translatable="false">none</item>
+        <item translatable="false">simple</item>
+        <item translatable="false">extended</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -133,7 +133,7 @@
         <item translatable="false">@string/h5</item>
         <item translatable="false">@string/h6</item>
     </string-array>
-    <string-array name="pref_arrkeys__markdown_toc" translatable="false">
+    <string-array name="arr_one_to_six" translatable="false">
         <item translatable="false">1</item>
         <item translatable="false">2</item>
         <item translatable="false">3</item>
@@ -141,7 +141,7 @@
         <item translatable="false">5</item>
         <item translatable="false">6</item>
     </string-array>
-    <string-array name="pref_arrdefault__markdown_toc" translatable="false">
+    <string-array name="arr_one_to_three" translatable="false">
         <item translatable="false">1</item>
         <item translatable="false">2</item>
         <item translatable="false">3</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -141,10 +141,4 @@
         <item translatable="false">5</item>
         <item translatable="false">6</item>
     </string-array>
-    <string-array name="arr_one_to_three" translatable="false">
-        <item translatable="false">1</item>
-        <item translatable="false">2</item>
-        <item translatable="false">3</item>
-    </string-array>
-
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -126,14 +126,25 @@
     </string-array>
 
     <string-array name="pref_arrdisp__markdown_toc" translatable="false">
-        <item translatable="false">@string/no_toc</item>
-        <item translatable="false">@string/simple_toc</item>
-        <item translatable="false">@string/extended_toc</item>
+        <item translatable="false">@string/h1</item>
+        <item translatable="false">@string/h2</item>
+        <item translatable="false">@string/h3</item>
+        <item translatable="false">@string/h4</item>
+        <item translatable="false">@string/h5</item>
+        <item translatable="false">@string/h6</item>
     </string-array>
     <string-array name="pref_arrkeys__markdown_toc" translatable="false">
-        <item translatable="false">none</item>
-        <item translatable="false">simple</item>
-        <item translatable="false">extended</item>
+        <item translatable="false">1</item>
+        <item translatable="false">2</item>
+        <item translatable="false">3</item>
+        <item translatable="false">4</item>
+        <item translatable="false">5</item>
+        <item translatable="false">6</item>
+    </string-array>
+    <string-array name="pref_arrdefault__markdown_toc" translatable="false">
+        <item translatable="false">1</item>
+        <item translatable="false">2</item>
+        <item translatable="false">3</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -126,12 +126,12 @@
     </string-array>
 
     <string-array name="pref_arrdisp__markdown_toc" translatable="false">
-        <item translatable="false">@string/h1</item>
-        <item translatable="false">@string/h2</item>
-        <item translatable="false">@string/h3</item>
-        <item translatable="false">@string/h4</item>
-        <item translatable="false">@string/h5</item>
-        <item translatable="false">@string/h6</item>
+        <item translatable="false">@string/heading_1</item>
+        <item translatable="false">@string/heading_2</item>
+        <item translatable="false">@string/heading_3</item>
+        <item translatable="false">@string/heading_4</item>
+        <item translatable="false">@string/heading_5</item>
+        <item translatable="false">@string/heading_6</item>
     </string-array>
     <string-array name="arr_one_to_six" translatable="false">
         <item translatable="false">1</item>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -329,10 +329,4 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="action_format_markdown" translatable="false">action_format_markdown</string>
     <string name="action_format_todotxt" translatable="false">action_format_todotxt</string>
     <string name="action_format_zimwiki" translatable="false">action_format_zimwiki</string>
-    <string name="h1">H1</string>
-    <string name="h2">H2</string>
-    <string name="h3">H3</string>
-    <string name="h4">H4</string>
-    <string name="h5">H5</string>
-    <string name="h6">H6</string>
 </resources>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -192,7 +192,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__inject_to_body" translatable="false">pref_key__inject_to_body</string>
     <string name="pref_key__markdown_render_math" translatable="false">pref_key__markdown_render_math</string>
     <string name="pref_key__markdown_newline_newparagraph" translatable="false">pref_key__markdown_newline_newparagraph</string>
-    <string name="pref_key__markdown_show_toc" translatable="false">pref_key__markdown_show_toc</string>
+    <string name="pref_key__markdown_table_of_contents" translatable="false">pref_key__markdown_table_of_contents</string>
     <string name="pref_key__is_launcher_for_special_files_enabled" translatable="false">pref_key__is_launcher_for_special_files_enabled</string>
     <string name="pref_key__editor_basic_color_scheme__bg_light" translatable="false">pref_key__editor_basic_color_scheme__bg_light</string>
     <string name="pref_key__editor_basic_color_scheme__fg_light" translatable="false">pref_key__editor_basic_color_scheme__fg_light</string>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -192,7 +192,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__inject_to_body" translatable="false">pref_key__inject_to_body</string>
     <string name="pref_key__markdown_render_math" translatable="false">pref_key__markdown_render_math</string>
     <string name="pref_key__markdown_newline_newparagraph" translatable="false">pref_key__markdown_newline_newparagraph</string>
-    <string name="pref_key__markdown_table_of_contents" translatable="false">pref_key__markdown_table_of_contents</string>
+    <string name="pref_key__markdown_table_of_contents_enabled_levels" translatable="false">pref_key__markdown_table_of_contents_enabled_levels</string>
     <string name="pref_key__is_launcher_for_special_files_enabled" translatable="false">pref_key__is_launcher_for_special_files_enabled</string>
     <string name="pref_key__editor_basic_color_scheme__bg_light" translatable="false">pref_key__editor_basic_color_scheme__bg_light</string>
     <string name="pref_key__editor_basic_color_scheme__fg_light" translatable="false">pref_key__editor_basic_color_scheme__fg_light</string>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -329,4 +329,10 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="action_format_markdown" translatable="false">action_format_markdown</string>
     <string name="action_format_todotxt" translatable="false">action_format_todotxt</string>
     <string name="action_format_zimwiki" translatable="false">action_format_zimwiki</string>
+    <string name="h1">H1</string>
+    <string name="h2">H2</string>
+    <string name="h3">H3</string>
+    <string name="h4">H4</string>
+    <string name="h5">H5</string>
+    <string name="h6">H6</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,9 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="edit_picture">Edit picture</string>
     <string name="math">Math</string>
     <string name="table_of_contents">Table of contents</string>
+    <string name="no_toc">No table of contents</string>
+    <string name="simple_toc">Simple table of contents (up to H3)</string>
+    <string name="extended_toc">Extended table of contents (up to H6)</string>
     <string name="miscellaneous">Miscellaneous</string>
     <string name="textaction">Text action</string>
     <string name="textactions">Text actions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,9 +257,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="edit_picture">Edit picture</string>
     <string name="math">Math</string>
     <string name="table_of_contents">Table of contents</string>
-    <string name="no_toc">No table of contents</string>
-    <string name="simple_toc">Simple table of contents (up to H3)</string>
-    <string name="extended_toc">Extended table of contents (up to H6)</string>
     <string name="miscellaneous">Miscellaneous</string>
     <string name="textaction">Text action</string>
     <string name="textactions">Text actions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -360,6 +360,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="heading_3">Heading 3</string>
     <string name="heading_4">Heading 4</string>
     <string name="heading_5">Heading 5</string>
+    <string name="heading_6">Heading 6</string>
     <string name="bold">Bold</string>
     <string name="italic">Italic</string>
     <string name="highlighted">Highlighted</string>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -462,7 +462,6 @@
                     android:dialogTitle="@string/table_of_contents"
                     android:entries="@array/pref_arrdisp__markdown_toc"
                     android:entryValues="@array/arr_one_to_six"
-                    android:defaultValue="@array/arr_one_to_three"
                     android:icon="@drawable/ic_list_black_24dp"
                     android:key="@string/pref_key__markdown_table_of_contents_enabled_levels" />
             </PreferenceCategory>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -464,7 +464,7 @@
                     android:entryValues="@array/arr_one_to_six"
                     android:defaultValue="@array/arr_one_to_three"
                     android:icon="@drawable/ic_list_black_24dp"
-                    android:key="@string/pref_key__markdown_table_of_contents" />
+                    android:key="@string/pref_key__markdown_table_of_contents_enabled_levels" />
             </PreferenceCategory>
             <PreferenceCategory android:title="@string/textactions">
                 <Preference

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -458,10 +458,14 @@
                     android:key="@string/pref_key__markdown_render_math"
                     android:summary="@string/katex_latex"
                     android:title="@string/math" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
+                <ListPreference
+                    android:defaultValue="none"
+                    android:dialogTitle="@string/table_of_contents"
+                    android:entries="@array/pref_arrdisp__markdown_toc"
+                    android:entryValues="@array/pref_arrkeys__markdown_toc"
                     android:icon="@drawable/ic_list_black_24dp"
-                    android:key="@string/pref_key__markdown_show_toc"
+                    android:key="@string/pref_key__markdown_table_of_contents"
+                    android:summary="%1$s"
                     android:title="@string/table_of_contents" />
             </PreferenceCategory>
             <PreferenceCategory android:title="@string/textactions">

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -461,8 +461,8 @@
                 <MultiSelectListPreference android:title="@string/table_of_contents"
                     android:dialogTitle="@string/table_of_contents"
                     android:entries="@array/pref_arrdisp__markdown_toc"
-                    android:entryValues="@array/pref_arrkeys__markdown_toc"
-                    android:defaultValue="@array/pref_arrdefault__markdown_toc"
+                    android:entryValues="@array/arr_one_to_six"
+                    android:defaultValue="@array/arr_one_to_three"
                     android:icon="@drawable/ic_list_black_24dp"
                     android:key="@string/pref_key__markdown_table_of_contents" />
             </PreferenceCategory>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -458,15 +458,13 @@
                     android:key="@string/pref_key__markdown_render_math"
                     android:summary="@string/katex_latex"
                     android:title="@string/math" />
-                <ListPreference
-                    android:defaultValue="none"
+                <MultiSelectListPreference android:title="@string/table_of_contents"
                     android:dialogTitle="@string/table_of_contents"
                     android:entries="@array/pref_arrdisp__markdown_toc"
                     android:entryValues="@array/pref_arrkeys__markdown_toc"
+                    android:defaultValue="@array/pref_arrdefault__markdown_toc"
                     android:icon="@drawable/ic_list_black_24dp"
-                    android:key="@string/pref_key__markdown_table_of_contents"
-                    android:summary="%1$s"
-                    android:title="@string/table_of_contents" />
+                    android:key="@string/pref_key__markdown_table_of_contents" />
             </PreferenceCategory>
             <PreferenceCategory android:title="@string/textactions">
                 <Preference


### PR DESCRIPTION
This PR adds the option to view headings up to H6 in the table of contents in view mode.

The original checkbox in the markdown settings allowed to choose between no table of contents (unchecked) and a table of contents with headings up to H3 (checked).
With these changes, the checkbox is replaced with a radio button preference that allows to choose between no table of contents, a simple table of contents (like the existing, up to H3) and an "extended" table of contents with headings up to H6.

Background: I have quite a few files in my notebook with headings beyond H3 which I was missing in the view mode table of contents. I feel others might profit from more heading levels as well, while some may still prefer a smaller table of contents which shows only the topmost (presumably most relevant) heading levels up to H3.

![grafik](https://user-images.githubusercontent.com/45181277/132142073-94a8664e-95bd-49a3-ac8a-63590dede791.png)

![grafik](https://user-images.githubusercontent.com/45181277/132142081-eaef87f2-ff23-4b14-a3cd-6f5196283dae.png)

