### PR TITLE
ZimWiki: Syntax highlighting for code, global setting

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighter.java
@@ -38,9 +38,9 @@ public class MarkdownHighlighter extends Highlighter {
         super(hlEditor, document);
         _highlightLinks = false;
         _highlightLineEnding = _appSettings.isMarkdownHighlightLineEnding();
-        _highlightCodeChangeFont = _appSettings.isMarkdownHighlightCodeFontMonospaceAllowed();
+        _highlightCodeChangeFont = _appSettings.isHighlightCodeFontMonospaceAllowed();
         _highlightBiggerHeadings = _appSettings.isMarkdownBiggerHeadings();
-        _highlightDisableCodeBlock = _appSettings.isMarkdownDisableCodeBlockHighlight();
+        _highlightDisableCodeBlock = _appSettings.isDisableCodeBlockHighlight();
         setTextModifier(new ListHandler(_appSettings.isMarkdownAutoUpdateList(), MarkdownAutoFormat.getPrefixPatterns()));
     }
 

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownHighlighter.java
@@ -26,7 +26,7 @@ public class MarkdownHighlighter extends Highlighter {
     private final boolean _highlightLineEnding;
     private final boolean _highlightCodeChangeFont;
     private final boolean _highlightBiggerHeadings;
-    private final boolean _highlightDisableCodeBlock;
+    private final boolean _highlightCodeBlock;
 
     private static final int MD_COLOR_HEADING = 0xffef6D00;
     private static final int MD_COLOR_LINK = 0xff1ea3fe;
@@ -38,9 +38,9 @@ public class MarkdownHighlighter extends Highlighter {
         super(hlEditor, document);
         _highlightLinks = false;
         _highlightLineEnding = _appSettings.isMarkdownHighlightLineEnding();
-        _highlightCodeChangeFont = _appSettings.isHighlightCodeFontMonospaceAllowed();
+        _highlightCodeChangeFont = _appSettings.isHighlightCodeMonospaceFont();
         _highlightBiggerHeadings = _appSettings.isMarkdownBiggerHeadings();
-        _highlightDisableCodeBlock = _appSettings.isDisableCodeBlockHighlight();
+        _highlightCodeBlock = _appSettings.isHighlightCodeBlock();
         setTextModifier(new ListHandler(_appSettings.isMarkdownAutoUpdateList(), MarkdownAutoFormat.getPrefixPatterns()));
     }
 
@@ -85,7 +85,7 @@ public class MarkdownHighlighter extends Highlighter {
                 createMonospaceSpanForMatches(spannable, MarkdownHighlighterPattern.CODE.pattern);
             }
             _profiler.restart("Code - bgcolor");
-            if (!_highlightDisableCodeBlock) {
+            if (_highlightCodeBlock) {
                 createColorBackgroundSpan(spannable, MarkdownHighlighterPattern.CODE.pattern, MD_COLOR_CODEBLOCK);
             }
 

--- a/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiHighlighter.java
@@ -74,6 +74,7 @@ public class ZimWikiHighlighter extends Highlighter {
         private static final int CHECKLIST_CHECKED_COLOR = 0xff54a309;
         private static final int CHECKLIST_CROSSED_COLOR = 0xffa90000;
         private static final int ZIMHEADER_COLOR = 0xff808080;
+        private static final int CODEBLOCK_COLOR = 0xff8c8c8c;
     }
 
 
@@ -120,10 +121,21 @@ public class ZimWikiHighlighter extends Highlighter {
         createSpanWithStrikeThroughForMatches(spannable, Patterns.STRIKETHROUGH.pattern);
 
         _profiler.restart("Preformatted (monospaced) inline");
-        createMonospaceSpanForMatches(spannable, Patterns.PREFORMATTED_INLINE.pattern);
+        if (_appSettings.isZimWikiHighlightCodeFontMonospaceAllowed()) {
+            createMonospaceSpanForMatches(spannable, Patterns.PREFORMATTED_INLINE.pattern);
+        }
+        if (!_appSettings.isZimWikiDisableCodeBlockHighlight()) {
+            createColorBackgroundSpan(spannable, Patterns.PREFORMATTED_INLINE.pattern, Colors.CODEBLOCK_COLOR);
+        }
 
         _profiler.restart("Preformatted (monospaced) multiline");
-        createMonospaceSpanForMatches(spannable, Patterns.PREFORMATTED_MULTILINE.pattern); // TODO: also indent a bit
+        // TODO: also indent a bit
+        if (_appSettings.isZimWikiHighlightCodeFontMonospaceAllowed()) {
+            createMonospaceSpanForMatches(spannable, Patterns.PREFORMATTED_MULTILINE.pattern);
+        }
+        if (!_appSettings.isZimWikiDisableCodeBlockHighlight()) {
+            createColorBackgroundSpan(spannable, Patterns.PREFORMATTED_MULTILINE.pattern, Colors.CODEBLOCK_COLOR);
+        }
 
         _profiler.restart("Unordered list");
         createColorSpanForMatches(spannable, Patterns.LIST_UNORDERED.pattern, Colors.UNORDERED_LIST_BULLET_COLOR);

--- a/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiHighlighter.java
@@ -121,19 +121,19 @@ public class ZimWikiHighlighter extends Highlighter {
         createSpanWithStrikeThroughForMatches(spannable, Patterns.STRIKETHROUGH.pattern);
 
         _profiler.restart("Preformatted (monospaced) inline");
-        if (_appSettings.isZimWikiHighlightCodeFontMonospaceAllowed()) {
+        if (_appSettings.isHighlightCodeFontMonospaceAllowed()) {
             createMonospaceSpanForMatches(spannable, Patterns.PREFORMATTED_INLINE.pattern);
         }
-        if (!_appSettings.isZimWikiDisableCodeBlockHighlight()) {
+        if (!_appSettings.isDisableCodeBlockHighlight()) {
             createColorBackgroundSpan(spannable, Patterns.PREFORMATTED_INLINE.pattern, Colors.CODEBLOCK_COLOR);
         }
 
         _profiler.restart("Preformatted (monospaced) multiline");
         // TODO: also indent a bit
-        if (_appSettings.isZimWikiHighlightCodeFontMonospaceAllowed()) {
+        if (_appSettings.isHighlightCodeFontMonospaceAllowed()) {
             createMonospaceSpanForMatches(spannable, Patterns.PREFORMATTED_MULTILINE.pattern);
         }
-        if (!_appSettings.isZimWikiDisableCodeBlockHighlight()) {
+        if (!_appSettings.isDisableCodeBlockHighlight()) {
             createColorBackgroundSpan(spannable, Patterns.PREFORMATTED_MULTILINE.pattern, Colors.CODEBLOCK_COLOR);
         }
 

--- a/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiHighlighter.java
@@ -121,19 +121,18 @@ public class ZimWikiHighlighter extends Highlighter {
         createSpanWithStrikeThroughForMatches(spannable, Patterns.STRIKETHROUGH.pattern);
 
         _profiler.restart("Preformatted (monospaced) inline");
-        if (_appSettings.isHighlightCodeFontMonospaceAllowed()) {
+        if (_appSettings.isHighlightCodeMonospaceFont()) {
             createMonospaceSpanForMatches(spannable, Patterns.PREFORMATTED_INLINE.pattern);
         }
-        if (!_appSettings.isDisableCodeBlockHighlight()) {
+        if (_appSettings.isHighlightCodeBlock()) {
             createColorBackgroundSpan(spannable, Patterns.PREFORMATTED_INLINE.pattern, Colors.CODEBLOCK_COLOR);
         }
 
         _profiler.restart("Preformatted (monospaced) multiline");
-        // TODO: also indent a bit
-        if (_appSettings.isHighlightCodeFontMonospaceAllowed()) {
+        if (_appSettings.isHighlightCodeMonospaceFont()) {
             createMonospaceSpanForMatches(spannable, Patterns.PREFORMATTED_MULTILINE.pattern);
         }
-        if (!_appSettings.isDisableCodeBlockHighlight()) {
+        if (_appSettings.isHighlightCodeBlock()) {
             createColorBackgroundSpan(spannable, Patterns.PREFORMATTED_MULTILINE.pattern, Colors.CODEBLOCK_COLOR);
         }
 

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -167,22 +167,6 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
         return getBool(R.string.pref_key__markdown__highlight_lineending_two_or_more_space, false);
     }
 
-    public boolean isMarkdownHighlightCodeFontMonospaceAllowed() {
-        return getBool(R.string.pref_key__markdown__monospace_some_parts, false);
-    }
-
-    public boolean isZimWikiHighlightCodeFontMonospaceAllowed() {
-        return getBool(R.string.pref_key__zimwiki__monospace_some_parts, false);
-    }
-
-    public boolean isMarkdownDisableCodeBlockHighlight() {
-        return getBool(R.string.pref_key__markdown__disable_code_block_highlight, false);
-    }
-
-    public boolean isZimWikiDisableCodeBlockHighlight() {
-        return getBool(R.string.pref_key__zimwiki__disable_code_block_highlight, false);
-    }
-
     public boolean isMarkdownAutoUpdateList() {
         return true;
         // return getBool(R.string.pref_key__markdown__auto_renumber_ordered_list, false);
@@ -321,6 +305,14 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
 
     public boolean isDisableSpellingRedUnderline() {
         return getBool(R.string.pref_key__editor_disable_spelling_red_underline, true);
+    }
+
+    public boolean isHighlightCodeFontMonospaceAllowed() {
+        return getBool(R.string.pref_key__monospace_some_parts, false);
+    }
+
+    public boolean isDisableCodeBlockHighlight() {
+        return getBool(R.string.pref_key__disable_code_block_highlight, false);
     }
 
     public void addRecentDocument(File file) {

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -167,6 +167,14 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
         return getBool(R.string.pref_key__markdown__highlight_lineending_two_or_more_space, false);
     }
 
+    public boolean isHighlightCodeMonospaceFont() {
+        return getBool(R.string.pref_key__highlight_code_monospace_font, false);
+    }
+
+    public boolean isHighlightCodeBlock() {
+        return !getBool(R.string.pref_key__hightlight_code_block_disabled, false);
+    }
+
     public boolean isMarkdownAutoUpdateList() {
         return true;
         // return getBool(R.string.pref_key__markdown__auto_renumber_ordered_list, false);
@@ -305,14 +313,6 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
 
     public boolean isDisableSpellingRedUnderline() {
         return getBool(R.string.pref_key__editor_disable_spelling_red_underline, true);
-    }
-
-    public boolean isHighlightCodeFontMonospaceAllowed() {
-        return getBool(R.string.pref_key__monospace_some_parts, false);
-    }
-
-    public boolean isDisableCodeBlockHighlight() {
-        return getBool(R.string.pref_key__disable_code_block_highlight, false);
     }
 
     public void addRecentDocument(File file) {

--- a/app/src/main/java/net/gsantner/markor/util/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/util/AppSettings.java
@@ -171,8 +171,16 @@ public class AppSettings extends SharedPreferencesPropertyBackend {
         return getBool(R.string.pref_key__markdown__monospace_some_parts, false);
     }
 
+    public boolean isZimWikiHighlightCodeFontMonospaceAllowed() {
+        return getBool(R.string.pref_key__zimwiki__monospace_some_parts, false);
+    }
+
     public boolean isMarkdownDisableCodeBlockHighlight() {
         return getBool(R.string.pref_key__markdown__disable_code_block_highlight, false);
+    }
+
+    public boolean isZimWikiDisableCodeBlockHighlight() {
+        return getBool(R.string.pref_key__zimwiki__disable_code_block_highlight, false);
     }
 
     public boolean isMarkdownAutoUpdateList() {

--- a/app/src/main/java/net/gsantner/opoc/util/NanoProfiler.java
+++ b/app/src/main/java/net/gsantner/opoc/util/NanoProfiler.java
@@ -28,6 +28,7 @@ public class NanoProfiler {
 
     public NanoProfiler setEnabled(boolean enabled) {
         _profilerEnabled = enabled;
+        _profilerEnabled = true;
         return this;
     }
 
@@ -38,6 +39,7 @@ public class NanoProfiler {
     }
 
     public void start(boolean increaseGroupCounter, String... optionalText) {
+        _profilerEnabled = true;
         if (_profilerEnabled) {
             if (increaseGroupCounter) {
                 _groupCount++;

--- a/app/src/main/java/net/gsantner/opoc/util/NanoProfiler.java
+++ b/app/src/main/java/net/gsantner/opoc/util/NanoProfiler.java
@@ -28,7 +28,6 @@ public class NanoProfiler {
 
     public NanoProfiler setEnabled(boolean enabled) {
         _profilerEnabled = enabled;
-        _profilerEnabled = true;
         return this;
     }
 
@@ -39,7 +38,6 @@ public class NanoProfiler {
     }
 
     public void start(boolean increaseGroupCounter, String... optionalText) {
-        _profilerEnabled = true;
         if (_profilerEnabled) {
             if (increaseGroupCounter) {
                 _groupCount++;

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -180,8 +180,8 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__more_info__copy_build_information" translatable="false">pref_key__more_info__copy_build_information</string>
     <string name="pref_key__editor_textaction_bar_item_padding" translatable="false">pref_key__editor_textaction_bar_item_padding</string>
     <string name="pref_key__editor_disable_spelling_red_underline" translatable="false">pref_key__editor_disable_spelling_red_underline</string>
-    <string name="pref_key__monospace_some_parts" translatable="false">pref_key__monospace_some_parts</string>
-    <string name="pref_key__disable_code_block_highlight" translatable="false">pref_key__disable_code_block_highlight</string>
+    <string name="pref_key__highlight_code_monospace_font" translatable="false">pref_key__highlight_code_monospace_font</string>
+    <string name="pref_key__hightlight_code_block_disabled" translatable="false">pref_key__hightlight_code_block_disabled</string>
     <string name="pref_key__editor_markdown_bigger_headings_2" translatable="false">pref_key__editor_markdown_bigger_headings_2</string>
     <string name="pref_key__editor_unordered_list_character" translatable="false">pref_key__editor_unordered_list_character</string>
     <string name="pref_key__recent_documents" translatable="false">pref_key__recent_documents</string>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -122,8 +122,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__markdown__hl_delay_v2" translatable="false">pref_key__markdown__hl_delay_v2</string>
     <string name="pref_key__quicknote_filepath" translatable="false">pref_key__quicknote_filepath</string>
     <string name="pref_key__markdown__highlight_lineending_two_or_more_space" translatable="false">pref_key__markdown__highlight_lineending_two_or_more_space</string>
-    <string name="pref_key__markdown__monospace_some_parts" translatable="false">pref_key__markdown__monospace_some_parts</string>
-    <string name="pref_key__markdown__disable_code_block_highlight" translatable="false">pref_key__markdown__disable_code_block_highlight</string>
     <string name="pref_key__markdown__auto_renumber_ordered_list" translatable="false">pref_key__markdown__auto_renumber_ordered_list</string>
     <string name="pref_key__markdown__reorder_actions" translatable="false">pref_key__markdown__reorder_actions</string>
     <string name="pref_key__todotxt__reorder_actions" translatable="false">pref_key__todotxt__reorder_actions</string>
@@ -182,6 +180,8 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__more_info__copy_build_information" translatable="false">pref_key__more_info__copy_build_information</string>
     <string name="pref_key__editor_textaction_bar_item_padding" translatable="false">pref_key__editor_textaction_bar_item_padding</string>
     <string name="pref_key__editor_disable_spelling_red_underline" translatable="false">pref_key__editor_disable_spelling_red_underline</string>
+    <string name="pref_key__monospace_some_parts" translatable="false">pref_key__monospace_some_parts</string>
+    <string name="pref_key__disable_code_block_highlight" translatable="false">pref_key__disable_code_block_highlight</string>
     <string name="pref_key__editor_markdown_bigger_headings_2" translatable="false">pref_key__editor_markdown_bigger_headings_2</string>
     <string name="pref_key__editor_unordered_list_character" translatable="false">pref_key__editor_unordered_list_character</string>
     <string name="pref_key__recent_documents" translatable="false">pref_key__recent_documents</string>
@@ -311,8 +311,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="select_current_line" translatable="false">Select current line(s)</string>
     <string name="pref_key__file_description_format" translatable="false">pref_key__file_description_format</string>
     <string name="pref_key__editor_zimwiki_bigger_headings" translatable="false">pref_key__editor_zimwiki_bigger_headings</string>
-    <string name="pref_key__zimwiki__monospace_some_parts" translatable="false">pref_key__zimwiki__monospace_some_parts</string>
-    <string name="pref_key__zimwiki__disable_code_block_highlight" translatable="false">pref_key__zimwiki__disable_code_block_highlight</string>
     <string name="pref_key__zimwiki__reorder_actions" translatable="false">pref_key__zimwiki__reorder_actions</string>
     <string name="pref_key__zimwiki__action_keys" translatable="false">pref_key__zimwiki__action_keys</string>
     <string name="pref_key__max_search_depth" translatable="false">pref_key__max_search_depth</string>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -311,6 +311,8 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="select_current_line" translatable="false">Select current line(s)</string>
     <string name="pref_key__file_description_format" translatable="false">pref_key__file_description_format</string>
     <string name="pref_key__editor_zimwiki_bigger_headings" translatable="false">pref_key__editor_zimwiki_bigger_headings</string>
+    <string name="pref_key__zimwiki__monospace_some_parts" translatable="false">pref_key__zimwiki__monospace_some_parts</string>
+    <string name="pref_key__zimwiki__disable_code_block_highlight" translatable="false">pref_key__zimwiki__disable_code_block_highlight</string>
     <string name="pref_key__zimwiki__reorder_actions" translatable="false">pref_key__zimwiki__reorder_actions</string>
     <string name="pref_key__zimwiki__action_keys" translatable="false">pref_key__zimwiki__action_keys</string>
     <string name="pref_key__max_search_depth" translatable="false">pref_key__max_search_depth</string>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -304,13 +304,13 @@
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:icon="@drawable/ic_code_black_24dp"
-                android:key="@string/pref_key__monospace_some_parts"
+                android:key="@string/pref_key__highlight_code_monospace_font"
                 android:summary="@string/use_different_fonttype_slow_down"
                 android:title="@string/use_monospace_for_code" />
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:icon="@drawable/ic_code_black_24dp"
-                android:key="@string/pref_key__disable_code_block_highlight"
+                android:key="@string/pref_key__hightlight_code_block_disabled"
                 android:title="@string/disable_code_block_highlight" />
         </PreferenceCategory>
 

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -539,6 +539,17 @@
                     android:key="@string/pref_key__editor_zimwiki_bigger_headings"
                     android:summary="@string/increase_text_size_of_headings_according_to_level"
                     android:title="@string/bigger_headings" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:icon="@drawable/ic_code_black_24dp"
+                    android:key="@string/pref_key__zimwiki__monospace_some_parts"
+                    android:summary="@string/use_different_fonttype_slow_down"
+                    android:title="@string/use_monospace_for_code" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:icon="@drawable/ic_code_black_24dp"
+                    android:key="@string/pref_key__zimwiki__disable_code_block_highlight"
+                    android:title="@string/disable_code_block_highlight" />
             </PreferenceCategory>
             <PreferenceCategory android:title="@string/textactions">
                 <Preference

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -301,6 +301,17 @@
                 android:key="@string/pref_key__editor_disable_spelling_red_underline"
                 android:summary="@string/spellcheck_keyboard_suggestion_stay_red_underline_vanishes"
                 android:title="@string/disable_spelling_underline" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:icon="@drawable/ic_code_black_24dp"
+                android:key="@string/pref_key__monospace_some_parts"
+                android:summary="@string/use_different_fonttype_slow_down"
+                android:title="@string/use_monospace_for_code" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:icon="@drawable/ic_code_black_24dp"
+                android:key="@string/pref_key__disable_code_block_highlight"
+                android:title="@string/disable_code_block_highlight" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/miscellaneous">
@@ -430,20 +441,9 @@
                     android:title="@string/bigger_headings" />
                 <CheckBoxPreference
                     android:defaultValue="false"
-                    android:icon="@drawable/ic_code_black_24dp"
-                    android:key="@string/pref_key__markdown__monospace_some_parts"
-                    android:summary="@string/use_different_fonttype_slow_down"
-                    android:title="@string/use_monospace_for_code" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
                     android:icon="@drawable/ic_baseline_keyboard_return_24"
                     android:key="@string/pref_key__markdown_newline_newparagraph"
                     android:title="@string/newline_is_new_paragraph" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:icon="@drawable/ic_code_black_24dp"
-                    android:key="@string/pref_key__markdown__disable_code_block_highlight"
-                    android:title="@string/disable_code_block_highlight" />
                 <!-- CheckBoxPreference
                     android:defaultValue="false"
                     android:icon="@drawable/ic_format_list_numbered_black_24dp"
@@ -539,17 +539,6 @@
                     android:key="@string/pref_key__editor_zimwiki_bigger_headings"
                     android:summary="@string/increase_text_size_of_headings_according_to_level"
                     android:title="@string/bigger_headings" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:icon="@drawable/ic_code_black_24dp"
-                    android:key="@string/pref_key__zimwiki__monospace_some_parts"
-                    android:summary="@string/use_different_fonttype_slow_down"
-                    android:title="@string/use_monospace_for_code" />
-                <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:icon="@drawable/ic_code_black_24dp"
-                    android:key="@string/pref_key__zimwiki__disable_code_block_highlight"
-                    android:title="@string/disable_code_block_highlight" />
             </PreferenceCategory>
             <PreferenceCategory android:title="@string/textactions">
                 <Preference


### PR DESCRIPTION
This PR adds the same functionality for ZimWiki for highlighting/formatting code which is already present for Markdown.

Before, code (inline and blocks) was always formatted as monospace, which led to severe performance problems in larger files with a lot of code samples.

Now, formatting code as monospace is optional (and turned off by default), but code is highlighted with gray background color (like for markdown). There's also the option to disable highlighting.

![grafik](https://user-images.githubusercontent.com/45181277/132964510-773f018a-8300-4844-92dc-5924921b3c3a.png)
![grafik](https://user-images.githubusercontent.com/45181277/132965039-ed897b13-27e7-4030-b099-b7f6dc592db0.png)
