### PR TITLE
make images fill 100% width of the screen, closes #1769

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/TextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextConverter.java
@@ -45,7 +45,7 @@ public abstract class TextConverter {
     protected static final String TOKEN_POST_LANG = "{{ post.lang }}";
 
     protected static final String HTML_DOCTYPE = "<!DOCTYPE html>";
-    protected static final String HTML001_HEAD_WITH_BASESTYLE = "<html lang='" + TOKEN_POST_LANG + "'><head>" + CSS_S + "html,body{padding:4px 8px 4px 8px;font-family:'" + TOKEN_FONT + "';}h1,h2,h3,h4,h5,h6{font-family:'sans-serif-condensed';}a{color: " + TOKEN_LINK_COLOR + ";text-decoration:underline;}img{height:auto;width:325px;margin:auto;}" + CSS_E;
+    protected static final String HTML001_HEAD_WITH_BASESTYLE = "<html lang='" + TOKEN_POST_LANG + "'><head>" + CSS_S + "html,body{padding:4px 8px 4px 8px;font-family:'" + TOKEN_FONT + "';}h1,h2,h3,h4,h5,h6{font-family:'sans-serif-condensed';}a{color: " + TOKEN_LINK_COLOR + ";text-decoration:underline;}img{width:100%;height:auto;margin:auto;}" + CSS_E;
     protected static final String HTML002_HEAD_WITH_STYLE_LIGHT = CSS_S + "html,body{color:#303030;}blockquote{color:#73747d;}" + CSS_E;
     protected static final String HTML002_HEAD_WITH_STYLE_DARK = CSS_S + "html,body{color:#ffffff;background-color:#303030;}a:visited{color:#dddddd;}blockquote{color:#cccccc;}" + CSS_E;
     protected static final String HTML003_RIGHT_TO_LEFT = CSS_S + "body{text-align:" + TOKEN_TEXT_DIRECTION + ";direction:rtl;}" + CSS_E;


### PR DESCRIPTION
Image width is small and not responsive to to fill 100% of available screen width and you can notice that more in landscape mode and on larger screens.
The max-width property defines the maximum width of an image and it works if the image width is larger than the maximum available width . If the image width is smaller than the maximum available width, the max-width property has no effect.


See also <https://github.com/gsantner/markor/discussions/1769>