### PR TITLE
Just try to use another colorPicker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "app/libs/ColorPickerHex"]
+	path = app/libs/ColorPickerHex
+	url = https://github.com/peterfajdiga/ColorPickerHex.git

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,6 +103,7 @@ android {
 }
 
 dependencies {
+    compile project(":ColorPickerHex")
     // Testing
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.13.1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,4 @@
 include(':app:thirdparty-lib-src:QuadFlask-colorpicker')
 include ':app'
+include ':ColorPickerHex'
+project(':ColorPickerHex').projectDir = new File('app/libs/ColorPickerHex/colorpickerhex')


### PR DESCRIPTION
Hello developer, I tried to add another color picker preference for Android that ”enables selecting colors using sliders or hexadecimal color codes“ from github, here is its URL(https://github.com/peterfajdiga/ColorPickerHex), do you mind using another project in your project?
PS: Maybe this small change is not very useful TAT




<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
