### PR TITLE
Defensive data loss prevention

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -97,7 +97,6 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     private HorizontalScrollView _hsView;
     private SearchView _menuSearchViewForViewMode;
     private Document _document;
-    private boolean _documentErrorExitInProgress = false;
     private TextFormat _textFormat;
     private ShareUtil _shareUtil;
     private TextViewUndoRedo _editTextUndoRedoHelper;
@@ -124,8 +123,8 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         final Bundle args = getArguments();
-        if (_savedInstanceState != null && _savedInstanceState.containsKey(SAVESTATE_DOCUMENT)) {
-            _document = (Document) _savedInstanceState.getSerializable(SAVESTATE_DOCUMENT);
+        if (savedInstanceState != null && savedInstanceState.containsKey(SAVESTATE_DOCUMENT)) {
+            _document = (Document) savedInstanceState.getSerializable(SAVESTATE_DOCUMENT);
         } else if (args != null && args.containsKey(Document.EXTRA_DOCUMENT)) {
             _document = (Document) args.get(Document.EXTRA_DOCUMENT);
         }
@@ -250,8 +249,10 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     }
 
     public void resume() {
-        loadDocument();
-        _hlEditor.onResume();
+        if (getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
+            loadDocument();
+            _hlEditor.onResume();
+        }
     }
 
     @Override
@@ -267,11 +268,13 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     }
 
     public void pause() {
-        saveDocument(false);
-        _hlEditor.onPause();
-        _appSettings.addRecentDocument(_document.getFile());
-        _appSettings.setDocumentPreviewState(_document.getPath(), _isPreviewVisible);
-        _appSettings.setLastEditPosition(_document.getPath(), _hlEditor.getSelectionStart());
+        if (getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) {
+            saveDocument(false);
+            _hlEditor.onPause();
+            _appSettings.addRecentDocument(_document.getFile());
+            _appSettings.setDocumentPreviewState(_document.getPath(), _isPreviewVisible);
+            _appSettings.setLastEditPosition(_document.getPath(), _hlEditor.getSelectionStart());
+        }
     }
 
     @Override

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -254,7 +254,7 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
                 final int lno = args.getInt(Document.EXTRA_FILE_LINE_NUMBER);
                 if (lno >= 0) {
                     startPos = StringUtils.getIndexFromLineOffset(_hlEditor.getText(), lno, 0);
-                } else if (lno == Document.EXTRA_FILE_LINE_NUMBER_LAST){
+                } else if (lno == Document.EXTRA_FILE_LINE_NUMBER_LAST) {
                     startPos = _hlEditor.length();
                 }
             }

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -35,6 +35,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.Lifecycle;
 
 import net.gsantner.markor.BuildConfig;
 import net.gsantner.markor.R;
@@ -264,6 +265,10 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     }
 
     public void resume() {
+        if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
+            return;
+        }
+
         loadDocument();
         if (_hlEditor != null) {
             _hlEditor.onResume();
@@ -283,6 +288,10 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     }
 
     public void pause() {
+        if (!getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED)) {
+            return;
+        }
+
         saveDocument(false);
         if (_hlEditor != null) {
             _hlEditor.onPause();

--- a/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
@@ -508,16 +508,12 @@ public class MainActivity extends MarkorBaseActivity implements FilesystemViewer
     @Override
     protected void onPause() {
         super.onPause();
-        ((DocumentEditFragment) _viewPagerAdapter.getItem(tabIdToPos(R.id.nav_todo))).pause();
-        ((DocumentEditFragment) _viewPagerAdapter.getItem(tabIdToPos(R.id.nav_quicknote))).pause();
         WrMarkorWidgetProvider.updateLauncherWidgets();
     }
 
     @Override
     protected void onStop() {
         super.onStop();
-        ((DocumentEditFragment) _viewPagerAdapter.getItem(tabIdToPos(R.id.nav_todo))).resume();
-        ((DocumentEditFragment) _viewPagerAdapter.getItem(tabIdToPos(R.id.nav_quicknote))).resume();
         restoreDefaultToolbar();
     }
 

--- a/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
@@ -1,5 +1,6 @@
 /*#######################################################
  *
+ *
  *   Maintained by Gregor Santner, 2017-
  *   https://gsantner.net/
  *
@@ -507,12 +508,16 @@ public class MainActivity extends MarkorBaseActivity implements FilesystemViewer
     @Override
     protected void onPause() {
         super.onPause();
+        ((DocumentEditFragment) _viewPagerAdapter.getItem(tabIdToPos(R.id.nav_todo))).pause();
+        ((DocumentEditFragment) _viewPagerAdapter.getItem(tabIdToPos(R.id.nav_quicknote))).pause();
         WrMarkorWidgetProvider.updateLauncherWidgets();
     }
 
     @Override
     protected void onStop() {
         super.onStop();
+        ((DocumentEditFragment) _viewPagerAdapter.getItem(tabIdToPos(R.id.nav_todo))).resume();
+        ((DocumentEditFragment) _viewPagerAdapter.getItem(tabIdToPos(R.id.nav_quicknote))).resume();
         restoreDefaultToolbar();
     }
 

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtHighlighter.java
@@ -47,7 +47,7 @@ public class TodoTxtHighlighter extends BasicTodoTxtHighlighter {
     }
 
     // Adds spacing and divider line between paragraphs
-    public static class ParagraphDividerSpan implements LineBackgroundSpan, LineHeightSpan, UpdateLayout, ShiftY {
+    public static class ParagraphDividerSpan implements LineBackgroundSpan, LineHeightSpan, UpdateLayout {
         private final int _lineColor;
         private final float _spacing;
         private Integer _origAscent = null;
@@ -73,11 +73,6 @@ public class TodoTxtHighlighter extends BasicTodoTxtHighlighter {
             }
             boolean isFirstLineInParagraph = start > 0 && text.charAt(start - 1) == '\n';
             fm.ascent = (isFirstLineInParagraph) ? fm.ascent - (int) _spacing : _origAscent;
-        }
-
-        @Override
-        public float yShift(final CharSequence text, final int start, final int end, final int index) {
-            return index >= start ? _spacing : 0;
         }
     }
 }

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -290,8 +290,9 @@ public class Document implements Serializable {
                 contentAsBytes = content.toString().getBytes();
             }
 
-            final ShareUtil shu = (shareUtil != null ? shareUtil : new ShareUtil(context));
-            if (shareUtil.isUnderStorageAccessFolder(_file, false) || shareUtil.isContentResolverProxyFile(_file)) {
+            shareUtil = (shareUtil != null ? shareUtil : new ShareUtil(context));
+            final boolean isContentResolverProxyFile = shareUtil.isContentResolverProxyFile(_file);
+            if (isContentResolverProxyFile || shareUtil.isUnderStorageAccessFolder(_file, false)) {
                 shareUtil.writeFile(_file, false, (fileOpened, fos) -> {
                     try {
                         if (_fileInfo != null && _fileInfo.hasBom) {
@@ -302,7 +303,7 @@ public class Document implements Serializable {
                         fos.write(contentAsBytes);
 
                         // Also overwrite content resolver proxy file in addition to writing back to the origin
-                        if (shu.isContentResolverProxyFile(_file)) {
+                        if (isContentResolverProxyFile) {
                             FileUtils.writeFile(_file, contentAsBytes, _fileInfo);
                         }
                     } catch (Exception ignored) {

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -122,6 +122,10 @@ public class Document implements Serializable {
         _modTimePref.edit().putLong(_file.getAbsolutePath(), _touchTime).apply();
     }
 
+    public void resetChangeTracking() {
+        _modTime = _touchTime = -1;
+    }
+
     public boolean hasFileChangedSinceLastLoad() {
         return _modTime < 0                            // Never read
                 || _touchTime < 0                      // Never read

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -10,6 +10,7 @@
 package net.gsantner.markor.model;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
@@ -20,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
 
+import net.gsantner.markor.App;
 import net.gsantner.markor.R;
 import net.gsantner.markor.activity.MainActivity;
 import net.gsantner.markor.format.TextFormat;
@@ -45,19 +47,21 @@ import other.de.stanetz.jpencconverter.JavaPasswordbasedCryption;
 public class Document implements Serializable {
     private static final int MAX_TITLE_EXTRACTION_LENGTH = 25;
 
+    private static final String MOD_PREF_NAME = "DOCUMENT_MOD_TIMES";
     public static final String EXTRA_DOCUMENT = "EXTRA_DOCUMENT"; // Document
     public static final String EXTRA_PATH = "EXTRA_PATH"; // java.io.File
     public static final String EXTRA_FILE_LINE_NUMBER = "EXTRA_FILE_LINE_NUMBER"; // int
-    public static final int EXTRA_FILE_LINE_NUMBER_LAST = -1; // Flag for last line. Any -ve number will work
+    public static final int EXTRA_FILE_LINE_NUMBER_LAST = -919385553; // Flag for last line
 
     private final File _file;
     private final String _fileExtension;
     private String _title = "";
     private String _path = "";
-    private long _modTime = 0;
+    private long _modTime = -1; // The file's mod time when it was last touched by this document
+    private long _touchTime = -1; // The last time this document touched the file
     private FileUtils.FileInfo _fileInfo;
-    @StringRes
-    private int _format = TextFormat.FORMAT_UNKNOWN;
+    private @StringRes int _format = TextFormat.FORMAT_UNKNOWN;
+    private transient SharedPreferences _modTimePref;
 
     // Used to check if string changed
     private long _lastHash = 0;
@@ -100,7 +104,32 @@ public class Document implements Serializable {
         return _file;
     }
 
-    public long lastModified() {
+    private void initModTimePref() {
+        // We do not do this in constructor as we want to init after deserialization too
+        if (_modTimePref == null) {
+            _modTimePref = App.get().getApplicationContext().getSharedPreferences(MOD_PREF_NAME, Context.MODE_PRIVATE);
+        }
+    }
+
+    private long getGlobalTouchTime() {
+        initModTimePref();
+        return _modTimePref.getLong(_file.getAbsolutePath(), 0);
+    }
+
+    private void setGlobalTouchTime() {
+        initModTimePref();
+        _touchTime = System.currentTimeMillis();
+        _modTimePref.edit().putLong(_file.getAbsolutePath(), _touchTime).apply();
+    }
+
+    public boolean hasFileChangedSinceLastLoad() {
+        return _modTime < 0                            // Never read
+                || _touchTime < 0                      // Never read
+                || fileModTime() > _modTime            // File mod time updated
+                || getGlobalTouchTime() > _touchTime;  // File has been modified by another document
+    }
+
+    public long fileModTime() {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 return Files.readAttributes(_file.toPath(), BasicFileAttributes.class).lastModifiedTime().toMillis();
@@ -200,7 +229,8 @@ public class Document implements Serializable {
 
         // Also set hash and time on load - should prevent unnecessary saves
         setContentHash(content);
-        _modTime = lastModified();
+        _modTime = fileModTime();
+        setGlobalTouchTime();
 
         return content;
     }
@@ -246,7 +276,7 @@ public class Document implements Serializable {
         }
 
         // Don't write same content if base file not changed
-        if (_modTime >= lastModified() && isContentSame(content)) {
+        if (_modTime == fileModTime() && isContentSame(content)) {
             return true;
         }
 
@@ -290,11 +320,8 @@ public class Document implements Serializable {
 
         if (success) {
             setContentHash(content);
-            final long curModTime = lastModified();
-            if (_modTime >= curModTime) {
-                Log.w("MARKOR_DOCUMENT", "File modification time unchanged after write");
-            }
-            _modTime = curModTime;
+            _modTime = fileModTime();
+            setGlobalTouchTime();
         }
 
         return success;

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -358,7 +358,7 @@ public class Document implements Serializable {
     }
 
     // Convenient wrapper
-    private static String getFileNameWithTimestamp(boolean includeExt) {
+    private static String getFileNameWithTimestamp(final boolean includeExt) {
         final String ext = includeExt ? MarkdownTextConverter.EXT_MARKDOWN__TXT : "";
         return ShareUtil.getFilenameWithTimestamp("", "", ext);
     }

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -276,7 +276,7 @@ public class Document implements Serializable {
         }
 
         // Don't write same content if base file not changed
-        if (_modTime == fileModTime() && isContentSame(content)) {
+        if (!hasFileChangedSinceLastLoad() && isContentSame(content)) {
             return true;
         }
 

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/Highlighter.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/Highlighter.java
@@ -214,7 +214,7 @@ public abstract class Highlighter {
         return _spannable;
     }
 
-    public synchronized Highlighter apply() {
+    public Highlighter apply() {
         return apply(new int[]{0, _spannable.length()});
     }
 
@@ -262,18 +262,6 @@ public abstract class Highlighter {
             _spannable.removeSpan(_layoutUpdater);
         }
         return this;
-    }
-
-    // The current offset of char at index in y due to spans implementing ShiftY
-    public final float yOffset(final int index) {
-        float offset = 0;
-        for (final int i : _applied) {
-            final SpanGroup group = _groups.get(i);
-            if (group.span instanceof ShiftY) {
-                offset += ((ShiftY) group.span).yShift(_spannable, group.start, group.end, index);
-            }
-        }
-        return offset;
     }
 
     /**
@@ -499,11 +487,5 @@ public abstract class Highlighter {
                     .setStrike(strikethrough)
                     .setTextSize(textSize);
         }
-    }
-
-    // Interface for spans which will shift text in Y - used to adjust scroll position
-    public interface ShiftY {
-        // How much will text at index be shifted in y
-        float yShift(CharSequence text, int spanStart, int spanEnd, int index);
     }
 }

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/Highlighter.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/Highlighter.java
@@ -296,7 +296,9 @@ public abstract class Highlighter {
     //
 
     protected final void addSpanGroup(final Object span, final int start, final int end) {
-        _groups.add(new SpanGroup(span, start, end));
+        if (end > start && span != null) {
+            _groups.add(new SpanGroup(span, start, end));
+        }
     }
 
     protected final void createSpanForMatches(final Pattern pattern, Callback.r1<Object, Matcher> creator, int... groupsToMatch) {

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -19,7 +19,6 @@ import android.text.InputFilter;
 import android.text.Layout;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
@@ -33,7 +32,6 @@ import net.gsantner.markor.ui.DraggableScrollbarScrollView;
 import net.gsantner.markor.util.AppSettings;
 import net.gsantner.opoc.android.dummy.TextWatcherDummy;
 import net.gsantner.opoc.util.Callback;
-import net.gsantner.opoc.util.NanoProfiler;
 import net.gsantner.opoc.util.StringUtils;
 
 @SuppressWarnings("UnusedReturnValue")
@@ -44,8 +42,6 @@ public class HighlightingEditor extends AppCompatEditText {
     final static long BRING_CURSOR_INTO_VIEW_DELAY_MS = 250; // Block auto-scrolling for time after highlighing (hack)
 
     public final static String PLACE_CURSOR_HERE_TOKEN = "%%PLACE_CURSOR_HERE%%";
-
-    private NanoProfiler _p = new NanoProfiler();
 
     private long _minPointIntoViewTime = 0;
     private int _blockBringPointIntoViewCount = 0;
@@ -97,6 +93,9 @@ public class HighlightingEditor extends AppCompatEditText {
         final ViewTreeObserver observer = getViewTreeObserver();
         observer.addOnScrollChangedListener(this::updateDynamicHighlighting);
         observer.addOnGlobalLayoutListener(this::updateDynamicHighlighting);
+
+        // Fix for android 12 perf issues - https://github.com/gsantner/markor/discussions/1794
+        setEmojiCompatEnabled(false);
     }
 
     // Highlighting

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -279,7 +279,7 @@ public class HighlightingEditor extends AppCompatEditText {
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
-        updateDynamicHighlighting();
+        post(this::updateDynamicHighlighting);
     }
 
     @Override

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -132,7 +132,7 @@ public class HighlightingEditor extends AppCompatEditText {
                 final float oldOffset = _hl.yOffset(shiftTestIndex);
 
                 withAccessibilityDisabled(() -> {
-                    // Hack to prevent scrolling to cursor. Time based blocking _may_ fail though.
+                    // Hack to prevent scrolling to cursor
                     blockBringPointIntoView();
                     _hl.clear();
                     if (recompute) {

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -116,7 +116,8 @@ public class HighlightingEditor extends AppCompatEditText {
     }
 
     private void updateHighlighting(final boolean recompute) {
-        if (!_isUpdatingDynamicHighlighting && _hlEnabled && _hl != null && getLayout() != null) {
+        final Layout layout = getLayout();
+        if (!_isUpdatingDynamicHighlighting && _hlEnabled && _hl != null && layout != null) {
             _isUpdatingDynamicHighlighting = true; // Don't enter here if already applying highlighting
 
             final Rect rect = new Rect();
@@ -129,8 +130,8 @@ public class HighlightingEditor extends AppCompatEditText {
                 // we compute the resulting shift and scroll the view to compensate in order to make
                 // the experience smooth for the user
                 final int middleY = Math.round(0.5f * (rect.top + rect.bottom));
-                final int shiftTestIndex = rowStart(middleY);
-                final float oldOffset = _hl.yOffset(shiftTestIndex);
+                final int shiftTestLine = layout.getLineForVertical(middleY);
+                final int oldOffset = layout.getLineBaseline(shiftTestLine);
 
                 withAccessibilityDisabled(() -> {
                     // Hack to prevent scrolling to cursor
@@ -142,12 +143,12 @@ public class HighlightingEditor extends AppCompatEditText {
                     _hl.apply(hlRegion(middleY, rect.height()));
                 });
 
-                _hlRect = rect;
-
-                final int shift = Math.round(_hl.yOffset(shiftTestIndex) - oldOffset);
-                if (_scrollView != null && shift != 0) {
+                final int shift = layout.getLineBaseline(shiftTestLine) - oldOffset;
+                if (_scrollView != null && Math.abs(shift) > 1) {
                     _scrollView.slowScrollShift(shift);
                 }
+
+                _hlRect = rect;
             }
 
             _isUpdatingDynamicHighlighting = false;

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/HighlightingEditor.java
@@ -259,13 +259,6 @@ public class HighlightingEditor extends AppCompatEditText {
         }
     }
 
-    // We don't want to save instance state - will be re-created anew
-    @SuppressLint("MissingSuperCall")
-    @Override
-    public Parcelable onSaveInstanceState() {
-        return new Bundle();
-    }
-
     @Override
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);

--- a/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/ui/FilesystemViewerFragment.java
@@ -566,7 +566,9 @@ public class FilesystemViewerFragment extends GsFragmentBase
     }
 
     public void clearSelection() {
-        _filesystemViewerAdapter.unselectAll();
+        if (_filesystemViewerAdapter != null) { // Happens when restoring after rotation etc
+            _filesystemViewerAdapter.unselectAll();
+        }
     }
 
 

--- a/app/src/main/java/net/gsantner/opoc/util/TextViewUndoRedo.java
+++ b/app/src/main/java/net/gsantner/opoc/util/TextViewUndoRedo.java
@@ -92,9 +92,7 @@ public class TextViewUndoRedo {
     }
 
     public void setTextView(TextView textView) {
-        if (mTextView != null) {
-            mTextView.removeTextChangedListener(mChangeListener);
-        }
+        disconnect();
         mTextView = textView;
         mTextView.addTextChangedListener(mChangeListener);
     }
@@ -109,7 +107,9 @@ public class TextViewUndoRedo {
      * Disconnect this undo/redo from the text view.
      */
     public void disconnect() {
-        mTextView.removeTextChangedListener(mChangeListener);
+        if (mTextView != null) {
+            mTextView.removeTextChangedListener(mChangeListener);
+        }
     }
 
     /**

--- a/app/src/main/res/layout/main__activity.xml
+++ b/app/src/main/res/layout/main__activity.xml
@@ -36,7 +36,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/main__view_pager_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -455,4 +455,5 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="auto_format">Auto-format</string>
     <string name="insert_snippet">Insert snippet</string>
     <string name="document_error_exit_message">Error encountered. Exiting to minimize data loss.</string>
+    <string name="save_error_clipboard">Save error. Document copied to clipboard.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,6 +456,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="share_into_format">Share into - Format</string>
     <string name="auto_format">Auto-format</string>
     <string name="insert_snippet">Insert snippet</string>
-    <string name="document_error_exit_message">Error encountered. Exiting to minimize data loss.</string>
-    <string name="save_error_clipboard">Save error. Document copied to clipboard.</string>
+    <string name="document_error_exit">Error: Could not open.</string>
+    <string name="document_error_clip">Error encountered: Text copied to clipboard.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -454,4 +454,5 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="share_into_format">Share into - Format</string>
     <string name="auto_format">Auto-format</string>
     <string name="insert_snippet">Insert snippet</string>
+    <string name="document_error_exit_message">Error encountered. Exiting to minimize data loss.</string>
 </resources>

--- a/app/thirdparty/java/other/writeily/format/WrProportionalHeaderSpanCreator.java
+++ b/app/thirdparty/java/other/writeily/format/WrProportionalHeaderSpanCreator.java
@@ -33,7 +33,7 @@ public class WrProportionalHeaderSpanCreator {
         return new LargerHeaderSpan(_color, _textSize, proportion);
     }
 
-    public static class LargerHeaderSpan extends CharacterStyle implements LineHeightSpan, UpdateLayout, Highlighter.ShiftY {
+    public static class LargerHeaderSpan extends CharacterStyle implements LineHeightSpan, UpdateLayout {
 
         final @ColorInt int _color;
         final float _headerSize;
@@ -55,11 +55,6 @@ public class WrProportionalHeaderSpanCreator {
         @Override
         public void chooseHeight(CharSequence charSequence, int i, int i1, int i2, int i3, Paint.FontMetricsInt fontMetricsInt) {
             fontMetricsInt.ascent -= _offset;
-        }
-
-        @Override
-        public float yShift(CharSequence text, int spanStart, int spanEnd, int index) {
-            return index >= spanStart ? _offset : 0;
         }
     }
 }


### PR DESCRIPTION
In this PR I add several things to prevent potential data loss

1. Mod time checks are augmented with an internal time database to mitigate issues with android's buggy FS
2. `_document != null` checks are replaced with a check and exit to prevent silent write failures
3. ~~onPause and onResume are triggered in a couple more places~~

I will personally want to test this for a long time before I am comfortable merging it into master. 

Todo:

- [ ] Better messaging etc
- [ ] Logging when we encounter a bad state
- [ ] Purging the time database when it grows too big