### PR TITLE
Fix language preference: Properly show all languages, by @gsantner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,14 +86,15 @@ static String findUsedAndroidLocales() {
     Set<String> langs = new HashSet<>()
     new File('.').eachFileRecurse(groovy.io.FileType.DIRECTORIES) {
         final foldername = it.name
-        if (foldername.startsWith('values-') && !it.canonicalPath.contains("build" + File.separator + "intermediates") && !it.canonicalPath.contains("gradle" + File.separator + "daemon")) {
+        if (foldername.contains('values-') && !it.absolutePath.contains("build" + File.separator + "intermediates") && !foldername.matches(".*values-((.*[0-9])|(land)|(port)).*")) {
             new File(it.toString()).eachFileRecurse(groovy.io.FileType.FILES) {
-                if (it.name.toLowerCase().endsWith(".xml") && it.getCanonicalFile().getText('UTF-8').contains("<string")) {
+                if (it.exists() && it.name.toLowerCase().endsWith(".xml") && it.getText('UTF-8').contains("<string")) {
                     langs.add(foldername.replace("values-", ""))
                 }
             }
         }
     }
+    langs = langs.sort()
     return '{' + langs.collect { "\"${it}\"" }.join(",") + '}'
 }
 


### PR DESCRIPTION
This PR fixes an issue with the language selection setting. I noticed that it not shows up other languages than system and english anymore. (Probably Gradle has changed some things regarding at the eachFileRecurse function or alike.)

Before vs fixed

![screenshot-2021-10-02__14-33-29](https://user-images.githubusercontent.com/6735650/135716499-13658dc4-eb69-4091-af77-3499aeea1c46.png)


