### PR TITLE
Don't overwrite newer files unless content modified

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -691,8 +691,9 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     // Only supports java.io.File. TODO: Android Content
     public boolean saveDocument(final boolean forceSaveEmpty) {
         // Document is written iff writeable && content has changed
-        if (checkPermissions() && _hlEditor != null && isAdded()) {
-            if (_document.saveContent(getContext(), _hlEditor.getText(), _shareUtil, forceSaveEmpty)) {
+        final CharSequence text = _hlEditor.getText();
+        if (!_document.isContentSame(text) && checkPermissions() && _hlEditor != null && isAdded()) {
+            if (_document.saveContent(getContext(), text, _shareUtil, forceSaveEmpty)) {
                 checkTextChangeState();
                 return true;
             } else {


### PR DESCRIPTION
Without this we have the following situation

1. Open file (don't modify)
2. File changed in background (syncthing etc)
3. On close, the changed file is overwritten by the old content

This is a bug I introduced :(