### PR TITLE
Launcher ShortCuts: Open ToDo & QuickNote at bottom

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentActivity.java
@@ -174,12 +174,14 @@ public class DocumentActivity extends MarkorBaseActivity {
         if (!intentIsSend && file != null) {
             final Document doc = new Document(file);
 
-            int startLine = intent.getIntExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
-            if (startLine < 0 && intentData != null) {
+            Integer startLine = null;
+            if (intent.hasExtra(Document.EXTRA_FILE_LINE_NUMBER)) {
+                startLine = intent.getIntExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
+            } else if (intentData != null) {
                 startLine = StringUtils.tryParseInt(intentData.getQueryParameter("line"), -1);
             }
 
-            final boolean startInPreview = (startLine < 0) && (
+            final boolean startInPreview = (startLine == null) && (
                     intent.getBooleanExtra(EXTRA_DO_PREVIEW, false) ||
                             _appSettings.getDocumentPreviewState(doc.getPath()) ||
                             file.getName().startsWith("index."));

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -77,7 +77,7 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
         DocumentEditFragment f = new DocumentEditFragment();
         Bundle args = new Bundle();
         args.putSerializable(Document.EXTRA_DOCUMENT, document);
-        if (lineNumber != null && lineNumber >= 0) {
+        if (lineNumber != null) {
             args.putInt(Document.EXTRA_FILE_LINE_NUMBER, lineNumber);
         }
         args.putBoolean(START_PREVIEW, preview);
@@ -232,8 +232,13 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
         if (_savedInstanceState == null) {
             if (isDisplayedAtMainActivity() || _appSettings.isEditorStartOnBotttom()) {
                 startPos = _hlEditor.length();
-            } else if (args != null && args.getInt(Document.EXTRA_FILE_LINE_NUMBER, -1) >= 0) {
-                startPos = StringUtils.getIndexFromLineOffset(_hlEditor.getText(), args.getInt(Document.EXTRA_FILE_LINE_NUMBER), 0);
+            } else if (args != null && args.containsKey(Document.EXTRA_FILE_LINE_NUMBER)) {
+                final int lno = args.getInt(Document.EXTRA_FILE_LINE_NUMBER);
+                if (lno >= 0) {
+                    startPos = StringUtils.getIndexFromLineOffset(_hlEditor.getText(), lno, 0);
+                } else {
+                    startPos = _hlEditor.length();
+                }
             }
         }
 

--- a/app/src/main/java/net/gsantner/markor/activity/openeditor/OpenEditorActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/openeditor/OpenEditorActivity.java
@@ -23,10 +23,16 @@ import net.gsantner.opoc.util.PermissionChecker;
 import java.io.File;
 
 public class OpenEditorActivity extends MarkorBaseActivity {
-    protected void openEditorForFile(File file) {
-        Intent openIntent = new Intent(getApplicationContext(), DocumentActivity.class)
+
+    protected void openEditorForFile(final File file, final Integer line) {
+        final Intent openIntent = new Intent(getApplicationContext(), DocumentActivity.class)
                 .setAction(Intent.ACTION_CALL_BUTTON)
                 .putExtra(Document.EXTRA_PATH, file);
+
+        if (line != null) {
+            openIntent.putExtra(Document.EXTRA_FILE_LINE_NUMBER, line);
+        }
+
         openActivityAndClose(openIntent, file);
     }
 

--- a/app/src/main/java/net/gsantner/markor/activity/openeditor/OpenEditorQuickNoteActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/openeditor/OpenEditorQuickNoteActivity.java
@@ -12,6 +12,7 @@ package net.gsantner.markor.activity.openeditor;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
+import net.gsantner.markor.model.Document;
 import net.gsantner.markor.util.AppSettings;
 
 public class OpenEditorQuickNoteActivity extends OpenEditorActivity {
@@ -19,6 +20,6 @@ public class OpenEditorQuickNoteActivity extends OpenEditorActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        openEditorForFile(new AppSettings(getApplicationContext()).getQuickNoteFile());
+        openEditorForFile(new AppSettings(getApplicationContext()).getQuickNoteFile(), Document.EXTRA_FILE_LINE_NUMBER_LAST);
     }
 }

--- a/app/src/main/java/net/gsantner/markor/activity/openeditor/OpenEditorTodoActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/openeditor/OpenEditorTodoActivity.java
@@ -12,6 +12,7 @@ package net.gsantner.markor.activity.openeditor;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
+import net.gsantner.markor.model.Document;
 import net.gsantner.markor.util.AppSettings;
 
 public class OpenEditorTodoActivity extends OpenEditorActivity {
@@ -19,6 +20,6 @@ public class OpenEditorTodoActivity extends OpenEditorActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        openEditorForFile(new AppSettings(getApplicationContext()).getTodoFile());
+        openEditorForFile(new AppSettings(getApplicationContext()).getTodoFile(), Document.EXTRA_FILE_LINE_NUMBER_LAST);
     }
 }

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -47,6 +47,7 @@ public class Document implements Serializable {
     public static final String EXTRA_DOCUMENT = "EXTRA_DOCUMENT"; // Document
     public static final String EXTRA_PATH = "EXTRA_PATH"; // java.io.File
     public static final String EXTRA_FILE_LINE_NUMBER = "EXTRA_FILE_LINE_NUMBER"; // int
+    public static final int EXTRA_FILE_LINE_NUMBER_LAST = -1; // Flag for last line. Any -ve number will work
 
     private final File _file;
     private final String _fileExtension;

--- a/app/src/main/java/net/gsantner/markor/util/ShortcutUtils.java
+++ b/app/src/main/java/net/gsantner/markor/util/ShortcutUtils.java
@@ -20,6 +20,7 @@ import android.support.annotation.NonNull;
 
 import net.gsantner.markor.R;
 import net.gsantner.markor.activity.openeditor.OpenEditorFromShortcutOrWidgetActivity;
+import net.gsantner.markor.model.Document;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -63,7 +64,8 @@ public class ShortcutUtils {
             // Create the to-do shortcut
             final Intent openTodo = new Intent(context, OpenEditorFromShortcutOrWidgetActivity.class)
                     .setAction(Intent.ACTION_EDIT)
-                    .setData(Uri.fromFile(appSettings.getTodoFile()));
+                    .setData(Uri.fromFile(appSettings.getTodoFile()))
+                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
 
             final ShortcutInfo shortcutToDo = new ShortcutInfo.Builder(context, ID_TO_DO)
                     .setShortLabel(createShortLabel(context.getString(R.string.todo)))
@@ -76,7 +78,8 @@ public class ShortcutUtils {
             // Create the QuickNote shortcut
             final Intent openQuickNote = new Intent(context, OpenEditorFromShortcutOrWidgetActivity.class)
                     .setAction(Intent.ACTION_EDIT)
-                    .setData(Uri.fromFile(appSettings.getQuickNoteFile()));
+                    .setData(Uri.fromFile(appSettings.getQuickNoteFile()))
+                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
 
             final ShortcutInfo shortcutQuickNote = new ShortcutInfo.Builder(context, ID_QUICK_NOTE)
                     .setShortLabel(createShortLabel(context.getString(R.string.quicknote)))

--- a/app/src/main/java/net/gsantner/markor/util/ShortcutUtils.java
+++ b/app/src/main/java/net/gsantner/markor/util/ShortcutUtils.java
@@ -65,7 +65,7 @@ public class ShortcutUtils {
             final Intent openTodo = new Intent(context, OpenEditorFromShortcutOrWidgetActivity.class)
                     .setAction(Intent.ACTION_EDIT)
                     .setData(Uri.fromFile(appSettings.getTodoFile()))
-                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
+                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, Document.EXTRA_FILE_LINE_NUMBER_LAST);
 
             final ShortcutInfo shortcutToDo = new ShortcutInfo.Builder(context, ID_TO_DO)
                     .setShortLabel(createShortLabel(context.getString(R.string.todo)))
@@ -79,7 +79,7 @@ public class ShortcutUtils {
             final Intent openQuickNote = new Intent(context, OpenEditorFromShortcutOrWidgetActivity.class)
                     .setAction(Intent.ACTION_EDIT)
                     .setData(Uri.fromFile(appSettings.getQuickNoteFile()))
-                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
+                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, Document.EXTRA_FILE_LINE_NUMBER_LAST);
 
             final ShortcutInfo shortcutQuickNote = new ShortcutInfo.Builder(context, ID_QUICK_NOTE)
                     .setShortLabel(createShortLabel(context.getString(R.string.quicknote)))

--- a/app/thirdparty/java/other/writeily/widget/WrMarkorWidgetProvider.java
+++ b/app/thirdparty/java/other/writeily/widget/WrMarkorWidgetProvider.java
@@ -64,13 +64,15 @@ public class WrMarkorWidgetProvider extends AppWidgetProvider {
             // Open To-do
             final Intent openTodo = new Intent(context, OpenEditorFromShortcutOrWidgetActivity.class)
                     .setAction(Intent.ACTION_EDIT)
-                    .putExtra(Document.EXTRA_PATH, appSettings.getTodoFile());
+                    .putExtra(Document.EXTRA_PATH, appSettings.getTodoFile())
+                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
             views.setOnClickPendingIntent(R.id.widget_todo, PendingIntent.getActivity(context, requestCode++, openTodo, PendingIntent.FLAG_UPDATE_CURRENT));
 
             // Open QuickNote
             final Intent openQuickNote = new Intent(context, OpenEditorFromShortcutOrWidgetActivity.class)
                     .setAction(Intent.ACTION_EDIT)
-                    .putExtra(Document.EXTRA_PATH, appSettings.getQuickNoteFile());
+                    .putExtra(Document.EXTRA_PATH, appSettings.getQuickNoteFile())
+                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
             views.setOnClickPendingIntent(R.id.widget_quicknote, PendingIntent.getActivity(context, requestCode++, openQuickNote, PendingIntent.FLAG_UPDATE_CURRENT));
 
             // Open Notebook

--- a/app/thirdparty/java/other/writeily/widget/WrMarkorWidgetProvider.java
+++ b/app/thirdparty/java/other/writeily/widget/WrMarkorWidgetProvider.java
@@ -65,14 +65,14 @@ public class WrMarkorWidgetProvider extends AppWidgetProvider {
             final Intent openTodo = new Intent(context, OpenEditorFromShortcutOrWidgetActivity.class)
                     .setAction(Intent.ACTION_EDIT)
                     .putExtra(Document.EXTRA_PATH, appSettings.getTodoFile())
-                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
+                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, Document.EXTRA_FILE_LINE_NUMBER_LAST);
             views.setOnClickPendingIntent(R.id.widget_todo, PendingIntent.getActivity(context, requestCode++, openTodo, PendingIntent.FLAG_UPDATE_CURRENT));
 
             // Open QuickNote
             final Intent openQuickNote = new Intent(context, OpenEditorFromShortcutOrWidgetActivity.class)
                     .setAction(Intent.ACTION_EDIT)
                     .putExtra(Document.EXTRA_PATH, appSettings.getQuickNoteFile())
-                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, -1);
+                    .putExtra(Document.EXTRA_FILE_LINE_NUMBER, Document.EXTRA_FILE_LINE_NUMBER_LAST);
             views.setOnClickPendingIntent(R.id.widget_quicknote, PendingIntent.getActivity(context, requestCode++, openQuickNote, PendingIntent.FLAG_UPDATE_CURRENT));
 
             // Open Notebook


### PR DESCRIPTION
This PR makes shortcuts to Todo and Quicknote also open the files at the bottom. Opening these files from the file browser is not affected