### PR TITLE
Fix recently added languages not displayed accordingly, by @gsantner

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/preference/LanguagePreferenceCompat.java
+++ b/app/src/main/java/net/gsantner/opoc/preference/LanguagePreferenceCompat.java
@@ -162,6 +162,10 @@ public class LanguagePreferenceCompat extends ListPreference {
             ret = ret.substring(0, ret.indexOf(" ") + 1) + "Cyrillic" + ret.substring(ret.indexOf(" "));
         } else if (localeAndroidCode.equals("fil")) {
             ret = ret.substring(0, ret.indexOf("(") + 1) + "Philippines)";
+        } else if (localeAndroidCode.equals("kmr")) {
+            ret = "Kurdish Kurmanji (کورمانجی)";
+        } else if (localeAndroidCode.equals("ckb")) {
+            ret = "Kurdish Sorani (" + ret.split("\\(")[1];
         }
 
         return ret;

--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,7 @@ static String findUsedAndroidLocales() {
             }
         }
     }
-    langs = langs.sort()
-    return '{' + langs.collect { "\"${it}\"" }.join(",") + '}'
+    return '{' + langs.sort().collect { "\"${it}\"" }.join(",") + '}'
 }
 
 ext.getGitHash = { ->


### PR DESCRIPTION
Fix recently added languages not displayed accordingly. 

* kmr would be just displayed as kmr
* ckb as Central Kurdish

Both don't have a proper/fancy language info builtin in the Java implementation Android has.  
So manually override both, similar to chinese and some other special language identifiers.


![screenshot-2021-10-02__15-03-39](https://user-images.githubusercontent.com/6735650/135717572-1a9f9599-d4f6-4104-a7ca-f64d0447a242.png)


