### PR TITLE
Renumber list performance improvement

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/AutoFormatter.java
+++ b/app/src/main/java/net/gsantner/markor/format/AutoFormatter.java
@@ -11,6 +11,7 @@ package net.gsantner.markor.format;
 
 import android.annotation.SuppressLint;
 import android.text.Editable;
+import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 
 import net.gsantner.opoc.util.StringUtils;
@@ -269,8 +270,9 @@ public class AutoFormatter {
             return;
         }
 
-        // Copy all the text
-        final StringBuilder text = new StringBuilder(edit);
+        // Copy all the text if we are going to process
+        // SpannableStringBuilder makes the spans _appear_ to transition smoothly
+        final Editable text = new SpannableStringBuilder(edit);
 
         // Stack represents each level in the list up from current
         final Stack<OrderedListLine> levels = new Stack<>();

--- a/app/src/main/java/net/gsantner/markor/format/AutoFormatter.java
+++ b/app/src/main/java/net/gsantner/markor/format/AutoFormatter.java
@@ -236,7 +236,7 @@ public class AutoFormatter {
      * @param position Position within current line
      * @return OrderedListLine corresponding to top of current list
      */
-    private static OrderedListLine getOrderedListStart(final Editable text, int position, final PrefixPatterns prefixPatterns) {
+    private static OrderedListLine getOrderedListStart(final CharSequence text, int position, final PrefixPatterns prefixPatterns) {
         position = Math.max(Math.min(position, text.length() - 1), 0);
         OrderedListLine listStart = new OrderedListLine(text, position, prefixPatterns);
 
@@ -261,7 +261,10 @@ public class AutoFormatter {
      * <p>
      * This is an unfortunately complex + complicated function. Tweak at your peril and test a *lot* :)
      */
-    public static void renumberOrderedList(final Editable text, int cursorPosition, final PrefixPatterns prefixPatterns) {
+    public static void renumberOrderedList(final Editable edit, int cursorPosition, final PrefixPatterns prefixPatterns) {
+
+        // Copy all the text
+        final StringBuilder text = new StringBuilder(edit);
 
         // Top of list
         final OrderedListLine firstLine = getOrderedListStart(text, cursorPosition, prefixPatterns);
@@ -329,6 +332,11 @@ public class AutoFormatter {
                     break;
                 }
             }
+
+            // Replace the text in Editable in one chunk
+            final int[] diff = StringUtils.findDiff(edit, text);
+            edit.replace(diff[0], diff[1], text.subSequence(diff[0], diff[2]));
+
         } catch (EmptyStackException ex) {
             // Usually means that indents and de-indents did not match up
             ex.printStackTrace();

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -167,17 +167,32 @@ public class HighlightingEditor extends AppCompatEditText {
         _activeListeners.remove(listener);
     }
 
+    // Run some code with accessibility disabled
+    public void withAccessibilityDisabled(final Callback.a0 callback) {
+        if (getAccessibilityEnabled()) {
+            try {
+                setAccessibilityEnabled(false);
+                callback.callback();
+            } finally {
+                setAccessibilityEnabled(true);
+            }
+        } else {
+            callback.callback();
+        }
+    }
+
     // Run some code with auto formatters disabled
+    // Also disables accessibility
     public void withAutoFormatDisabled(final Callback.a0 callback) {
         if (getAutoFormatEnabled()) {
             try {
                 setAutoFormatEnabled(false);
-                callback.callback();
+                withAccessibilityDisabled(() -> callback.callback());
             } finally {
                 setAutoFormatEnabled(true);
             }
         } else {
-            callback.callback();
+            withAccessibilityDisabled(() -> callback.callback());
         }
     }
 

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -169,15 +169,11 @@ public class HighlightingEditor extends AppCompatEditText {
 
     // Run some code with accessibility disabled
     public void withAccessibilityDisabled(final Callback.a0 callback) {
-        if (getAccessibilityEnabled()) {
-            try {
-                setAccessibilityEnabled(false);
-                callback.callback();
-            } finally {
-                setAccessibilityEnabled(true);
-            }
-        } else {
+        try {
+            _accessibilityEnabled = false;
             callback.callback();
+        } finally {
+            _accessibilityEnabled = true;
         }
     }
 
@@ -228,16 +224,14 @@ public class HighlightingEditor extends AppCompatEditText {
                 if (MainActivity.IS_DEBUG_ENABLED) {
                     AppSettings.appendDebugLog("Start highlighting");
                 }
-                setAccessibilityEnabled(false);
-                _hl.run(getText());
+                withAccessibilityDisabled(() ->_hl.run(getText()));
             } catch (Exception e) {
                 // In no case ever let highlighting crash the editor
                 e.printStackTrace();
             } catch (Error e) {
                 e.printStackTrace();
-            } finally {
-                setAccessibilityEnabled(true);
             }
+
             if (MainActivity.IS_DEBUG_ENABLED) {
                 AppSettings.appendDebugLog(_hl._profiler.resetDebugText());
                 AppSettings.appendDebugLog("Finished highlighting");
@@ -337,13 +331,5 @@ public class HighlightingEditor extends AppCompatEditText {
         if (MainActivity.IS_DEBUG_ENABLED) {
             AppSettings.appendDebugLog("Selection changed: " + selStart + "->" + selEnd);
         }
-    }
-
-    public void setAccessibilityEnabled(final boolean enabled) {
-        _accessibilityEnabled = enabled;
-    }
-
-    public boolean getAccessibilityEnabled() {
-        return _accessibilityEnabled;
     }
 }

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -388,15 +388,10 @@ public abstract class TextActions {
      * @param matchAll Whether to stop matching subsequent ReplacePatterns after first match+replace
      */
     public static void runRegexReplaceAction(final EditText editor, final List<ReplacePattern> patterns, final boolean matchAll) {
-        try {
-            if (editor instanceof HighlightingEditor) {
-                ((HighlightingEditor) editor).setAccessibilityEnabled(false);
-            }
+        if (editor instanceof HighlightingEditor) {
+            ((HighlightingEditor) editor).withAutoFormatDisabled(() -> _runRegexReplaceAction(editor, patterns, matchAll));
+        } else {
             _runRegexReplaceAction(editor, patterns, matchAll);
-        } finally {
-            if (editor instanceof HighlightingEditor) {
-                ((HighlightingEditor) editor).setAccessibilityEnabled(true);
-            }
         }
     }
 
@@ -772,15 +767,7 @@ public abstract class TextActions {
 
     public final void runRenumberOrderedListIfRequired(final boolean force) {
         if (force || _hlEditor.getAutoFormatEnabled()) {
-            final boolean isAccessibilityEnabled = _hlEditor.getAccessibilityEnabled();
-            try {
-                _hlEditor.setAccessibilityEnabled(false);
-                _hlEditor.withAutoFormatDisabled(() -> renumberOrderedList(StringUtils.getSelection(_hlEditor)[0]));
-            } finally {
-                if (isAccessibilityEnabled) {
-                    _hlEditor.setAccessibilityEnabled(true);
-                }
-            }
+            _hlEditor.withAutoFormatDisabled(() -> renumberOrderedList(StringUtils.getSelection(_hlEditor)[0]));
         }
     }
 

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -473,7 +473,8 @@ public final class StringUtils {
         }
 
         int end = 0;
-        while(end < minLength && source.charAt(sl - end - 1) == dest.charAt(dl - end - 1)) end++;
+        final int maxEnd = minLength - start;
+        while(end < maxEnd && source.charAt(sl - end - 1) == dest.charAt(dl - end - 1)) end++;
 
         return new int[] { start, dl - end, sl - end };
     }

--- a/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/StringUtils.java
@@ -452,4 +452,29 @@ public final class StringUtils {
         interpolated.append(temp); // Remaining text
         return interpolated.toString();
     }
+
+    // Find the smallest single difference region { a, b, c }
+    // s.t. setting dest[a:b] = source[a:c] makes dest == source
+    public static int[] findDiff(final CharSequence dest, final CharSequence source) {
+
+        final int dl = dest.length(), sl = source.length();
+        final int minLength = Math.min(dl, sl);
+
+        int start = 0;
+        while(start < minLength && source.charAt(start) == dest.charAt(start)) start++;
+
+        // Handle several special cases
+        if (sl == dl && start == sl) { // Case where 2 sequences are same
+            return new int[] { sl, sl, sl };
+        } else if (sl < dl && start == sl) { // Pure crop
+            return new int[] { sl, dl, sl };
+        } else if (dl < sl && start == dl) { // Pure append
+            return new int[] { dl, dl, sl };
+        }
+
+        int end = 0;
+        while(end < minLength && source.charAt(sl - end - 1) == dest.charAt(dl - end - 1)) end++;
+
+        return new int[] { start, dl - end, sl - end };
+    }
 }

--- a/app/src/test/java/net/gsantner/markor/StringUtilsTest.java
+++ b/app/src/test/java/net/gsantner/markor/StringUtilsTest.java
@@ -1,0 +1,26 @@
+package net.gsantner.markor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.gsantner.opoc.util.StringUtils;
+
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void findDiffTest() {
+        assertThat(StringUtils.findDiff("", "")).isEqualTo(new int[] {0, 0, 0});
+        assertThat(StringUtils.findDiff("abcd", "abcd")).isEqualTo(new int[] {4, 4, 4});
+        assertThat(StringUtils.findDiff("ab", "abcd")).isEqualTo(new int[] {2, 2, 4});
+        assertThat(StringUtils.findDiff("abcd", "ab")).isEqualTo(new int[] {2, 4, 2});
+        assertThat(StringUtils.findDiff("ab1d", "ab2d")).isEqualTo(new int[] {2, 3, 3});
+        assertThat(StringUtils.findDiff("ab12d", "ab34d")).isEqualTo(new int[] {2, 4, 4});
+        assertThat(StringUtils.findDiff("ab12d", "ab3d")).isEqualTo(new int[] {2, 4, 3});
+        assertThat(StringUtils.findDiff("ab12d", "abd")).isEqualTo(new int[] {2, 4, 2});
+        assertThat(StringUtils.findDiff("abd", "ab12d")).isEqualTo(new int[] {2, 2, 4});
+        assertThat(StringUtils.findDiff("abcd", "")).isEqualTo(new int[] {0, 4, 0});
+        assertThat(StringUtils.findDiff("", "abcd")).isEqualTo(new int[] {0, 0, 4});
+    }
+}
+

--- a/app/src/test/java/net/gsantner/markor/StringUtilsTest.java
+++ b/app/src/test/java/net/gsantner/markor/StringUtilsTest.java
@@ -21,6 +21,9 @@ public class StringUtilsTest {
         assertThat(StringUtils.findDiff("abd", "ab12d")).isEqualTo(new int[] {2, 2, 4});
         assertThat(StringUtils.findDiff("abcd", "")).isEqualTo(new int[] {0, 4, 0});
         assertThat(StringUtils.findDiff("", "abcd")).isEqualTo(new int[] {0, 0, 4});
+        assertThat(StringUtils.findDiff("ab11d", "ab1d")).isEqualTo(new int[] {3, 4, 3});
+        assertThat(StringUtils.findDiff("aaaaa", "aaa")).isEqualTo(new int[] {3, 5, 3});
+        assertThat(StringUtils.findDiff("aaa", "aaaaa")).isEqualTo(new int[] {3, 3, 5});
     }
 }
 


### PR DESCRIPTION
This PR improves performance when renumbering a list.

Renumbering is currently done in place. This adds an undo and triggers a check for whether the text has changed multiple times in rapid succession.

In this PR the renumber has been modified to work on a _copy_ of the text. The original editable is updated in one step by diffing against the updated copy.

Have also improved the way accessibility is disabled for some operations 