### PR TITLE
View-Mode: Action buttons similar to Edit-Mode

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -50,6 +50,7 @@ import net.gsantner.markor.ui.FileInfoDialog;
 import net.gsantner.markor.ui.FilesystemViewerCreator;
 import net.gsantner.markor.ui.SearchOrCustomTextDialogCreator;
 import net.gsantner.markor.ui.hleditor.HighlightingEditor;
+import net.gsantner.markor.ui.hleditor.TextActions;
 import net.gsantner.markor.util.AppSettings;
 import net.gsantner.markor.util.ContextUtils;
 import net.gsantner.markor.util.MarkorWebViewClient;
@@ -618,9 +619,7 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
         _hlEditor.setDynamicHighlightingEnabled(_appSettings.isDynamicHighlightingEnabled());
         _hlEditor.setAutoFormatters(_textFormat.getAutoFormatInputFilter(), _textFormat.getAutoFormatTextWatcher());
         _hlEditor.setAutoFormatEnabled(_appSettings.getDocumentAutoFormatEnabled(_document.getPath()));
-        _textFormat.getTextActions()
-                .setHighlightingEditor(_hlEditor)
-                .appendTextActionsToBar(_textActionsBar);
+        _textFormat.getTextActions().setHighlightingEditor(_hlEditor).setWebView(_webView);
 
         updateMenuToggleStates(textFormatId);
     }
@@ -735,6 +734,7 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
 
     public void setViewModeVisibility(final boolean show) {
         final Activity activity = getActivity();
+        _textFormat.getTextActions().recreateTextActionBarButtons(_textActionsBar, show ? TextActions.ActionItem.DisplayMode.VIEW : TextActions.ActionItem.DisplayMode.EDIT);
         if (show) {
             updateViewModeText();
             new ActivityUtils(activity).hideSoftKeyboard().freeContextRef();
@@ -785,16 +785,7 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     @Override
     protected boolean onToolbarLongClicked(View v) {
         if (getUserVisibleHint()) {
-            if (_isPreviewVisible) {
-                boolean top = _webView.getScrollY() > 100;
-                _webView.scrollTo(0, top ? 0 : _webView.getContentHeight());
-                if (!top) {
-                    _webView.scrollBy(0, 1000);
-                    _webView.scrollBy(0, 1000);
-                }
-            } else {
-                _textFormat.getTextActions().runJumpBottomTopAction();
-            }
+            _textFormat.getTextActions().runJumpBottomTopAction(_isPreviewVisible ? TextActions.ActionItem.DisplayMode.VIEW : TextActions.ActionItem.DisplayMode.EDIT);
             return true;
         }
         return false;

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditFragment.java
@@ -408,12 +408,12 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        if (item == null) {
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
+        final Activity activity = getActivity();
+        if (activity == null) {
             return true;
         }
-        _shareUtil.setContext(getContext());
-        final Activity activity = getActivity();
+        _shareUtil.setContext(activity);
         final int itemId = item.getItemId();
         switch (itemId) {
             case R.id.action_undo: {
@@ -613,14 +613,17 @@ public class DocumentEditFragment extends GsFragmentBase implements TextFormat.T
     }
 
     public void applyTextFormat(final int textFormatId) {
+        final Activity activity = getActivity();
+        if (activity == null) {
+            return;
+        }
         _textActionsBar.removeAllViews();
-        _textFormat = TextFormat.getFormat(textFormatId, getActivity(), _document);
+        _textFormat = TextFormat.getFormat(textFormatId, activity, _document);
         _hlEditor.setHighlighter(_textFormat.getHighlighter());
         _hlEditor.setDynamicHighlightingEnabled(_appSettings.isDynamicHighlightingEnabled());
         _hlEditor.setAutoFormatters(_textFormat.getAutoFormatInputFilter(), _textFormat.getAutoFormatTextWatcher());
         _hlEditor.setAutoFormatEnabled(_appSettings.getDocumentAutoFormatEnabled(_document.getPath()));
-        _textFormat.getTextActions().setHighlightingEditor(_hlEditor).setWebView(_webView);
-
+        _textFormat.getTextActions().setUiReferences(activity, _hlEditor, _webView);
         updateMenuToggleStates(textFormatId);
     }
 

--- a/app/src/main/java/net/gsantner/markor/format/TextFormat.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextFormat.java
@@ -9,9 +9,11 @@
 #########################################################*/
 package net.gsantner.markor.format;
 
-import android.app.Activity;
+import android.content.Context;
 import android.text.InputFilter;
 import android.text.TextWatcher;
+
+import androidx.annotation.NonNull;
 
 import net.gsantner.markor.R;
 import net.gsantner.markor.format.keyvalue.KeyValueConverter;
@@ -85,15 +87,15 @@ public class TextFormat {
         void applyTextFormat(int textFormatId);
     }
 
-    public static TextFormat getFormat(int formatId, final Activity activity, final Document document) {
+    public static TextFormat getFormat(int formatId, @NonNull final Context context, final Document document) {
         final TextFormat format = new TextFormat();
-        final AppSettings as = new AppSettings(activity);
+        final AppSettings as = new AppSettings(context.getApplicationContext());
 
         switch (formatId) {
             case FORMAT_PLAIN: {
                 format._converter = CONVERTER_PLAINTEXT;
                 format._highlighter = new PlaintextHighlighter(as);
-                format._textActions = new PlaintextTextActions(activity, document);
+                format._textActions = new PlaintextTextActions(context, document);
                 format._autoFormatInputFilter = new MarkdownAutoFormat(); // Using the markdown syntax for plain text
                 format._autoFormatTextWatcher = new ListHandler(MarkdownAutoFormat.getPrefixPatterns());
                 break;
@@ -101,20 +103,20 @@ public class TextFormat {
             case FORMAT_TODOTXT: {
                 format._converter = CONVERTER_TODOTXT;
                 format._highlighter = new TodoTxtHighlighter(as);
-                format._textActions = new TodoTxtTextActions(activity, document);
+                format._textActions = new TodoTxtTextActions(context, document);
                 format._autoFormatInputFilter = new TodoTxtAutoFormat();
                 break;
             }
             case FORMAT_KEYVALUE: {
                 format._converter = CONVERTER_KEYVALUE;
                 format._highlighter = new KeyValueHighlighter(as);
-                format._textActions = new PlaintextTextActions(activity, document);
+                format._textActions = new PlaintextTextActions(context, document);
                 break;
             }
             case FORMAT_ZIMWIKI: {
                 format._converter = CONVERTER_ZIMWIKI;
                 format._highlighter = new ZimWikiHighlighter(as);
-                format._textActions = new ZimWikiTextActions(activity, document);
+                format._textActions = new ZimWikiTextActions(context, document);
                 format._autoFormatInputFilter = new ZimWikiAutoFormat();
                 format._autoFormatTextWatcher = new ListHandler(ZimWikiAutoFormat.getPrefixPatterns());
                 break;
@@ -123,7 +125,7 @@ public class TextFormat {
             case FORMAT_MARKDOWN: {
                 format._converter = CONVERTER_MARKDOWN;
                 format._highlighter = new MarkdownHighlighter(as);
-                format._textActions = new MarkdownTextActions(activity, document);
+                format._textActions = new MarkdownTextActions(context, document);
                 format._autoFormatInputFilter = new MarkdownAutoFormat();
                 format._autoFormatTextWatcher = new ListHandler(MarkdownAutoFormat.getPrefixPatterns());
                 break;

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
@@ -10,10 +10,10 @@
 package net.gsantner.markor.format.markdown;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
+import android.content.Context;
 import android.view.KeyEvent;
-import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
 import net.gsantner.markor.R;
@@ -29,8 +29,8 @@ import java.util.List;
 
 public class MarkdownTextActions extends TextActions {
 
-    public MarkdownTextActions(Activity activity, Document document) {
-        super(activity, document);
+    public MarkdownTextActions(@NonNull Context context, Document document) {
+        super(context, document);
     }
 
     @Override
@@ -167,7 +167,6 @@ public class MarkdownTextActions extends TextActions {
                     _hlEditor.getText().insert(_hlEditor.getSelectionEnd(), "\n```\n");
                     _hlEditor.setSelection(c + "\n```\n".length());
                 });
-                Toast.makeText(_activity, R.string.code_block, Toast.LENGTH_SHORT).show();
                 return true;
             }
             default: {

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
@@ -68,6 +68,9 @@ public class MarkdownTextActions extends TextActions {
                 new ActionItem(R.string.tmaid_common_move_text_one_line_up, R.drawable.ic_baseline_arrow_upward_24, R.string.move_text_one_line_up),
                 new ActionItem(R.string.tmaid_common_move_text_one_line_down, R.drawable.ic_baseline_arrow_downward_24, R.string.move_text_one_line_down),
                 new ActionItem(R.string.tmaid_common_insert_snippet, R.drawable.ic_baseline_file_copy_24, R.string.insert_snippet),
+
+                new ActionItem(R.string.tmaid_common_web_jump_to_very_top_or_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom, ActionItem.DisplayMode.VIEW),
+                new ActionItem(R.string.tmaid_common_web_jump_to_table_of_contents, R.drawable.ic_list_black_24dp, R.string.table_of_contents, ActionItem.DisplayMode.VIEW),
         };
 
         return Arrays.asList(TMA_ACTIONS);

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextActions.java
@@ -71,6 +71,7 @@ public class MarkdownTextActions extends TextActions {
 
                 new ActionItem(R.string.tmaid_common_web_jump_to_very_top_or_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom, ActionItem.DisplayMode.VIEW),
                 new ActionItem(R.string.tmaid_common_web_jump_to_table_of_contents, R.drawable.ic_list_black_24dp, R.string.table_of_contents, ActionItem.DisplayMode.VIEW),
+                new ActionItem(R.string.tmaid_common_rotate_screen, R.drawable.ic_rotate_left_black_24dp, R.string.rotate, ActionItem.DisplayMode.ANY),
         };
 
         return Arrays.asList(TMA_ACTIONS);

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
@@ -239,7 +239,7 @@ public class MarkdownTextConverter extends TextConverter {
             head += CSS_TOC_STYLE;
             options.set(TocExtension.LEVELS, TocOptions.getLevels(appSettings.getMarkdownTableOfContentLevels()))
                     .set(TocExtension.TITLE, context.getString(R.string.table_of_contents))
-                    .set(TocExtension.DIV_CLASS, "markor-table-of-contents")
+                    .set(TocExtension.DIV_CLASS, "markor-table-of-contents toc")
                     .set(TocExtension.LIST_CLASS, "markor-table-of-contents-list")
                     .set(TocExtension.BLANK_LINE_SPACER, false);
         }

--- a/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextActions.java
@@ -30,12 +30,10 @@ public class PlaintextTextActions extends TextActions {
 
     @Override
     public List<ActionItem> getActiveActionList() {
-
         final ActionItem[] TMA_ACTIONS = {
                 new ActionItem(R.string.tmaid_common_checkbox_list, R.drawable.ic_check_box_black_24dp, R.string.check_list),
                 new ActionItem(R.string.tmaid_common_unordered_list_char, R.drawable.ic_list_black_24dp, R.string.unordered_list),
                 new ActionItem(R.string.tmaid_common_ordered_list_number, R.drawable.ic_format_list_numbered_black_24dp, R.string.ordered_list),
-                new ActionItem(R.string.tmaid_common_jump_to_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom),
                 new ActionItem(R.string.tmaid_common_delete_lines, R.drawable.ic_delete_black_24dp, R.string.delete_lines),
                 new ActionItem(R.string.tmaid_common_open_link_browser, R.drawable.ic_open_in_browser_black_24dp, R.string.open_link),
                 new ActionItem(R.string.tmaid_common_attach_something, R.drawable.ic_attach_file_black_24dp, R.string.attach),
@@ -47,6 +45,8 @@ public class PlaintextTextActions extends TextActions {
                 new ActionItem(R.string.tmaid_common_move_text_one_line_up, R.drawable.ic_baseline_arrow_upward_24, R.string.move_text_one_line_up),
                 new ActionItem(R.string.tmaid_common_move_text_one_line_down, R.drawable.ic_baseline_arrow_downward_24, R.string.move_text_one_line_down),
                 new ActionItem(R.string.tmaid_common_insert_snippet, R.drawable.ic_baseline_file_copy_24, R.string.insert_snippet),
+
+                new ActionItem(R.string.tmaid_common_web_jump_to_very_top_or_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom, ActionItem.DisplayMode.VIEW),
         };
 
         return Arrays.asList(TMA_ACTIONS);

--- a/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextActions.java
@@ -47,6 +47,8 @@ public class PlaintextTextActions extends TextActions {
                 new ActionItem(R.string.tmaid_common_insert_snippet, R.drawable.ic_baseline_file_copy_24, R.string.insert_snippet),
 
                 new ActionItem(R.string.tmaid_common_web_jump_to_very_top_or_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom, ActionItem.DisplayMode.VIEW),
+                new ActionItem(R.string.tmaid_common_view_file_in_other_app, R.drawable.ic_open_in_browser_black_24dp, R.string.open_with, ActionItem.DisplayMode.ANY),
+                new ActionItem(R.string.tmaid_common_rotate_screen, R.drawable.ic_rotate_left_black_24dp, R.string.rotate, ActionItem.DisplayMode.ANY),
         };
 
         return Arrays.asList(TMA_ACTIONS);

--- a/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextActions.java
@@ -9,8 +9,9 @@
 #########################################################*/
 package net.gsantner.markor.format.plaintext;
 
-import android.app.Activity;
+import android.content.Context;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
 import net.gsantner.markor.R;
@@ -24,8 +25,8 @@ import java.util.List;
 
 public class PlaintextTextActions extends TextActions {
 
-    public PlaintextTextActions(Activity activity, Document document) {
-        super(activity, document);
+    public PlaintextTextActions(@NonNull Context context, Document document) {
+        super(context, document);
     }
 
     @Override

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
@@ -65,6 +65,8 @@ public class TodoTxtTextActions extends TextActions {
                 new ActionItem(R.string.tmaid_common_move_text_one_line_up, R.drawable.ic_baseline_arrow_upward_24, R.string.move_text_one_line_up),
                 new ActionItem(R.string.tmaid_common_move_text_one_line_down, R.drawable.ic_baseline_arrow_downward_24, R.string.move_text_one_line_down),
                 new ActionItem(R.string.tmaid_common_insert_snippet, R.drawable.ic_baseline_file_copy_24, R.string.insert_snippet),
+
+                new ActionItem(R.string.tmaid_common_web_jump_to_very_top_or_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom, ActionItem.DisplayMode.VIEW),
         };
 
         return Arrays.asList(TMA_ACTIONS);

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
@@ -12,6 +12,7 @@ package net.gsantner.markor.format.todotxt;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.DatePickerDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.text.Editable;
@@ -42,8 +43,8 @@ public class TodoTxtTextActions extends TextActions {
 
     private static final String LAST_SORT_ORDER_KEY = TodoTxtTextActions.class.getCanonicalName() + "_last_sort_order_key";
 
-    public TodoTxtTextActions(Activity activity, Document document) {
-        super(activity, document);
+    public TodoTxtTextActions(@NonNull Context context, Document document) {
+        super(context, document);
     }
 
     @Override
@@ -348,8 +349,8 @@ public class TodoTxtTextActions extends TextActions {
                 .setActivity(_activity)
                 .setListener(listener)
                 .setCalendar(initDate)
-                .setMessage(_context.getString(R.string.due_date))
-                .setExtraLabel(_context.getString(R.string.clear))
+                .setMessage(getContext().getString(R.string.due_date))
+                .setExtraLabel(getContext().getString(R.string.clear))
                 .setExtraListener(clear)
                 .show(((FragmentActivity) _activity).getSupportFragmentManager(), "date");
     }

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTextActions.java
@@ -67,6 +67,7 @@ public class TodoTxtTextActions extends TextActions {
                 new ActionItem(R.string.tmaid_common_insert_snippet, R.drawable.ic_baseline_file_copy_24, R.string.insert_snippet),
 
                 new ActionItem(R.string.tmaid_common_web_jump_to_very_top_or_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom, ActionItem.DisplayMode.VIEW),
+                new ActionItem(R.string.tmaid_common_rotate_screen, R.drawable.ic_rotate_left_black_24dp, R.string.rotate, ActionItem.DisplayMode.ANY),
         };
 
         return Arrays.asList(TMA_ACTIONS);

--- a/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiTextActions.java
@@ -74,6 +74,9 @@ public class ZimWikiTextActions extends net.gsantner.markor.ui.hleditor.TextActi
                 new ActionItem(R.string.tmaid_common_move_text_one_line_up, R.drawable.ic_baseline_arrow_upward_24, R.string.move_text_one_line_up),
                 new ActionItem(R.string.tmaid_common_move_text_one_line_down, R.drawable.ic_baseline_arrow_downward_24, R.string.move_text_one_line_down),
                 new ActionItem(R.string.tmaid_common_insert_snippet, R.drawable.ic_baseline_file_copy_24, R.string.insert_snippet),
+
+                new ActionItem(R.string.tmaid_common_web_jump_to_very_top_or_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom, ActionItem.DisplayMode.VIEW),
+                new ActionItem(R.string.tmaid_common_web_jump_to_table_of_contents, R.drawable.ic_list_black_24dp, R.string.table_of_contents, ActionItem.DisplayMode.VIEW),
         };
 
         return Arrays.asList(ZIMWIKI_ACTIONS);

--- a/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiTextActions.java
@@ -77,6 +77,7 @@ public class ZimWikiTextActions extends net.gsantner.markor.ui.hleditor.TextActi
 
                 new ActionItem(R.string.tmaid_common_web_jump_to_very_top_or_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom, ActionItem.DisplayMode.VIEW),
                 new ActionItem(R.string.tmaid_common_web_jump_to_table_of_contents, R.drawable.ic_list_black_24dp, R.string.table_of_contents, ActionItem.DisplayMode.VIEW),
+                new ActionItem(R.string.tmaid_common_rotate_screen, R.drawable.ic_rotate_left_black_24dp, R.string.rotate, ActionItem.DisplayMode.ANY),
         };
 
         return Arrays.asList(ZIMWIKI_ACTIONS);

--- a/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiTextActions.java
+++ b/app/src/main/java/net/gsantner/markor/format/zimwiki/ZimWikiTextActions.java
@@ -9,10 +9,11 @@
 #########################################################*/
 package net.gsantner.markor.format.zimwiki;
 
-import android.app.Activity;
+import android.content.Context;
 import android.os.Build;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
 import net.gsantner.markor.R;
@@ -34,8 +35,8 @@ import java.util.regex.Matcher;
 
 public class ZimWikiTextActions extends net.gsantner.markor.ui.hleditor.TextActions {
 
-    public ZimWikiTextActions(Activity activity, Document document) {
-        super(activity, document);
+    public ZimWikiTextActions(@NonNull Context context, Document document) {
+        super(context, document);
     }
 
     @Override

--- a/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
+++ b/app/src/main/java/net/gsantner/markor/ui/hleditor/TextActions.java
@@ -44,7 +44,7 @@ import net.gsantner.markor.util.ActivityUtils;
 import net.gsantner.markor.util.AppSettings;
 import net.gsantner.opoc.format.plaintext.PlainTextStuff;
 import net.gsantner.opoc.util.Callback;
-import net.gsantner.opoc.util.ContextUtils;
+import net.gsantner.opoc.util.FileUtils;
 import net.gsantner.opoc.util.StringUtils;
 
 import java.util.ArrayList;
@@ -257,7 +257,7 @@ public abstract class TextActions {
         final Set<String> disabledKeys = new HashSet<>(getDisabledActions());
         for (final String key : orderedKeys) {
             final ActionItem action = map.get(key);
-            if (!disabledKeys.contains(key) && action.displayMode == displayMode) {
+            if (!disabledKeys.contains(key) && (action.displayMode == displayMode || action.displayMode == ActionItem.DisplayMode.ANY)) {
                 appendTextActionToBar(barLayout, action.iconId, action.stringId, action.keyId);
             }
         }
@@ -632,7 +632,7 @@ public abstract class TextActions {
                     if (url.endsWith(")")) {
                         url = url.substring(0, url.length() - 1);
                     }
-                    new ContextUtils(_activity).openWebpageInExternalBrowser(url);
+                    _au.openWebpageInExternalBrowser(url);
                 }
                 return true;
             }
@@ -660,6 +660,14 @@ public abstract class TextActions {
             }
             case R.string.tmaid_common_web_jump_to_table_of_contents: {
                 m_webView.loadUrl("javascript:document.getElementsByClassName('toc')[0].scrollIntoView();");
+                return true;
+            }
+            case R.string.tmaid_common_view_file_in_other_app: {
+                _au.viewFileInOtherApp(_document.getFile(), FileUtils.getMimeType(_document.getFile()));
+                return true;
+            }
+            case R.string.tmaid_common_rotate_screen: {
+                _au.nextScreenRotationSetting();
                 return true;
             }
         }
@@ -721,7 +729,7 @@ public abstract class TextActions {
         public int stringId;
         public DisplayMode displayMode;
 
-        public enum DisplayMode {EDIT, VIEW}
+        public enum DisplayMode {EDIT, VIEW, ANY}
 
         public ActionItem(@StringRes int key, @DrawableRes int icon, @StringRes int string, final DisplayMode... a_displayMode) {
             keyId = key;

--- a/app/src/main/java/net/gsantner/opoc/util/ActivityUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/ActivityUtils.java
@@ -1,15 +1,12 @@
 /*#######################################################
  *
- *   Maintained by Gregor Santner, 2016-
- *   https://gsantner.net/
- *
- *   License of this file: Apache 2.0 (Commercial upon request)
- *     https://www.apache.org/licenses/LICENSE-2.0
- *     https://github.com/gsantner/opoc/#licensing
+ * SPDX-FileCopyrightText: 2016-2022 Gregor Santner <https://gsantner.net/>
+ * SPDX-License-Identifier: Unlicense OR CC0-1.0
  *
 #########################################################*/
 package net.gsantner.opoc.util;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.ActivityNotFoundException;
@@ -17,6 +14,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.res.TypedArray;
 import android.net.Uri;
@@ -33,6 +31,7 @@ import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.WebView;
 import android.widget.ScrollView;
+import android.widget.Toast;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.StringRes;
@@ -49,7 +48,7 @@ import java.util.List;
 
 
 @SuppressWarnings({"WeakerAccess", "unused", "SameParameterValue", "SpellCheckingInspection", "rawtypes", "UnusedReturnValue"})
-public class ActivityUtils extends net.gsantner.opoc.util.ContextUtils {
+public class ActivityUtils extends net.gsantner.opoc.util.ShareUtil {
     //########################
     //## Members, Constructors
     //########################
@@ -379,6 +378,7 @@ public class ActivityUtils extends net.gsantner.opoc.util.ContextUtils {
      *
      * @param pref one out of system (daynight toggle), auto (daynight hour), autocompat (hour 5-17), light (fixed), dark (fixed)
      */
+    @SuppressLint("WrongConstant")
     public static void applyDayNightTheme(final String pref) {
         final boolean prefLight = pref.contains("light") || ("autocompat".equals(pref) && SharedPreferencesPropertyBackend.isCurrentHourOfDayBetween(9, 17));
         final boolean prefDark = pref.contains("dark") || ("autocompat".equals(pref) && !SharedPreferencesPropertyBackend.isCurrentHourOfDayBetween(9, 17));
@@ -392,5 +392,37 @@ public class ActivityUtils extends net.gsantner.opoc.util.ContextUtils {
         } else if ("auto".equals(pref)) {
             AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
         }
+    }
+
+
+    public void nextScreenRotationSetting() {
+        String text = "";
+        int nextOrientation;
+        switch (_activity.getRequestedOrientation()) {
+            case ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE: {
+                nextOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+                text = "Portrait";
+                break;
+            }
+            case ActivityInfo.SCREEN_ORIENTATION_PORTRAIT: {
+                nextOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR;
+                text = "Sensor";
+                break;
+            }
+            case ActivityInfo.SCREEN_ORIENTATION_SENSOR: {
+                nextOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+                text = "Default";
+                break;
+            }
+            default: {
+                nextOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+                text = "Landscape";
+                break;
+            }
+        }
+        int resId = getResId(ResType.STRING, text);
+        text = (resId != 0 ? _context.getString(resId) : text);
+        Toast.makeText(_context, text, Toast.LENGTH_SHORT).show();
+        _activity.setRequestedOrientation(nextOrientation);
     }
 }

--- a/app/src/main/java/net/gsantner/opoc/util/ShareUtil.java
+++ b/app/src/main/java/net/gsantner/opoc/util/ShareUtil.java
@@ -94,7 +94,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * (M)Permissions are not checked, wrap ShareUtils methods if neccessary
  */
 @SuppressWarnings({"UnusedReturnValue", "WeakerAccess", "SameParameterValue", "unused", "deprecation", "ConstantConditions", "ObsoleteSdkInt", "SpellCheckingInspection", "JavadocReference", "ConstantLocale", "ComparatorCombinators"})
-public class ShareUtil {
+public class ShareUtil extends ContextUtils {
     public final static String EXTRA_FILEPATH = "real_file_path_2";
     public final static SimpleDateFormat DATEFORMAT_RFC3339ISH = new SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss", Locale.getDefault());
     public final static SimpleDateFormat DATEFORMAT_IMG = new SimpleDateFormat("yyyyMMdd-HHmmss", Locale.getDefault()); //20190511-230845
@@ -117,16 +117,13 @@ public class ShareUtil {
     protected String _chooserTitle;
 
     public ShareUtil(final Context context) {
+        super(context);
         _context = context;
         _chooserTitle = "➥";
     }
 
     public void setContext(final Context c) {
         _context = c;
-    }
-
-    public void freeContextRef() {
-        _context = null;
     }
 
     public String getFileProviderAuthority() {

--- a/app/src/main/res/layout/document__fragment__edit.xml
+++ b/app/src/main/res/layout/document__fragment__edit.xml
@@ -78,6 +78,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/background"
+        android:layout_marginBottom="@dimen/textactions_bar_height"
         android:visibility="gone" />
 
     <FrameLayout

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -217,6 +217,8 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="tmaid_common_time_insert_timestamp" translatable="false">tmaid_common_time_insert_timestamp</string>
     <string name="tmaid_common_web_jump_to_very_top_or_bottom" translatable="false">tmaid_common_web_jump_to_very_top_or_bottom</string>
     <string name="tmaid_common_web_jump_to_table_of_contents" translatable="false">tmaid_common_web_jump_to_table_of_contents</string>
+    <string name="tmaid_common_view_file_in_other_app" translatable="false">tmaid_common_view_file_in_other_app</string>
+    <string name="tmaid_common_rotate_screen" translatable="false">tmaid_common_rotate_screen</string>
     <string name="tmaid_common_accordion" translatable="false">tmaid_common_accordion</string>
     <string name="tmaid_common_indent" translatable="false">tmaid_common_indent</string>
     <string name="tmaid_common_set_indent_size" translatable="false">tmaid_common_set_indent_size</string>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -215,7 +215,8 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="tmaid_common_color_picker" translatable="false">tmaid_common_color_picker</string>
     <string name="tmaid_common_time" translatable="false">tmaid_common_time</string>
     <string name="tmaid_common_time_insert_timestamp" translatable="false">tmaid_common_time_insert_timestamp</string>
-    <string name="tmaid_common_jump_to_bottom" translatable="false">tmaid_common_jump_to_bottom</string>
+    <string name="tmaid_common_web_jump_to_very_top_or_bottom" translatable="false">tmaid_common_web_jump_to_very_top_or_bottom</string>
+    <string name="tmaid_common_web_jump_to_table_of_contents" translatable="false">tmaid_common_web_jump_to_table_of_contents</string>
     <string name="tmaid_common_accordion" translatable="false">tmaid_common_accordion</string>
     <string name="tmaid_common_indent" translatable="false">tmaid_common_indent</string>
     <string name="tmaid_common_set_indent_size" translatable="false">tmaid_common_set_indent_size</string>


### PR DESCRIPTION
Enable the bottom action bar also for view mode and populate some actions. Automatically swaps list of actions which are either available to edit-only, view-only or both.

Example actions implemented:
* jump to top/bottom
* jump to TableOfContents
* open filie in other app
* rotate screen

All of these I remember to being asked at least once and users being confused. So now with that addition users can jump to the table of contents for example just with one click reachable by thumb.

new functionality for opoc utils: rotate screen (automatically jumps in round between default->landscape->portrait->sensor->default)


possible future additions, using these buttons:
* #699 

![screenshot-2022-08-21__18-38-26](https://user-images.githubusercontent.com/6735650/185801554-5cabe7c6-8b1c-4492-8e7a-98a270ad63b2.png)
