### PR TITLE
[Feature] View mode: open Image,Video,Audio files in Markor

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -768,9 +768,6 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     public void webViewJavascriptCallback(final String[] jsArgs) {
         final String[] args = (jsArgs == null || jsArgs.length == 0 || jsArgs[0] == null) ? new String[0] : jsArgs;
         final String type = args.length == 0 || TextUtils.isEmpty(args[0]) ? "" : args[0];
-        if (type.equals(EmbedBinaryConverter.JS_CALLBACK_TYPE_OPEN_CURRENT_FILE_IN_EXTERNAL_APP)) {
-            _shareUtil.viewFileInOtherApp(_document.getFile(), FileUtils.getMimeType(_document.getFile()));
-        }
     }
 
     private static boolean fadeInOut(final View in, final View out) {

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -141,10 +141,6 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
         }
     }
 
-    public boolean isViewBinary() {
-        return !(getActivity() instanceof MainActivity);
-    }
-
     @Override
     protected int getLayoutResId() {
         return R.layout.document__fragment__edit;
@@ -389,7 +385,7 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
         //Only trigger the load process if constructing or file updated
         final long modTime = _document != null ? _document.lastModified() : Long.MIN_VALUE;
         boolean doReload = modTime > _loadModTime;
-        if (doReload && !isViewBinary()) {
+        if (doReload && !_document.isBinaryFileNoTextLoading()) {
 
             _loadModTime = modTime;
 
@@ -722,7 +718,7 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     public boolean saveDocument(final boolean forceSaveEmpty) {
         // Document is written iff writeable && content has changed
         final CharSequence text = _hlEditor.getText();
-        if (_document != null && !isViewBinary() && !_document.isContentSame(text) && checkPermissions() && isAdded()) {
+        if (_document != null && !_document.isBinaryFileNoTextLoading() && !_document.isContentSame(text) && checkPermissions() && isAdded()) {
             if (_document.saveContent(getActivity(), text, _shareUtil, forceSaveEmpty)) {
                 checkTextChangeState();
                 return true;
@@ -768,6 +764,9 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     public void webViewJavascriptCallback(final String[] jsArgs) {
         final String[] args = (jsArgs == null || jsArgs.length == 0 || jsArgs[0] == null) ? new String[0] : jsArgs;
         final String type = args.length == 0 || TextUtils.isEmpty(args[0]) ? "" : args[0];
+        if (type.equalsIgnoreCase("toast") && args.length == 2){
+            Toast.makeText(getActivity(), args[1], Toast.LENGTH_SHORT).show();
+        }
     }
 
     private static boolean fadeInOut(final View in, final View out) {

--- a/app/src/main/java/net/gsantner/markor/format/TextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextConverter.java
@@ -59,12 +59,12 @@ public abstract class TextConverter {
     protected static final String HTML002_HEAD_WITH_STYLE_LIGHT = CSS_S + "html,body{color:#303030;}blockquote{color:#73747d;}" + CSS_E;
     protected static final String HTML002_HEAD_WITH_STYLE_DARK = CSS_S + "html,body{color:#ffffff;background-color:#303030;}a:visited{color:#dddddd;}blockquote{color:#cccccc;}" + CSS_E;
     protected static final String HTML003_RIGHT_TO_LEFT = CSS_S + "body{text-align:" + TOKEN_TEXT_DIRECTION + ";direction:rtl;}" + CSS_E;
-    protected static final String HTML004_HEAD_META_VIEWPORT_MOBILE = "<style>video, img { max-width: 100%; } pre { max-width: 100%; } </style>";//"<meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'>";
+    protected static final String HTML004_HEAD_META_VIEWPORT_MOBILE = "<style>video, img { max-width: 100%; } pre { max-width: 100%; overflow: auto; } </style>";//"<meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'>";
     protected static final String HTML100_PERCENT_IN_FILEPATH = "<base>" + JS_S + "var newbase = document.baseURI.split('%').join('%25'); document.querySelector('base').setAttribute('href', newbase);" + JS_E;
     protected static final String CSS_TABLE_STYLE = CSS_S + "table, th, td {  border: 1px solid " + TOKEN_BW_INVERSE_OF_THEME + "; border-collapse: collapse; border-spacing: 0; padding: 6px; }" + CSS_E;
     protected static final String CSS_BUTTON_STYLE_MATERIAL = CSS_S + "button:hover,button:active {filter: invert(1);} button { display: inline-block; box-sizing: border-box; border: none; border-radius: 4px; padding: 0 16px; min-width: 64px; height: 36px; font-family: 'Roboto'; font-size: 14px; font-weight: 500;  line-height: 36px; overflow: hidden; outline: none; vertical-align: middle; text-align: center; text-overflow: ellipsis; text-transform: uppercase; box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12); margin: 4px 4px 8px 0px;}   " + CSS_E;
     protected static final String CSS_BUTTON_STYLE_EMOJIBTN = CSS_S + " .emojibtn,.fa {font-size:250%; background: transparent; padding: 0px; min-width:0px;}   " + CSS_E;
-    protected static final String CSS_CLASS_STICKY_TOP = CSS_S + " .sticky {position: sticky; display: inline-block; border: 0px solid "+ TOKEN_BW_INVERSE_OF_THEME+"} " + CSS_E;
+    protected static final String CSS_CLASS_STICKY = CSS_S + " .sticky {position: sticky; display: inline-block; border: 0px solid " + TOKEN_BW_INVERSE_OF_THEME + ";} " + CSS_E;
 
     // onPageLoaded_markor_private() invokes the user injected function onPageLoaded()
     protected static final String HTML500_BODY = "</head>\n<body class='" + TOKEN_TEXT_CONVERTER_CSS_CLASS + "' onload='onPageLoaded_markor_private();'>\n\n<!-- USER DOCUMENT CONTENT -->\n\n\n";
@@ -138,7 +138,7 @@ public abstract class TextConverter {
         if (isExportInLightMode) {
             html = html.replace("html,body{color:#303030;}", "html,body{color: black !important; background-color: white !important;}");
         }
-        html += HTML004_HEAD_META_VIEWPORT_MOBILE + CSS_TABLE_STYLE + CSS_BUTTON_STYLE_MATERIAL + CSS_BUTTON_STYLE_EMOJIBTN + CSS_CLASS_STICKY_TOP;
+        html += HTML004_HEAD_META_VIEWPORT_MOBILE + CSS_TABLE_STYLE + CSS_BUTTON_STYLE_MATERIAL + CSS_BUTTON_STYLE_EMOJIBTN + CSS_CLASS_STICKY;
         if (appSettings.isRenderRtl()) {
             html += HTML003_RIGHT_TO_LEFT;
         }
@@ -180,7 +180,7 @@ public abstract class TextConverter {
                 .replace(TOKEN_FONT, font)
                 .replace(TOKEN_TEXT_CONVERTER_CSS_CLASS, "format-" + getClass().getSimpleName().toLowerCase().replace("textconverter", "").replace("converter", "") + " fileext-" + getFileExtension(file).replace(".", ""))
                 .replace(TOKEN_POST_TODAY_DATE, DateFormat.getDateFormat(context).format(new Date()))
-                .replace(TOKEN_FILEURI_VIEWED_FILE, file != null ? Uri.fromFile(file.getAbsoluteFile()).toString() : "file:///dummy");
+                .replace(TOKEN_FILEURI_VIEWED_FILE, (file != null ? Uri.fromFile(file.getAbsoluteFile()).toString() : "file:///dummy").replace("'", "\\'").replace("\"", "\\\""));
 
         return html;
     }

--- a/app/src/main/java/net/gsantner/markor/format/TextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextConverter.java
@@ -66,6 +66,7 @@ public abstract class TextConverter {
     protected static final String CSS_BUTTON_STYLE_MATERIAL = CSS_S + "button:hover,button:active {filter: invert(1);} button { display: inline-block; box-sizing: border-box; border: none; border-radius: 4px; padding: 0 16px; min-width: 64px; height: 36px; font-family: 'Roboto'; font-size: 14px; font-weight: 500;  line-height: 36px; overflow: hidden; outline: none; vertical-align: middle; text-align: center; text-overflow: ellipsis; text-transform: uppercase; box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12); margin: 4px 4px 8px 0px;}   " + CSS_E;
     protected static final String CSS_BUTTON_STYLE_EMOJIBTN = CSS_S + " .emojibtn,.fa {font-size:250%; background: transparent; padding: 0px; min-width:0px;}   " + CSS_E;
     protected static final String CSS_CLASS_STICKY = CSS_S + " .sticky {position: sticky; display: inline-block; border: 0px solid " + TOKEN_BW_INVERSE_OF_THEME + ";} " + CSS_E;
+    protected static final String CSS_CLASS_FLOAT = CSS_S + " .floatl {float: left;} .clear {clear:both;} " + CSS_E;
 
     // onPageLoaded_markor_private() invokes the user injected function onPageLoaded()
     protected static final String HTML500_BODY = "</head>\n<body class='" + TOKEN_TEXT_CONVERTER_CSS_CLASS + "' onload='onPageLoaded_markor_private();'>\n\n<!-- USER DOCUMENT CONTENT -->\n\n\n";
@@ -139,7 +140,7 @@ public abstract class TextConverter {
         if (isExportInLightMode) {
             html = html.replace("html,body{color:#303030;}", "html,body{color: black !important; background-color: white !important;}");
         }
-        html += HTML004_HEAD_META_VIEWPORT_MOBILE + CSS_TABLE_STYLE + CSS_BUTTON_STYLE_MATERIAL + CSS_BUTTON_STYLE_EMOJIBTN + CSS_CLASS_STICKY;
+        html += HTML004_HEAD_META_VIEWPORT_MOBILE + CSS_TABLE_STYLE + CSS_CLASS_FLOAT + CSS_BUTTON_STYLE_MATERIAL + CSS_BUTTON_STYLE_EMOJIBTN + CSS_CLASS_STICKY;
         if (appSettings.isRenderRtl()) {
             html += HTML003_RIGHT_TO_LEFT;
         }

--- a/app/src/main/java/net/gsantner/markor/format/TextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextConverter.java
@@ -46,6 +46,7 @@ public abstract class TextConverter {
     protected static final String TOKEN_FONT = "{{ app.text_font }}";
     protected static final String TOKEN_BW_INVERSE_OF_THEME = "{{ app.token_bw_inverse_of_theme }}";
     protected static final String TOKEN_BW_INVERSE_OF_THEME_HEADER_UNDERLINE = "{{ app.token_headline_underline_inverse_of_theme }}";
+    protected static final String TOKEN_COLOR_GREY_OF_THEME = "{{ app.token_color_grey_inverse_of_theme }}";
     protected static final String TOKEN_LINK_COLOR = "{{ app.token_link_color }}";
     protected static final String TOKEN_ACCENT_COLOR = "{{ app.token_accent_color }}";
     protected static final String TOKEN_TEXT_CONVERTER_CSS_CLASS = "{{ post.text_converter_name }}";
@@ -174,6 +175,7 @@ public abstract class TextConverter {
         html = html
                 .replace(TOKEN_BW_INVERSE_OF_THEME, darkTheme ? "white" : "black")
                 .replace(TOKEN_BW_INVERSE_OF_THEME_HEADER_UNDERLINE, darkTheme ? "#eaecef" : "#696969")
+                .replace(TOKEN_COLOR_GREY_OF_THEME, ContextUtils.colorToHexString(ContextCompat.getColor(context, darkTheme ? R.color.grey : R.color.lighter_grey)))
                 .replace(TOKEN_LINK_COLOR, appSettings.getViewModeLinkColor())
                 .replace(TOKEN_ACCENT_COLOR, ContextUtils.colorToHexString(ContextCompat.getColor(context, R.color.accent)))
                 .replace(TOKEN_TEXT_DIRECTION, appSettings.isRenderRtl() ? "right" : "left")

--- a/app/src/main/java/net/gsantner/markor/format/TextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextConverter.java
@@ -175,7 +175,7 @@ public abstract class TextConverter {
         html = html
                 .replace(TOKEN_BW_INVERSE_OF_THEME, darkTheme ? "white" : "black")
                 .replace(TOKEN_BW_INVERSE_OF_THEME_HEADER_UNDERLINE, darkTheme ? "#eaecef" : "#696969")
-                .replace(TOKEN_COLOR_GREY_OF_THEME, ContextUtils.colorToHexString(ContextCompat.getColor(context, darkTheme ? R.color.grey : R.color.lighter_grey)))
+                .replace(TOKEN_COLOR_GREY_OF_THEME, darkTheme ? "#393939" : ContextUtils.colorToHexString(ContextCompat.getColor(context, R.color.lighter_grey)))
                 .replace(TOKEN_LINK_COLOR, appSettings.getViewModeLinkColor())
                 .replace(TOKEN_ACCENT_COLOR, ContextUtils.colorToHexString(ContextCompat.getColor(context, R.color.accent)))
                 .replace(TOKEN_TEXT_DIRECTION, appSettings.isRenderRtl() ? "right" : "left")

--- a/app/src/main/java/net/gsantner/markor/format/TextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextConverter.java
@@ -59,11 +59,12 @@ public abstract class TextConverter {
     protected static final String HTML002_HEAD_WITH_STYLE_LIGHT = CSS_S + "html,body{color:#303030;}blockquote{color:#73747d;}" + CSS_E;
     protected static final String HTML002_HEAD_WITH_STYLE_DARK = CSS_S + "html,body{color:#ffffff;background-color:#303030;}a:visited{color:#dddddd;}blockquote{color:#cccccc;}" + CSS_E;
     protected static final String HTML003_RIGHT_TO_LEFT = CSS_S + "body{text-align:" + TOKEN_TEXT_DIRECTION + ";direction:rtl;}" + CSS_E;
-    protected static final String HTML004_HEAD_META_VIEWPORT_MOBILE = "<style>video, img { max-width: 100%; } pre { max-width: 100%; overflow: auto; } </style>";//"<meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'>";
+    protected static final String HTML004_HEAD_META_VIEWPORT_MOBILE = "<style>video, img { max-width: 100%; } pre { max-width: 100%; } </style>";//"<meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'>";
     protected static final String HTML100_PERCENT_IN_FILEPATH = "<base>" + JS_S + "var newbase = document.baseURI.split('%').join('%25'); document.querySelector('base').setAttribute('href', newbase);" + JS_E;
     protected static final String CSS_TABLE_STYLE = CSS_S + "table, th, td {  border: 1px solid " + TOKEN_BW_INVERSE_OF_THEME + "; border-collapse: collapse; border-spacing: 0; padding: 6px; }" + CSS_E;
     protected static final String CSS_BUTTON_STYLE_MATERIAL = CSS_S + "button:hover,button:active {filter: invert(1);} button { display: inline-block; box-sizing: border-box; border: none; border-radius: 4px; padding: 0 16px; min-width: 64px; height: 36px; font-family: 'Roboto'; font-size: 14px; font-weight: 500;  line-height: 36px; overflow: hidden; outline: none; vertical-align: middle; text-align: center; text-overflow: ellipsis; text-transform: uppercase; box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12); margin: 4px 4px 8px 0px;}   " + CSS_E;
     protected static final String CSS_BUTTON_STYLE_EMOJIBTN = CSS_S + " .emojibtn,.fa {font-size:250%; background: transparent; padding: 0px; min-width:0px;}   " + CSS_E;
+    protected static final String CSS_CLASS_STICKY_TOP = CSS_S + " .sticky {position: sticky; display: inline-block; border: 0px solid "+ TOKEN_BW_INVERSE_OF_THEME+"} " + CSS_E;
 
     // onPageLoaded_markor_private() invokes the user injected function onPageLoaded()
     protected static final String HTML500_BODY = "</head>\n<body class='" + TOKEN_TEXT_CONVERTER_CSS_CLASS + "' onload='onPageLoaded_markor_private();'>\n\n<!-- USER DOCUMENT CONTENT -->\n\n\n";
@@ -137,7 +138,7 @@ public abstract class TextConverter {
         if (isExportInLightMode) {
             html = html.replace("html,body{color:#303030;}", "html,body{color: black !important; background-color: white !important;}");
         }
-        html += HTML004_HEAD_META_VIEWPORT_MOBILE + CSS_TABLE_STYLE + CSS_BUTTON_STYLE_MATERIAL + CSS_BUTTON_STYLE_EMOJIBTN;
+        html += HTML004_HEAD_META_VIEWPORT_MOBILE + CSS_TABLE_STYLE + CSS_BUTTON_STYLE_MATERIAL + CSS_BUTTON_STYLE_EMOJIBTN + CSS_CLASS_STICKY_TOP;
         if (appSettings.isRenderRtl()) {
             html += HTML003_RIGHT_TO_LEFT;
         }

--- a/app/src/main/java/net/gsantner/markor/format/TextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextConverter.java
@@ -63,6 +63,7 @@ public abstract class TextConverter {
     protected static final String HTML100_PERCENT_IN_FILEPATH = "<base>" + JS_S + "var newbase = document.baseURI.split('%').join('%25'); document.querySelector('base').setAttribute('href', newbase);" + JS_E;
     protected static final String CSS_TABLE_STYLE = CSS_S + "table, th, td {  border: 1px solid " + TOKEN_BW_INVERSE_OF_THEME + "; border-collapse: collapse; border-spacing: 0; padding: 6px; }" + CSS_E;
     protected static final String CSS_BUTTON_STYLE_MATERIAL = CSS_S + "button:hover,button:active {filter: invert(1);} button { display: inline-block; box-sizing: border-box; border: none; border-radius: 4px; padding: 0 16px; min-width: 64px; height: 36px; font-family: 'Roboto'; font-size: 14px; font-weight: 500;  line-height: 36px; overflow: hidden; outline: none; vertical-align: middle; text-align: center; text-overflow: ellipsis; text-transform: uppercase; box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12); margin: 4px 4px 8px 0px;}   " + CSS_E;
+    protected static final String CSS_BUTTON_STYLE_EMOJIBTN = CSS_S + " .emojibtn,.fa {font-size:250%; background: transparent; padding: 0px; min-width:0px;}   " + CSS_E;
 
     // onPageLoaded_markor_private() invokes the user injected function onPageLoaded()
     protected static final String HTML500_BODY = "</head>\n<body class='" + TOKEN_TEXT_CONVERTER_CSS_CLASS + "' onload='onPageLoaded_markor_private();'>\n\n<!-- USER DOCUMENT CONTENT -->\n\n\n";
@@ -136,7 +137,7 @@ public abstract class TextConverter {
         if (isExportInLightMode) {
             html = html.replace("html,body{color:#303030;}", "html,body{color: black !important; background-color: white !important;}");
         }
-        html += HTML004_HEAD_META_VIEWPORT_MOBILE + CSS_TABLE_STYLE + CSS_BUTTON_STYLE_MATERIAL;
+        html += HTML004_HEAD_META_VIEWPORT_MOBILE + CSS_TABLE_STYLE + CSS_BUTTON_STYLE_MATERIAL + CSS_BUTTON_STYLE_EMOJIBTN;
         if (appSettings.isRenderRtl()) {
             html += HTML003_RIGHT_TO_LEFT;
         }

--- a/app/src/main/java/net/gsantner/markor/format/TextFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextFormat.java
@@ -16,6 +16,7 @@ import android.text.TextWatcher;
 import androidx.annotation.NonNull;
 
 import net.gsantner.markor.R;
+import net.gsantner.markor.format.binary.EmbedBinaryConverter;
 import net.gsantner.markor.format.keyvalue.KeyValueConverter;
 import net.gsantner.markor.format.keyvalue.KeyValueHighlighter;
 import net.gsantner.markor.format.markdown.MarkdownAutoFormat;
@@ -49,12 +50,16 @@ public class TextFormat {
     public static final int FORMAT_PLAIN = R.string.action_format_plaintext;
     public static final int FORMAT_TODOTXT = R.string.action_format_todotxt;
     public static final int FORMAT_KEYVALUE = R.string.action_format_keyvalue;
+    public static final int FORMAT_EMBEDBINARY = R.string.action_format_embedbinary;
+
 
     public final static MarkdownTextConverter CONVERTER_MARKDOWN = new MarkdownTextConverter();
     public final static ZimWikiTextConverter CONVERTER_ZIMWIKI = new ZimWikiTextConverter();
     public final static TodoTxtTextConverter CONVERTER_TODOTXT = new TodoTxtTextConverter();
     public final static KeyValueConverter CONVERTER_KEYVALUE = new KeyValueConverter();
     public final static PlaintextConverter CONVERTER_PLAINTEXT = new PlaintextConverter();
+    public final static EmbedBinaryConverter CONVERTER_EMBEDBINARY = new EmbedBinaryConverter();
+
 
     // Order here is used to **determine** format by it's file extension and/or content heading
     private final static TextConverter[] CONVERTERS = new TextConverter[]{
@@ -63,6 +68,7 @@ public class TextFormat {
             CONVERTER_ZIMWIKI,
             CONVERTER_KEYVALUE,
             CONVERTER_PLAINTEXT,
+            CONVERTER_EMBEDBINARY,
     };
 
     public static boolean isTextFile(final String absolutePath) {
@@ -119,6 +125,12 @@ public class TextFormat {
                 format._textActions = new ZimWikiTextActions(context, document);
                 format._autoFormatInputFilter = new ZimWikiAutoFormat();
                 format._autoFormatTextWatcher = new ListHandler(ZimWikiAutoFormat.getPrefixPatterns());
+                break;
+            }
+            case FORMAT_EMBEDBINARY: {
+                format._converter = CONVERTER_EMBEDBINARY;
+                format._highlighter = new PlaintextHighlighter(as);
+                format._textActions = new PlaintextTextActions(context, document);
                 break;
             }
             default:

--- a/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
@@ -61,11 +61,31 @@ public class EmbedBinaryConverter extends TextConverter {
 
         // Usage of binary file depending on file extension / MIME
         if (EXT_IMAGE.contains(extWithDot)) {
-            converted += "<img src='" + TOKEN_FILEURI_VIEWED_FILE + "' alt='Your Android device does not support the file format.'/>";
+            converted += "<img class='rotatable' src='" + TOKEN_FILEURI_VIEWED_FILE + "' alt='Your Android device does not support the file format.'/>";
         } else if (EXT_VIDEO.contains(extWithDot)) {
-            converted += "<video autoplay controls loop style='max-height: 85vh; width: 100%; max-width: 100%;' src='" + TOKEN_FILEURI_VIEWED_FILE + "'/>Your Android device does not support the video tag or the file format.</video>";
+            converted += "<video class='htmlav' autoplay controls loop style='max-height: 85vh; width: 100%; max-width: 100%;' src='" + TOKEN_FILEURI_VIEWED_FILE + "'/>Your Android device does not support the video tag or the file format.</video>";
         } else if (EXT_AUDIO.contains(extWithDot)) {
-            converted += " <audio title='" + file.getName() + "' autoplay controls loop style='width: 100%;'><source src='" + TOKEN_FILEURI_VIEWED_FILE + "'>Your Android device does not support the audio tag or the file format.</audio>";
+            converted += " <audio class='htmlav' title='" + file.getName() + "' autoplay controls loop style='width: 100%;'><source src='" + TOKEN_FILEURI_VIEWED_FILE + "'>Your Android device does not support the audio tag or the file format.</audio>";
+        }
+
+        // div width side margins
+        converted += "\n\n<br/><div style='margin: 16px; margin-top: 0px;'><br/>\n";
+
+        if (converted.contains("htmlav")) {
+            converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-9e9);\"/>⏮️️</button>";
+            converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏪</button>";
+            converted += "<button type='button' class='fa' onclick=\"javascript:document.avPause();\"/>⏯️</button>";
+            converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏩</button>";
+            converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(+9e9);\"/>⏭️</button>";
+            converted += "<button type='button' class='fa' onclick=\"javascript:document.avLoopToggle();\"/>&#128257;</button>";
+            onLoadJs += "document.avSeek       = function(delta) { var o=document.getElementsByClassName('htmlav')[0]; o.currentTime +=delta; o.play(); };";
+            onLoadJs += "document.avLoopToggle = function()      { var o=document.getElementsByClassName('htmlav')[0]; o.loop = !o.loop; };";
+            onLoadJs += "document.avPause      = function()      { var o=document.getElementsByClassName('htmlav')[0]; if(o.paused){o.play();} else{o.pause();}; };";
+        }
+        if (converted.contains("rotatable")) {
+            converted += "<button type='button' class='fa' onclick=\"javascript:document.rotate();\"/>&#128260️</button>";
+            onLoadJs += "document.rotation = 0;";
+            onLoadJs += "document.rotate       = function()      { var o=document.getElementsByClassName('rotatable')[0]; document.rotation+=90; o.style.transform = 'rotate(xdeg)'.replace('x', document.rotation); };";
         }
 
         // Add file info table below content
@@ -74,23 +94,10 @@ public class EmbedBinaryConverter extends TextConverter {
         for (Pair<String, String> metaPair : shu.extractFileMetadata(context, file, true)) {
             table.append(String.format("%s | %s\n", metaPair.first.replace("|", "/"), metaPair.second.replace("|", "/")));
         }
-
-
-        converted += "\n\n<br/><div style='margin: 16px;'>\n";
-        // Add button to open in external app
-        converted += String.format("<button style='background-color: " + TOKEN_ACCENT_COLOR + ";' type='button' onclick=\"javascript:Android.webViewJavascriptCallback('%s');\"/>%s</button>"
-                , JS_CALLBACK_TYPE_OPEN_CURRENT_FILE_IN_EXTERNAL_APP
-                , context.getString(R.string.open_file_with)
-        );
-        converted += String.format("<button style='background-color: " + TOKEN_ACCENT_COLOR + ";' type='button' onclick=\"javascript:Android.webViewJavascriptCallback('%s');\"/>%s</button>"
-                , JS_CALLBACK_TYPE_OPEN_CURRENT_FILE_IN_EXTERNAL_APP
-                , context.getString(R.string.rotate)
-        );
-
-        converted += "<br/>";
         converted += MarkdownTextConverter.flexmarkRenderer.render(MarkdownTextConverter.flexmarkParser.parse(table.toString()));
-        converted += "</div>";
 
+        // end div with side margins
+        converted += "</div>";
 
         converted += HTML101_BODY_END;
         shu.setContext(null);

--- a/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
@@ -27,7 +27,6 @@ public class EmbedBinaryConverter extends TextConverter {
     private static final List<String> EXT_AUDIO = Arrays.asList(".mp3", ".ogg", ".flac", ".opus", ".oga", ".wma", ".m4a", ".aac", ".wav", ".amr", ".mid", ".midi", ".pcm");
     private static final List<String> EXT_IMAGE = Arrays.asList(".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".svg", ".heic", ".heif");
     private static final List<String> EXT_VIDEO = Arrays.asList(".webm", ".mp4", ".mpeg4", ".mpeg", ".mpg", ".mkv", ".3gp", ".ts", ".m4v");
-    private static final List<String> EXT_TEXT_PLAYLIST = Arrays.asList(".m3u", ".m3u8"); // don't register
 
     public static final String EXT_MATCHES_M3U_PLAYLIST = "(?i).m3u8?";
 
@@ -64,7 +63,7 @@ public class EmbedBinaryConverter extends TextConverter {
             converted += "\n<div class='sticky' style='top: 0px; border-top-width:0.1px; width: 100%; background: black;'>\n";
             if (EXT_IMAGE.contains(extWithDot)) {
                 converted += "<img class='' src='" + TOKEN_FILEURI_VIEWED_FILE + "' alt='Your Android device does not support the file format.'/>";
-            } else if (EXT_VIDEO.contains(extWithDot) || EXT_TEXT_PLAYLIST.contains(extWithDot)) {
+            } else if (EXT_VIDEO.contains(extWithDot) || extWithDot.matches(EXT_MATCHES_M3U_PLAYLIST)) {
                 converted += "<video class='htmlav' autoplay controls loop style='max-height: 85vh; width: 100%; max-width: 100%;' srcx='" + TOKEN_FILEURI_VIEWED_FILE + "'/>Your Android device does not support the video tag or the file format.</video>";
             } else if (EXT_AUDIO.contains(extWithDot)) {
                 converted += " <audio class='htmlav' title='" + file.getName() + "' autoplay loop controls loop='0' style='width: 100%;'><source srcx='" + TOKEN_FILEURI_VIEWED_FILE + "'>Your Android device does not support the audio tag or the file format.</audio>";

--- a/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
@@ -1,0 +1,109 @@
+/*#######################################################
+ *
+ *   Maintained by Gregor Santner, 2018-
+ *   https://gsantner.net/
+ *
+ *   License of this file: Apache 2.0 (Commercial upon request)
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+#########################################################*/
+package net.gsantner.markor.format.binary;
+
+import android.content.Context;
+import android.util.Pair;
+
+import net.gsantner.markor.R;
+import net.gsantner.markor.format.TextConverter;
+import net.gsantner.markor.format.markdown.MarkdownTextConverter;
+import net.gsantner.opoc.util.FileUtils;
+import net.gsantner.opoc.util.ShareUtil;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@SuppressWarnings("WeakerAccess")
+public class EmbedBinaryConverter extends TextConverter {
+    private static final List<String> EXT = new ArrayList<>();
+    private static final List<String> EXT_AUDIO = Arrays.asList(".mp3", ".ogg", ".flac", ".opus", ".oga", ".wma", ".m4a", ".aac", ".wav", ".amr", ".mid", ".midi", ".pcm");
+    private static final List<String> EXT_IMAGE = Arrays.asList(".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".svg", ".heic", ".heif");
+    private static final List<String> EXT_VIDEO = Arrays.asList(".webm", ".mp4", ".mpeg4", ".mpeg", ".mpg", ".mkv", ".3gp", ".ts");
+
+    private static final String HTML100_BODY_BEGIN = "<div>\n  ";
+    private static final String HTML101_BODY_END = "\n\n</div>";
+    private static final String CSS_EMBED_STYLE = CSS_S + "html,body{padding: 0px; margin:0px;}" + CSS_E;
+    private static final String CSS_EMBED_TABLE_LIMITS = CSS_S + "table {word-break: break-word;} thead tr th:first-child, tbody tr td:first-child {word-break:keep-all; min-width: 100px;} thead {display:none;}" + CSS_E;
+
+    public static final String JS_CALLBACK_TYPE_OPEN_CURRENT_FILE_IN_EXTERNAL_APP = "openCurrentFileInExternalApp";
+
+    static {
+        EXT.addAll(EXT_IMAGE);
+        EXT.addAll(EXT_VIDEO);
+        EXT.addAll(EXT_AUDIO);
+    }
+
+
+    //########################
+    //## Methods
+    //########################
+
+    @Override
+    public String convertMarkup(String markup, Context context, boolean isExportInLightMode, File file) {
+        String converted = "", onLoadJs = "", head = "";
+        if (file == null) {
+            return "";
+        }
+        converted = HTML100_BODY_BEGIN;
+        head = CSS_EMBED_STYLE + CSS_EMBED_TABLE_LIMITS;
+        final String extWithDot = FileUtils.getFilenameExtension(file);
+        final ShareUtil shu = new ShareUtil(context);
+
+        // Usage of binary file depending on file extension / MIME
+        if (EXT_IMAGE.contains(extWithDot)) {
+            converted += "<img src='" + TOKEN_FILEURI_VIEWED_FILE + "' alt='Your Android device does not support the file format.'/>";
+        } else if (EXT_VIDEO.contains(extWithDot)) {
+            converted += "<video autoplay controls loop style='max-height: 85vh; width: 100%; max-width: 100%;' src='" + TOKEN_FILEURI_VIEWED_FILE + "'/>Your Android device does not support the video tag or the file format.</video>";
+        } else if (EXT_AUDIO.contains(extWithDot)) {
+            converted += " <audio title='" + file.getName() + "' autoplay controls loop style='width: 100%;'><source src='" + TOKEN_FILEURI_VIEWED_FILE + "'>Your Android device does not support the audio tag or the file format.</audio>";
+        }
+
+        // Add file info table below content
+        StringBuilder table = new StringBuilder("");
+        table.append(String.format("%s | %s\n-----|-----\n", context.getString(R.string.type), context.getString(R.string.info)));
+        for (Pair<String, String> metaPair : shu.extractFileMetadata(context, file, true)) {
+            table.append(String.format("%s | %s\n", metaPair.first.replace("|", "/"), metaPair.second.replace("|", "/")));
+        }
+
+
+        converted += "\n\n<br/><div style='margin: 16px;'>\n";
+        // Add button to open in external app
+        converted += String.format("<button style='background-color: " + TOKEN_ACCENT_COLOR + ";' type='button' onclick=\"javascript:Android.webViewJavascriptCallback('%s');\"/>%s</button>"
+                , JS_CALLBACK_TYPE_OPEN_CURRENT_FILE_IN_EXTERNAL_APP
+                , context.getString(R.string.open_file_with)
+        );
+        converted += String.format("<button style='background-color: " + TOKEN_ACCENT_COLOR + ";' type='button' onclick=\"javascript:Android.webViewJavascriptCallback('%s');\"/>%s</button>"
+                , JS_CALLBACK_TYPE_OPEN_CURRENT_FILE_IN_EXTERNAL_APP
+                , context.getString(R.string.rotate)
+        );
+
+        converted += "<br/>";
+        converted += MarkdownTextConverter.flexmarkRenderer.render(MarkdownTextConverter.flexmarkParser.parse(table.toString()));
+        converted += "</div>";
+
+
+        converted += HTML101_BODY_END;
+        shu.setContext(null);
+        return putContentIntoTemplate(context, converted, isExportInLightMode, file, onLoadJs, head);
+    }
+
+    @Override
+    protected String getContentType() {
+        return CONTENT_TYPE_HTML;
+    }
+
+    @Override
+    protected boolean isFileOutOfThisFormat(String filepath, String extWithDot) {
+        return EXT.contains(extWithDot);
+    }
+}

--- a/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
@@ -1,10 +1,7 @@
 /*#######################################################
  *
- *   Maintained by Gregor Santner, 2018-
- *   https://gsantner.net/
- *
- *   License of this file: Apache 2.0 (Commercial upon request)
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * SPDX-FileCopyrightText: 2022-2022 Gregor Santner <https://gsantner.net/>
+ * SPDX-License-Identifier: Unlicense OR CC0-1.0
  *
 #########################################################*/
 package net.gsantner.markor.format.binary;
@@ -15,6 +12,7 @@ import android.util.Pair;
 import net.gsantner.markor.R;
 import net.gsantner.markor.format.TextConverter;
 import net.gsantner.markor.format.markdown.MarkdownTextConverter;
+import net.gsantner.opoc.format.playlist.SimpleM3UParser;
 import net.gsantner.opoc.util.FileUtils;
 import net.gsantner.opoc.util.ShareUtil;
 
@@ -29,13 +27,14 @@ public class EmbedBinaryConverter extends TextConverter {
     private static final List<String> EXT_AUDIO = Arrays.asList(".mp3", ".ogg", ".flac", ".opus", ".oga", ".wma", ".m4a", ".aac", ".wav", ".amr", ".mid", ".midi", ".pcm");
     private static final List<String> EXT_IMAGE = Arrays.asList(".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".svg", ".heic", ".heif");
     private static final List<String> EXT_VIDEO = Arrays.asList(".webm", ".mp4", ".mpeg4", ".mpeg", ".mpg", ".mkv", ".3gp", ".ts");
+    private static final List<String> EXT_TEXT_PLAYLIST = Arrays.asList(".m3u", ".m3u8"); // don't register
+
+    public static final String EXT_MATCHES_M3U_PLAYLIST = "(?i).m3u8?";
 
     private static final String HTML100_BODY_BEGIN = "<div>\n  ";
     private static final String HTML101_BODY_END = "\n\n</div>";
     private static final String CSS_EMBED_STYLE = CSS_S + "html,body{padding: 0px; margin:0px;}" + CSS_E;
     private static final String CSS_EMBED_TABLE_LIMITS = CSS_S + "table {word-break: break-word;} thead tr th:first-child, tbody tr td:first-child {word-break:keep-all; min-width: 100px;} thead {display:none;}" + CSS_E;
-
-    public static final String JS_CALLBACK_TYPE_OPEN_CURRENT_FILE_IN_EXTERNAL_APP = "openCurrentFileInExternalApp";
 
     static {
         EXT.addAll(EXT_IMAGE);
@@ -48,56 +47,88 @@ public class EmbedBinaryConverter extends TextConverter {
     //## Methods
     //########################
 
+    @SuppressWarnings({"ConstantConditions", "StringConcatenationInLoop"})
     @Override
     public String convertMarkup(String markup, Context context, boolean isExportInLightMode, File file) {
         String converted = "", onLoadJs = "", head = "";
         if (file == null) {
             return "";
         }
-        converted = HTML100_BODY_BEGIN;
         head = CSS_EMBED_STYLE + CSS_EMBED_TABLE_LIMITS;
+        converted = HTML100_BODY_BEGIN;
         final String extWithDot = FileUtils.getFilenameExtension(file);
         final ShareUtil shu = new ShareUtil(context);
 
-        // Usage of binary file depending on file extension / MIME
-        if (EXT_IMAGE.contains(extWithDot)) {
-            converted += "<img class='rotatable' src='" + TOKEN_FILEURI_VIEWED_FILE + "' alt='Your Android device does not support the file format.'/>";
-        } else if (EXT_VIDEO.contains(extWithDot)) {
-            converted += "<video class='htmlav' autoplay controls loop style='max-height: 85vh; width: 100%; max-width: 100%;' src='" + TOKEN_FILEURI_VIEWED_FILE + "'/>Your Android device does not support the video tag or the file format.</video>";
-        } else if (EXT_AUDIO.contains(extWithDot)) {
-            converted += " <audio class='htmlav' title='" + file.getName() + "' autoplay controls loop style='width: 100%;'><source src='" + TOKEN_FILEURI_VIEWED_FILE + "'>Your Android device does not support the audio tag or the file format.</audio>";
+        // Sticky header with content depending on type
+        if (true){
+            converted += "\n<div class='sticky' style='top: 0px; border-top-width:0.1px; width: 100%; background: black;'>\n";
+            if (EXT_IMAGE.contains(extWithDot)) {
+                converted += "<img class='rotatable' src='" + TOKEN_FILEURI_VIEWED_FILE + "' alt='Your Android device does not support the file format.'/><br/>";
+            } else if (EXT_VIDEO.contains(extWithDot) || EXT_TEXT_PLAYLIST.contains(extWithDot)) {
+                converted += "<video class='htmlav' autoplay controls loop style='max-height: 85vh; width: 100%; max-width: 100%;' srcx='" + TOKEN_FILEURI_VIEWED_FILE + "'/>Your Android device does not support the video tag or the file format.</video><br/>";
+            } else if (EXT_AUDIO.contains(extWithDot)) {
+                converted += " <audio class='htmlav' title='" + file.getName() + "' autoplay loop controls loop='0' style='width: 100%;'><source srcx='" + TOKEN_FILEURI_VIEWED_FILE + "'>Your Android device does not support the audio tag or the file format.</audio><br/>";
+            }
+            if (converted.contains("htmlav")) {
+                converted += "<button type='button' class='fa' onclick=\"javascript:document.avSetPlaylistPos(null, -1);\"/>⏮️️</button>";
+                converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏪</button>";
+                converted += "<button type='button' class='fa' onclick=\"javascript:document.avPause();\"/>⏯️</button>";
+                converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏩</button>";
+                converted += "<button type='button' class='fa' onclick=\"javascript:document.avSetPlaylistPos(null, +1);\"/>⏭️</button>";
+                converted += "<button type='button' class='fa' onclick=\"javascript:document.avLoopToggle();\"/>&#128257;</button>";
+                onLoadJs += "document.playlist = []; document.playlistTitles = []; document.playlistIndex = -1;";
+                onLoadJs += "document.avLoopToggle = function()      { var o=document.getElementsByClassName('htmlav')[0]; o.loop = !o.loop; };";
+                onLoadJs += "document.avSeek           = function(delta)    { var o=document.getElementsByClassName('htmlav')[0]; o.currentTime +=delta; o.play(); };";
+                onLoadJs += "document.avSetPlaylistPos = function(i, delta) { " +
+                        "i = i!=null ? i : document.playlistIndex; delta = delta!=null ? delta : 0;" +
+                        "document.playlistIndex = (i+delta)%document.playlist.length;" +
+                        "document.avSetUrl(document.playlist[document.playlistIndex]);" +
+                        "Android.webViewJavascriptCallback(['toast', document.playlistTitles[document.playlistIndex] ]);" +
+                        "};";
+                onLoadJs += "document.avPause          = function()         { var o=document.getElementsByClassName('htmlav')[0]; if(o.paused){o.play();} else{o.pause();}; };";
+                onLoadJs += "document.avSetUrl         = function(u)        { var o=document.getElementsByClassName('htmlav')[0]; o.src = u; };";
+                onLoadJs += "document.avAddToPlaylist  = function(t, u)     { var o=document.getElementsByClassName('htmlav')[0]; document.playlist.push(u); document.playlistTitles.push(t); if (document.playlistIndex < 0){ document.avSetPlaylistPos(null, 1);} };";
+                onLoadJs += "document.getElementsByClassName('htmlav')[0].addEventListener('ended', ()=>{ console.error('ended'); document.avSetPlaylistPos(null, +1); });";
+
+                // Add file itself as first item to playlist
+                onLoadJs += "document.avAddToPlaylist('" + TOKEN_FILEURI_VIEWED_FILE+ "', '" + TOKEN_FILEURI_VIEWED_FILE + "');";
+            }
+            if (converted.contains("rotatable")) {
+                converted += "<button type='button' class='fa' onclick=\"javascript:document.rotate();\"/>&#128260️</button>";
+                onLoadJs += "document.rotation = 0;";
+                onLoadJs += "document.rotate       = function()      { var o=document.getElementsByClassName('rotatable')[0]; document.rotation+=90; o.style.transform = 'rotate(xdeg)'.replace('x', document.rotation); o.style.height = Math.min(o.offsetHeight, window.screen.width*0.9)+'px'; };";
+            }
+            converted += "\n</div>\n"; // sticky
         }
+
 
         // div width side margins
-        converted += "\n\n<br/><div style='margin: 16px; margin-top: 0px;'><br/>\n";
+        if (true) {
+            converted += "\n\n<div style='margin: 16px; margin-top: 0px;'><br/>\n";
+            // Add file info table below content
+            StringBuilder table = new StringBuilder("");
+            table.append(String.format("%s | %s\n-----|-----\n", context.getString(R.string.type), context.getString(R.string.info)));
+            for (Pair<String, String> metaPair : shu.extractFileMetadata(context, file, true)) {
+                table.append(String.format("%s | %s\n", metaPair.first.replace("|", "/"), metaPair.second.replace("|", "/")));
+            }
+            converted += MarkdownTextConverter.flexmarkRenderer.render(MarkdownTextConverter.flexmarkParser.parse(table.toString()));
 
-        if (converted.contains("htmlav")) {
-            converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-9e9);\"/>⏮️️</button>";
-            converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏪</button>";
-            converted += "<button type='button' class='fa' onclick=\"javascript:document.avPause();\"/>⏯️</button>";
-            converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏩</button>";
-            converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(+9e9);\"/>⏭️</button>";
-            converted += "<button type='button' class='fa' onclick=\"javascript:document.avLoopToggle();\"/>&#128257;</button>";
-            onLoadJs += "document.avSeek       = function(delta) { var o=document.getElementsByClassName('htmlav')[0]; o.currentTime +=delta; o.play(); };";
-            onLoadJs += "document.avLoopToggle = function()      { var o=document.getElementsByClassName('htmlav')[0]; o.loop = !o.loop; };";
-            onLoadJs += "document.avPause      = function()      { var o=document.getElementsByClassName('htmlav')[0]; if(o.paused){o.play();} else{o.pause();}; };";
-        }
-        if (converted.contains("rotatable")) {
-            converted += "<button type='button' class='fa' onclick=\"javascript:document.rotate();\"/>&#128260️</button>";
-            onLoadJs += "document.rotation = 0;";
-            onLoadJs += "document.rotate       = function()      { var o=document.getElementsByClassName('rotatable')[0]; document.rotation+=90; o.style.transform = 'rotate(xdeg)'.replace('x', document.rotation); };";
-        }
+            // m3u/m3u8: buttons for playlist entries
+            if (extWithDot.matches(EXT_MATCHES_M3U_PLAYLIST)) {
+                int i = 0;
+                for (SimpleM3UParser.M3U_Entry line : new SimpleM3UParser().parse(FileUtils.readTextFileFast(file).first)) {
+                    converted += "\n<button type='button' onclick=\"javascript:document.avSetPlaylistPos("+(i+1)+");\"/>" + line.getName() + "</button>";
+                    onLoadJs += "\ndocument.avAddToPlaylist('" + line.getName() + "', '"+ line.getUrl() + "');";
+                    i++;
+                }
+                if (i > 0) {
+                    onLoadJs += "document.avLoopToggle(); document.avSetPlaylistPos(1, 0);";
+                }
+            }
 
-        // Add file info table below content
-        StringBuilder table = new StringBuilder("");
-        table.append(String.format("%s | %s\n-----|-----\n", context.getString(R.string.type), context.getString(R.string.info)));
-        for (Pair<String, String> metaPair : shu.extractFileMetadata(context, file, true)) {
-            table.append(String.format("%s | %s\n", metaPair.first.replace("|", "/"), metaPair.second.replace("|", "/")));
+            // end div with side margins
+            converted += "</div>";
         }
-        converted += MarkdownTextConverter.flexmarkRenderer.render(MarkdownTextConverter.flexmarkParser.parse(table.toString()));
-
-        // end div with side margins
-        converted += "</div>";
 
         converted += HTML101_BODY_END;
         shu.setContext(null);

--- a/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
@@ -26,7 +26,7 @@ public class EmbedBinaryConverter extends TextConverter {
     private static final List<String> EXT = new ArrayList<>();
     private static final List<String> EXT_AUDIO = Arrays.asList(".mp3", ".ogg", ".flac", ".opus", ".oga", ".wma", ".m4a", ".aac", ".wav", ".amr", ".mid", ".midi", ".pcm");
     private static final List<String> EXT_IMAGE = Arrays.asList(".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".svg", ".heic", ".heif");
-    private static final List<String> EXT_VIDEO = Arrays.asList(".webm", ".mp4", ".mpeg4", ".mpeg", ".mpg", ".mkv", ".3gp", ".ts");
+    private static final List<String> EXT_VIDEO = Arrays.asList(".webm", ".mp4", ".mpeg4", ".mpeg", ".mpg", ".mkv", ".3gp", ".ts", ".m4v");
     private static final List<String> EXT_TEXT_PLAYLIST = Arrays.asList(".m3u", ".m3u8"); // don't register
 
     public static final String EXT_MATCHES_M3U_PLAYLIST = "(?i).m3u8?";
@@ -63,20 +63,20 @@ public class EmbedBinaryConverter extends TextConverter {
         if (true) {
             converted += "\n<div class='sticky' style='top: 0px; border-top-width:0.1px; width: 100%; background: black;'>\n";
             if (EXT_IMAGE.contains(extWithDot)) {
-                converted += "<img class='rotatable' src='" + TOKEN_FILEURI_VIEWED_FILE + "' alt='Your Android device does not support the file format.'/><br/>";
+                converted += "<img class='' src='" + TOKEN_FILEURI_VIEWED_FILE + "' alt='Your Android device does not support the file format.'/>";
             } else if (EXT_VIDEO.contains(extWithDot) || EXT_TEXT_PLAYLIST.contains(extWithDot)) {
-                converted += "<video class='htmlav' autoplay controls loop style='max-height: 85vh; width: 100%; max-width: 100%;' srcx='" + TOKEN_FILEURI_VIEWED_FILE + "'/>Your Android device does not support the video tag or the file format.</video><br/>";
+                converted += "<video class='htmlav' autoplay controls loop style='max-height: 85vh; width: 100%; max-width: 100%;' srcx='" + TOKEN_FILEURI_VIEWED_FILE + "'/>Your Android device does not support the video tag or the file format.</video>";
             } else if (EXT_AUDIO.contains(extWithDot)) {
-                converted += " <audio class='htmlav' title='" + file.getName() + "' autoplay loop controls loop='0' style='width: 100%;'><source srcx='" + TOKEN_FILEURI_VIEWED_FILE + "'>Your Android device does not support the audio tag or the file format.</audio><br/>";
+                converted += " <audio class='htmlav' title='" + file.getName() + "' autoplay loop controls loop='0' style='width: 100%;'><source srcx='" + TOKEN_FILEURI_VIEWED_FILE + "'>Your Android device does not support the audio tag or the file format.</audio>";
             }
-            converted += "<div style='margin-left: 12px; margin-right: 8px;'>";
+            converted += "<span class='clear'></span><div style='margin-left: 12px; margin-right: 8px;'>";
             if (converted.contains("htmlav")) {
-                converted += "<button type='button' class='fa' onclick=\"javascript:document.avSetPlaylistPos(null, -1);\"/>⏮️️</button>";
-                converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏪</button>";
-                converted += "<button type='button' class='fa' onclick=\"javascript:document.avPause();\"/>⏯️</button>";
-                converted += "<button type='button' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏩</button>";
-                converted += "<button type='button' class='fa' onclick=\"javascript:document.avSetPlaylistPos(null, +1);\"/>⏭️</button>";
-                converted += "<button type='button' class='fa' onclick=\"javascript:document.avLoopToggle();\"/>&#128257;</button>";
+                converted += "<button type='button floatl' class='fa' onclick=\"javascript:document.avSetPlaylistPos(null, -1);\"/>⏮️️</button>";
+                converted += "<button type='button floatl' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏪</button>";
+                converted += "<button type='button floatl' class='fa' onclick=\"javascript:document.avPause();\"/>⏯️</button>";
+                converted += "<button type='button floatl' class='fa' onclick=\"javascript:document.avSeek(-30);\"/>⏩</button>";
+                converted += "<button type='button floatl' class='fa' onclick=\"javascript:document.avSetPlaylistPos(null, +1);\"/>⏭️</button>";
+                converted += "<button type='button floatl' class='fa' onclick=\"javascript:document.avLoopToggle();\"/>&#128257;</button>";
                 onLoadJs += "document.playlist = []; document.playlistTitles = []; document.playlistIndex = -1;";
                 onLoadJs += "document.avLoopToggle = function()      { var o=document.getElementsByClassName('htmlav')[0]; o.loop = !o.loop; };";
                 onLoadJs += "document.avSeek           = function(delta)    { var o=document.getElementsByClassName('htmlav')[0]; o.currentTime +=delta; o.play(); };";
@@ -95,7 +95,7 @@ public class EmbedBinaryConverter extends TextConverter {
                 onLoadJs += "document.avAddToPlaylist('" + TOKEN_FILEURI_VIEWED_FILE + "', '" + TOKEN_FILEURI_VIEWED_FILE + "');";
             }
             if (converted.contains("rotatable")) {
-                converted += "<button type='button' class='fa' onclick=\"javascript:document.rotate();\"/>&#128260️</button>";
+                converted += "<button type='button floatl' class='fa' onclick=\"javascript:document.rotate();\"/>&#128260️</button>";
                 onLoadJs += "document.rotation = 0;";
                 onLoadJs += "document.rotate       = function()      { var o=document.getElementsByClassName('rotatable')[0]; document.rotation+=90; o.style.transform = 'rotate(xdeg)'.replace('x', document.rotation); o.style.height = Math.min(o.offsetHeight, window.screen.width*0.9)+'px'; };";
             }

--- a/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryConverter.java
@@ -60,7 +60,7 @@ public class EmbedBinaryConverter extends TextConverter {
         final ShareUtil shu = new ShareUtil(context);
 
         // Sticky header with content depending on type
-        if (true){
+        if (true) {
             converted += "\n<div class='sticky' style='top: 0px; border-top-width:0.1px; width: 100%; background: black;'>\n";
             if (EXT_IMAGE.contains(extWithDot)) {
                 converted += "<img class='rotatable' src='" + TOKEN_FILEURI_VIEWED_FILE + "' alt='Your Android device does not support the file format.'/><br/>";
@@ -91,7 +91,7 @@ public class EmbedBinaryConverter extends TextConverter {
                 onLoadJs += "document.getElementsByClassName('htmlav')[0].addEventListener('ended', ()=>{ console.error('ended'); document.avSetPlaylistPos(null, +1); });";
 
                 // Add file itself as first item to playlist
-                onLoadJs += "document.avAddToPlaylist('" + TOKEN_FILEURI_VIEWED_FILE+ "', '" + TOKEN_FILEURI_VIEWED_FILE + "');";
+                onLoadJs += "document.avAddToPlaylist('" + TOKEN_FILEURI_VIEWED_FILE + "', '" + TOKEN_FILEURI_VIEWED_FILE + "');";
             }
             if (converted.contains("rotatable")) {
                 converted += "<button type='button' class='fa' onclick=\"javascript:document.rotate();\"/>&#128260️</button>";
@@ -117,8 +117,8 @@ public class EmbedBinaryConverter extends TextConverter {
             if (extWithDot.matches(EXT_MATCHES_M3U_PLAYLIST)) {
                 int i = 0;
                 for (SimpleM3UParser.M3U_Entry line : new SimpleM3UParser().parse(FileUtils.readTextFileFast(file).first)) {
-                    converted += "\n<button type='button' onclick=\"javascript:document.avSetPlaylistPos("+(i+1)+");\"/>" + line.getName() + "</button>";
-                    onLoadJs += "\ndocument.avAddToPlaylist('" + line.getName() + "', '"+ line.getUrl() + "');";
+                    converted += "\n<button type='button' onclick=\"javascript:document.avSetPlaylistPos(" + (i + 1) + ");\"/>" + line.getName() + "</button>";
+                    onLoadJs += "\ndocument.avAddToPlaylist('" + line.getName() + "', '" + line.getUrl() + "');";
                     i++;
                 }
                 if (i > 0) {

--- a/app/src/main/java/net/gsantner/markor/format/keyvalue/KeyValueConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/keyvalue/KeyValueConverter.java
@@ -12,12 +12,14 @@ package net.gsantner.markor.format.keyvalue;
 import net.gsantner.markor.format.plaintext.PlaintextConverter;
 
 import java.util.Arrays;
+import java.util.List;
 
 @SuppressWarnings("WeakerAccess")
 public class KeyValueConverter extends PlaintextConverter {
+    private static final List<String> EXT = Arrays.asList(".yml", ".yaml", ".toml", ".vcf", ".ics", ".ini", ".json", ".csv", ".zim");
 
     @Override
     public boolean isFileOutOfThisFormat(String filepath, String extWithDot) {
-        return Arrays.asList(new String[]{".yml", ".yaml", ".toml", ".vcf", ".ics", ".ini", ".json", ".csv", ".zim"}).contains(extWithDot);
+        return EXT.contains(extWithDot);
     }
 }

--- a/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextConverter.java
@@ -14,7 +14,10 @@ import android.content.Context;
 import androidx.core.text.TextUtilsCompat;
 
 import net.gsantner.markor.format.TextConverter;
+import net.gsantner.markor.format.TextFormat;
+import net.gsantner.markor.format.binary.EmbedBinaryConverter;
 import net.gsantner.markor.util.AppSettings;
+import net.gsantner.opoc.util.FileUtils;
 
 import java.io.File;
 import java.util.Arrays;
@@ -24,8 +27,7 @@ import java.util.List;
 public class PlaintextConverter extends TextConverter {
     private static final String HTML100_BODY_PRE_BEGIN = "<pre style='white-space: pre-wrap;font-family: " + TOKEN_FONT + "' >";
     private static final String HTML101_BODY_PRE_END = "</pre>";
-    private static final List<String> EXT = Arrays.asList(".txt", ".taskpaper", ".html", ".adoc", ".org", ".ldg", ".ledger", ".diff", ".patch");
-
+    private static final List<String> EXT = Arrays.asList(".txt", ".taskpaper", ".html", ".htm", ".adoc", ".org", ".ldg", ".ledger", ".diff", ".patch", ".m3u", ".m3u8");
 
     //########################
     //## Methods
@@ -34,8 +36,12 @@ public class PlaintextConverter extends TextConverter {
     @Override
     public String convertMarkup(String markup, Context context, boolean isExportInLightMode, File file) {
         String converted = "", onLoadJs = "", head = "";
-        if (file != null && file.getName().toLowerCase().endsWith(".html")) {
+        final String extWithDot = FileUtils.getFilenameExtension(file);
+
+        if (extWithDot.startsWith(".htm")) {
             converted += markup;
+        } else if (extWithDot.matches(EmbedBinaryConverter.EXT_MATCHES_M3U_PLAYLIST)) {
+            return TextFormat.CONVERTER_EMBEDBINARY.convertMarkup(markup, context, isExportInLightMode, file);
         } else {
             converted = HTML100_BODY_PRE_BEGIN
                     + TextUtilsCompat.htmlEncode(markup)

--- a/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiTextActions.java
@@ -11,7 +11,6 @@ package net.gsantner.markor.format.zimwiki;
 
 import android.content.Context;
 import android.os.Build;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
@@ -22,7 +21,6 @@ import net.gsantner.markor.format.AutoFormatter;
 import net.gsantner.markor.model.Document;
 import net.gsantner.markor.ui.AttachImageOrLinkDialog;
 import net.gsantner.markor.ui.SearchOrCustomTextDialogCreator;
-import net.gsantner.opoc.util.ContextUtils;
 import net.gsantner.opoc.util.StringUtils;
 
 import java.io.File;
@@ -222,7 +220,7 @@ public class ZimWikiTextActions extends net.gsantner.markor.ui.hleditor.TextActi
         }
 
         if (resolver.isWebLink()) {
-           getAndroidUtils().openWebpageInExternalBrowser(resolvedLink);
+            getAndroidUtils().openWebpageInExternalBrowser(resolvedLink);
         } else {
             DocumentActivity.launch(getActivity(), new File(resolvedLink), false, null, null);
         }

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -172,7 +172,10 @@ public class Document implements Serializable {
     public synchronized String loadContent(final Context context) {
         String content;
         final char[] pw;
-        if (isEncrypted() && (pw = getPasswordWithWarning(context)) != null) {
+
+        if (isBinaryFileNoTextLoading()) {
+            content = "";
+        } else if (isEncrypted() && (pw = getPasswordWithWarning(context)) != null) {
             try {
                 final byte[] encryptedContext = FileUtils.readCloseStreamWithSize(new FileInputStream(_file), (int) _file.length());
                 if (encryptedContext.length > JavaPasswordbasedCryption.Version.NAME_LENGTH) {
@@ -243,6 +246,9 @@ public class Document implements Serializable {
 
     @SuppressWarnings("ConstantConditions")
     public synchronized boolean saveContent(final Context context, final CharSequence content, ShareUtil shareUtil1, boolean isManualSave) {
+        if (isBinaryFileNoTextLoading()) {
+            return true;
+        }
         if (!isManualSave && TextUtils.getTrimmedLength(content) < ShareUtil.MIN_OVERWRITE_LENGTH) {
             return false;
         }

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -152,6 +152,10 @@ public class Document implements Serializable {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && file.getName().endsWith(JavaPasswordbasedCryption.DEFAULT_ENCRYPTION_EXTENSION);
     }
 
+    public boolean isBinaryFileNoTextLoading() {
+        return _file != null && TextFormat.CONVERTER_EMBEDBINARY.isFileOutOfThisFormat(_file.getAbsolutePath());
+    }
+
     public boolean isEncrypted() {
         return isEncrypted(_file);
     }

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -79,6 +79,8 @@ public class Document implements Serializable {
             setFormat(TextFormat.FORMAT_MARKDOWN);
         } else if (TextFormat.CONVERTER_ZIMWIKI.isFileOutOfThisFormat(getPath())) {
             setFormat(TextFormat.FORMAT_ZIMWIKI);
+        } else if (TextFormat.CONVERTER_EMBEDBINARY.isFileOutOfThisFormat(getPath())) {
+            setFormat(TextFormat.FORMAT_EMBEDBINARY);
         } else {
             setFormat(TextFormat.FORMAT_PLAIN);
         }

--- a/app/src/main/java/net/gsantner/opoc/format/OpocSimplePlaylistParser.java
+++ b/app/src/main/java/net/gsantner/opoc/format/OpocSimplePlaylistParser.java
@@ -10,12 +10,7 @@
  * Mainly for playlists with video streams
  * See https://gsantner.net/blog/2019/07/26/simple-m3u-playlist-parser-iptv-m3u8-android-java.html
  */
-package net.gsantner.opoc.format.playlist;
-
-import android.app.Activity;
-import android.content.Intent;
-import android.net.Uri;
-import android.os.Environment;
+package net.gsantner.opoc.format;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -30,7 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * Simple Parser for M3U playlists
  */
 @SuppressWarnings({"WeakerAccess", "CaughtExceptionImmediatelyRethrown", "unused", "SpellCheckingInspection"})
-public class SimpleM3UParser {
+public class OpocSimplePlaylistParser {
     private final static String EXTINF_TAG = "#EXTINF:";
     private final static String EXTINF_TVG_NAME = "tvg-name=\"";
     private final static String EXTINF_TVG_ID = "tvg-id=\"";
@@ -204,17 +199,21 @@ public class SimpleM3UParser {
         public int seconds = -1;
         public boolean isRadio = false;
 
-        public String getName() {
+        public String getName(int... maxLen) {
+            final int limitTotal = maxLen != null && maxLen.length > 0 ? maxLen[0] : 999;
+            final int limitBegin = Math.round(limitTotal * 0.565f);
+            final int limitEnd = Math.round(limitTotal * 0.435f);
+
+            String t = "";
             if (tvgName != null) {
-                return tvgName;
+                t = tvgName;
             } else if (name != null) {
-                return name;
+                t = name;
             } else if (url != null) {
-                String t = url.replaceFirst("(?i)https?:..", "");
-                t = t.length() < 27 ? t : t.replaceFirst("(.{20}).+(.{7})", "$1…$2");
-                return t;
+                t = url.replaceFirst("(?i)https?:..", "").replaceFirst("\\.\\w+$", "");
             }
-            return "";
+            t = t.length() < limitTotal ? t : t.replaceFirst("(.{"+limitBegin+"}).+(.{"+limitEnd+"})", "$1…$2");
+            return t;
         }
 
         public String getUrl() {
@@ -232,16 +231,17 @@ public class SimpleM3UParser {
     ////
     ///  Examples
     //
+/*
     public static class Examples {
         public static List<M3U_Entry> example() {
-            SimpleM3UParser simpleM3UParser = new SimpleM3UParser();
+            OpocSimplePlaylistParser simpleM3UParser = new OpocSimplePlaylistParser();
             File moviesFolder = new File(Environment.getExternalStorageDirectory(), Environment.DIRECTORY_MOVIES);
             return simpleM3UParser.parse(new File(moviesFolder, "streams.m3u"));
         }
 
         public static List<M3U_Entry> exampleWithLogoRewrite() {
             List<M3U_Entry> playlist = new ArrayList<>();
-            SimpleM3UParser simpleM3UParser = new SimpleM3UParser();
+            OpocSimplePlaylistParser simpleM3UParser = new OpocSimplePlaylistParser();
             File moviesFolder = new File(new File(Environment.getExternalStorageDirectory(), Environment.DIRECTORY_MOVIES), "liveStreams");
             File logosFolder = new File(moviesFolder, "Senderlogos");
             File streams = new File(moviesFolder, "streams.m3u");
@@ -262,4 +262,5 @@ public class SimpleM3UParser {
             activity.startActivity(intent);
         }
     }
+*/
 }

--- a/app/src/main/java/net/gsantner/opoc/format/playlist/SimpleM3UParser.java
+++ b/app/src/main/java/net/gsantner/opoc/format/playlist/SimpleM3UParser.java
@@ -1,0 +1,265 @@
+/*#######################################################
+ *
+ * SPDX-FileCopyrightText: 2019-2022 Gregor Santner <https://gsantner.net/>
+ * SPDX-License-Identifier: Unlicense OR CC0-1.0
+ *
+#########################################################*/
+
+/*
+ * Simple Parser for M3U playlists with some extensions
+ * Mainly for playlists with video streams
+ * See https://gsantner.net/blog/2019/07/26/simple-m3u-playlist-parser-iptv-m3u8-android-java.html
+ */
+package net.gsantner.opoc.format.playlist;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Environment;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Simple Parser for M3U playlists
+ */
+@SuppressWarnings({"WeakerAccess", "CaughtExceptionImmediatelyRethrown", "unused", "SpellCheckingInspection"})
+public class SimpleM3UParser {
+    private final static String EXTINF_TAG = "#EXTINF:";
+    private final static String EXTINF_TVG_NAME = "tvg-name=\"";
+    private final static String EXTINF_TVG_ID = "tvg-id=\"";
+    private final static String EXTINF_TVG_LOGO = "tvg-logo=\"";
+    private final static String EXTINF_TVG_EPGURL = "tvg-epgurl=\"";
+    private final static String EXTINF_GROUP_TITLE = "group-title=\"";
+    private final static String EXTINF_RADIO = "radio=\"";
+    private final static String EXTINF_TAGS = "tags=\"";
+
+    // ########################
+    // ##
+    // ## Members
+    // ##
+    // ########################
+
+    // Parse m3u file by reading content from file
+    public ArrayList<M3U_Entry> parse(File filepath) {
+        try {
+            return parse(new FileInputStream(filepath));
+        } catch (Exception ignored) {
+            return new ArrayList<>();
+        }
+    }
+
+    // Parse m3u file by reading from inputstream
+    public ArrayList<M3U_Entry> parse(InputStream inputStream) {
+
+        StringBuilder text = new StringBuilder();
+        String line = "";
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
+            while ((line = br.readLine()) != null) {
+                text.append(line);
+                text.append("\n");
+            }
+        } catch (Exception ignored) {
+        }
+
+        return parse(text.toString());
+    }
+
+    public ArrayList<M3U_Entry> parse(String text) {
+        final AtomicReference<M3U_Entry> lastEntry = new AtomicReference<>(null);
+        final ArrayList<M3U_Entry> entries = new ArrayList<>();
+
+        text = text.trim().replace("\r", "");
+
+        for (String line : text.split("\n")) {
+            try {
+                parseLine(line, entries, lastEntry);
+            } catch (Exception e) {
+                lastEntry.set(null);
+            }
+        }
+        return entries;
+    }
+
+    // Parse one line of m3u
+    private void parseLine(String line, final List<M3U_Entry> entries, final AtomicReference<M3U_Entry> lastEntry) {
+        line = line.trim();
+
+        if (line.startsWith(EXTINF_TAG)) {
+            // #EXTINF line
+            try {
+                lastEntry.set(parseExtInf(line));
+            } catch (Exception ignored) {
+            }
+        } else if (!line.isEmpty() && !line.startsWith("#")) {
+            // URL line (no comment, no empty line(trimmed))
+            lastEntry.compareAndSet(null, new M3U_Entry());
+            lastEntry.get().url = line.trim();
+            entries.add(lastEntry.getAndSet(null));
+        } else {
+            // No useable data -> reset last EXTINF for next entry
+            lastEntry.set(null);
+        }
+    }
+
+    private M3U_Entry parseExtInf(String line) {
+        M3U_Entry curEntry = new M3U_Entry();
+        StringBuilder buf = new StringBuilder(20);
+        if (line.length() < EXTINF_TAG.length() + 1) {
+            return curEntry;
+        }
+
+        // Strip tag
+        line = line.substring(EXTINF_TAG.length());
+
+        // Read seconds (may end with comma or whitespace)
+        while (line.length() > 0) {
+            char c = line.charAt(0);
+            if (Character.isDigit(c) || c == '-' || c == '+') {
+                buf.append(c);
+                line = line.substring(1);
+            } else {
+                break;
+            }
+        }
+        if (buf.length() == 0 || line.isEmpty()) {
+            return curEntry;
+        }
+        curEntry.seconds = Integer.parseInt(buf.toString());
+
+        // tvg tags
+        String old = null;
+        while (!line.isEmpty() && !line.startsWith(",") && !line.equals(old)) {
+            old = line = line.trim();
+            if (line.startsWith(EXTINF_TVG_NAME) && line.length() > EXTINF_TVG_NAME.length()) {
+                line = line.substring(EXTINF_TVG_NAME.length());
+                int i = line.indexOf("\"");
+                curEntry.tvgName = line.substring(0, i).replace("'", "");
+                line = line.substring(i + 1);
+            } else if (line.startsWith(EXTINF_TVG_LOGO) && line.length() > EXTINF_TVG_LOGO.length()) {
+                line = line.substring(EXTINF_TVG_LOGO.length());
+                int i = line.indexOf("\"");
+                curEntry.tvgLogo = line.substring(0, i);
+                line = line.substring(i + 1);
+            } else if (line.startsWith(EXTINF_TVG_EPGURL) && line.length() > EXTINF_TVG_EPGURL.length()) {
+                line = line.substring(EXTINF_TVG_EPGURL.length());
+                int i = line.indexOf("\"");
+                curEntry.tvgEpgUrl = line.substring(0, i);
+                line = line.substring(i + 1);
+            } else if (line.startsWith(EXTINF_RADIO) && line.length() > EXTINF_RADIO.length()) {
+                line = line.substring(EXTINF_RADIO.length());
+                int i = line.indexOf("\"");
+                curEntry.isRadio = Boolean.parseBoolean(line.substring(0, i));
+                line = line.substring(i + 1);
+            } else if (line.startsWith(EXTINF_GROUP_TITLE) && line.length() > EXTINF_GROUP_TITLE.length()) {
+                line = line.substring(EXTINF_GROUP_TITLE.length());
+                int i = line.indexOf("\"");
+                curEntry.groupTitle = line.substring(0, i);
+                line = line.substring(i + 1);
+            } else if (line.startsWith(EXTINF_TVG_ID) && line.length() > EXTINF_TVG_ID.length()) {
+                line = line.substring(EXTINF_TVG_ID.length());
+                int i = line.indexOf("\"");
+                curEntry.tvgId = line.substring(0, i);
+                line = line.substring(i + 1);
+            } else if (line.startsWith(EXTINF_TAGS) && line.length() > EXTINF_TAGS.length()) {
+                line = line.substring(EXTINF_TAGS.length());
+                int i = line.indexOf("\"");
+                curEntry.tags = line.substring(0, i).split(",");
+                line = line.substring(i + 1);
+            } else {
+                line = line.substring(line.indexOf("\"") + 1);
+                line = line.substring(line.indexOf("\"") + 1);
+            }
+        }
+
+        // Name
+        line = line.trim();
+        if (line.length() > 1 && line.startsWith(",")) {
+            line = line.substring(1);
+            line = line.trim();
+            if (!line.isEmpty()) {
+                curEntry.name = line.replace("'", "");
+            }
+        }
+        return curEntry;
+    }
+
+    /**
+     * Data class for M3U Entries with getters & setters
+     */
+    public static class M3U_Entry {
+        public String tvgName, name;
+        public String tvgLogo;
+        public String tvgEpgUrl;
+        public String tvgId;
+        public String groupTitle;
+        public String url;
+        public String[] tags = new String[0];
+        public int seconds = -1;
+        public boolean isRadio = false;
+
+        public String getName() {
+            if (tvgName != null) {
+                return tvgName;
+            } else if (name != null) {
+                return name;
+            } else if (url != null) {
+                String t = url.replaceFirst("(?i)https?:..", "");
+                t = t.length() < 27 ? t : t.replaceFirst("(.{20}).+(.{7})", "$1…$2");
+                return t;
+            }
+            return "";
+        }
+
+        public String getUrl() {
+            return url == null ? "" : url;
+        }
+
+        @Override
+        public String toString() {
+            return getName() + " " + getUrl();
+        }
+    }
+
+
+    ////////////////////////////////////////////////////////////////////////////////////////////
+    ////
+    ///  Examples
+    //
+    public static class Examples {
+        public static List<M3U_Entry> example() {
+            SimpleM3UParser simpleM3UParser = new SimpleM3UParser();
+            File moviesFolder = new File(Environment.getExternalStorageDirectory(), Environment.DIRECTORY_MOVIES);
+            return simpleM3UParser.parse(new File(moviesFolder, "streams.m3u"));
+        }
+
+        public static List<M3U_Entry> exampleWithLogoRewrite() {
+            List<M3U_Entry> playlist = new ArrayList<>();
+            SimpleM3UParser simpleM3UParser = new SimpleM3UParser();
+            File moviesFolder = new File(new File(Environment.getExternalStorageDirectory(), Environment.DIRECTORY_MOVIES), "liveStreams");
+            File logosFolder = new File(moviesFolder, "Senderlogos");
+            File streams = new File(moviesFolder, "streams.m3u");
+            for (M3U_Entry entry : simpleM3UParser.parse(streams)) {
+                if (entry.tvgLogo != null) {
+                    entry.tvgLogo = new File(logosFolder, entry.tvgLogo).getAbsolutePath();
+                }
+                playlist.add(entry);
+            }
+            return playlist;
+        }
+
+        public static void startStreamPlaybackInVLC(Activity activity, String url) {
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT | Intent.FLAG_ACTIVITY_NO_ANIMATION);
+            intent.setDataAndTypeAndNormalize(Uri.parse(url), "video/*");
+            intent.setPackage("org.videolan.vlc");
+            activity.startActivity(intent);
+        }
+    }
+}

--- a/app/src/main/java/net/gsantner/opoc/net/OpocWebViewChromeClient.java
+++ b/app/src/main/java/net/gsantner/opoc/net/OpocWebViewChromeClient.java
@@ -8,8 +8,10 @@ package net.gsantner.opoc.net;
 
 import android.app.Activity;
 import android.os.Build;
+import android.text.TextUtils;
 import android.view.View;
 import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
 
@@ -23,6 +25,8 @@ import java.lang.ref.WeakReference;
  */
 @SuppressWarnings("rawtypes")
 public class OpocWebViewChromeClient extends WebChromeClient {
+    public static String userAgentOverride = "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.97 Mobile Safari/537.36";
+
     private final WeakReference<FrameLayout> m_fullscreenContainer;
     private final WeakReference<Activity> m_activity;
     private final WeakReference<WebView> m_webView;
@@ -39,6 +43,11 @@ public class OpocWebViewChromeClient extends WebChromeClient {
         m_fullscreenContainer = new WeakReference<>(fullscreenContainer);
         m_activity = new WeakReference<>(activity);
         m_webView = new WeakReference<>(webView);
+
+        final WebSettings webSettings = m_webView.get().getSettings();
+        if (!TextUtils.isEmpty(userAgentOverride)) {
+            webSettings.setUserAgentString(userAgentOverride);
+        }
     }
 
     @Override

--- a/app/src/main/res/menu/document__edit__menu.xml
+++ b/app/src/main/res/menu/document__edit__menu.xml
@@ -101,7 +101,7 @@
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/submenu_toggles"
+        android:id="@+id/submenu_per_file_settings"
         android:icon="@drawable/ic_check_black_24dp"
         android:title="@string/file_settings"
         app:showAsAction="never">

--- a/app/src/main/res/menu/document__edit__menu.xml
+++ b/app/src/main/res/menu/document__edit__menu.xml
@@ -164,6 +164,10 @@
                             android:id="@string/action_format_zimwiki"
                             android:icon="@drawable/fountain_pen"
                             android:title="@string/zim_wiki" />
+                        <item
+                            android:id="@string/action_format_embedbinary"
+                            android:icon="@drawable/ic_image_black_24dp"
+                            android:title="@string/embed_binary" />
                     </group>
                 </menu>
             </item>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -23,6 +23,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="more_info_on_how_to_donate_or_otherwise_support_this_project" translatable="false">@string/more_info_on_how_to_donate_or_otherwise_support_this_project_text</string>
     <string name="donate_" translatable="false">@string/donate</string>
     <string name="huuid" translatable="false">hUUID</string>
+    <string name="embed_binary" translatable="false">Embed binary</string>
 
 
     <string name="checkmark_symbol" translatable="false">\u2301</string>
@@ -328,6 +329,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__todotxt__due_date_offset" translatable="false">pref_key__todotxt_due_date_offset</string>
     <string name="action_format_keyvalue" translatable="false">action_format_keyvalue</string>
     <string name="action_format_plaintext" translatable="false">action_format_plaintext</string>
+    <string name="action_format_embedbinary" translatable="false">action_format_embedbinary</string>
     <string name="action_format_markdown" translatable="false">action_format_markdown</string>
     <string name="action_format_todotxt" translatable="false">action_format_todotxt</string>
     <string name="action_format_zimwiki" translatable="false">action_format_zimwiki</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -332,6 +332,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="recursive_search_in_current_directory">Recursive search in current directory.</string>
     <string name="always_open_with_this_app">Always open with this app</string>
     <string name="always_open_files_with_this_app_when_list_contains_file_extension">Always open files with this app when the list contains the file extension. Use \'None, .html, .css , .js\' for example if you want to edit web files and those without file extension.</string>
+    <string name="open_file_with">Open file with</string>
     <string name="rotate">Rotate</string>
     <string name="template">Template</string>
     <string name="send_debug_log">Send Debug Log</string>


### PR DESCRIPTION
View mode: Feature open Image,Video,Audio files and other WebView supported formats in view mode (allow open jpg/mp4/mp3 etc directly in Markor), by @gsantner, closes #1200

* List of supported filetypes depends on native support by Android OS & WebView, [here](https://developer.android.com/guide/topics/media/media-formats) is a overview of the supported filetypes. This of course includes the most relevant stuff like jpg/png/mp4/mp3/webm.. 
* Also added: WebChromeClient => fullscreen video playback. This means also videos embedded in markdown then also have the fullscreen button enabled.
* Extract generic media information like title/artist/bitrate if possible with builtin Android utility

state 28. august:  
![screenshot-2022-08-28__16-59-59-embed-binary](https://user-images.githubusercontent.com/6735650/187081384-a6ef9240-61c9-4a58-9b39-a882e0116929.png)





state of earliest version:  video, image, audio .. and also you can zoom in with zoom gesture 😄 . And yes everything shown is in a webview using html5 video/img tags + file://reference.


![3](https://user-images.githubusercontent.com/6735650/185771592-1864cd16-b141-47f6-bd06-e4a3c17473ff.png)

