### PR TITLE
Fix preference-key based buttons not working on some devices with turkish locale

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/MoreInfoFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/MoreInfoFragment.java
@@ -79,8 +79,7 @@ public class MoreInfoFragment extends GsPreferenceFragmentCompat<AppSettings> {
                 }
                 case R.string.pref_key__more_info__help: {
                     _cu.openWebpageInExternalBrowser(
-                            String.format("https://gsantner.net/project/%s.html?source=inapp_more_help_faq",
-                                    getString(R.string.app_name_real).toLowerCase()));
+                            String.format("https://gsantner.net/project/%s.html?source=inapp_more_help_faq", getString(R.string.app_name_real).toLowerCase()));
                     return true;
                 }
                 case R.string.pref_key__more_info__donate: {

--- a/app/src/main/java/net/gsantner/opoc/util/ContextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/ContextUtils.java
@@ -127,7 +127,7 @@ public class ContextUtils {
      */
     public int getResId(final ResType resType, final String name) {
         try {
-            return _context.getResources().getIdentifier(name, resType.name().toLowerCase(), _context.getPackageName());
+            return _context.getResources().getIdentifier(name, resType.name().toLowerCase(Locale.ENGLISH), _context.getPackageName());
         } catch (Exception e) {
             return 0;
         }
@@ -231,7 +231,7 @@ public class ContextUtils {
         }
         if (src == null || src.trim().isEmpty()) {
             return "Sideloaded";
-        } else if (src.toLowerCase().contains(".amazon.")) {
+        } else if (src.toLowerCase(Locale.ENGLISH).contains(".amazon.")) {
             return "Amazon Appstore";
         }
         switch (src) {
@@ -1048,7 +1048,7 @@ public class ContextUtils {
 
     public String getFileProvider() {
         for (final ProviderInfo info : getProvidersInfos()) {
-            if (info.name.toLowerCase().contains("fileprovider")) {
+            if (info.name.toLowerCase(Locale.ENGLISH).contains("fileprovider")) {
                 return info.authority;
             }
         }


### PR DESCRIPTION
* Fix preference-key based buttons not working on some devices with turkish locale
* Fixes #1425 #1443 

Switched language to turkish and found most buttons do not work. This was due the getResKey function always returned 0. While "STRING".toLowerCase() is supposed to be "string" everywhere...still there is an issue as outlined here <https://stackoverflow.com/questions/47250454/android-resourcesnotfoundexception-on-a-specific-language> ("`The infamous Turkish locale bug`).

With the change applied settings, moreinfo buttons etc started to work properly.