### PR TITLE
Fix EditText component doubletap due android minWidth bug

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -54,7 +54,7 @@
 
     <!-- reduced spacing -->
     <style name="LessSpaceActionButtonStyle" parent="Widget.AppCompat.ActionButton">
-        <item name="android:minWidth">0dip</item>
+        <item name="android:minWidth">1dip</item>
         <item name="android:paddingLeft">8dip</item>
         <item name="android:paddingRight">8dip</item>
         <item name="android:paddingStart">8dip</item>


### PR DESCRIPTION
Fix EditText component doubletap due android minWidth bug introduced in #1516, closes #1786

insights: `https://stackoverflow.com/questions/33892291/double-click-to-select-text-from-edittext-cause-an-arithmeticexception`