### PR TITLE
Remove ambiguity and streamline checklist items in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -18,7 +18,7 @@ body:
           required: true
         - label: Markor **is** up to date. See [Releases](https://github.com/gsantner/markor/tags) for the latest version. Updates are available from [F-Droid](https://f-droid.org/en/packages/net.gsantner.markor/) and GitHub. 
           required: true
-        - label: Is the bug still present in the latest code version (git master)? Please [download](https://nightly.link/gsantner/markor/workflows/build-android-project/master) and try the test version of Markor, named **Mordor**. No worries Markor and Mordor appear as completely separate applications, you can install both side-by-side and Markor settings are not touched. In case the issue is resolved there, you don't need to create a bug report - the change will be part of the next Markor update.
+        - label: The bug is not present in the latest code version (git master). (Please [download](https://nightly.link/gsantner/markor/workflows/build-android-project/master) and try the test version of Markor, named **Mordor**. Don't worry; Markor and Mordor appear as completely separate applications. You can install both side-by-side, and Markor settings are not touched. In case the issue is resolved there, you don't need to create a bug report. The change will be part of the next Markor update.)
           required: true
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -18,7 +18,7 @@ body:
           required: true
         - label: Markor **is** up to date. See [Releases](https://github.com/gsantner/markor/tags) for the latest version. Updates are available from [F-Droid](https://f-droid.org/en/packages/net.gsantner.markor/) and GitHub. 
           required: true
-        - label: Is the wanted feature/enhancement present in the latest code version (git master)? Please [download](https://nightly.link/gsantner/markor/workflows/build-android-project/master) and try the test version of Markor, named **Mordor**. No worries Markor and Mordor appear as completely separate applications, you can install both side-by-side and Markor settings are not touched. If so, the change will be part of the next Markor update.
+        - label: The wanted feature/enhancement is not present in the latest code version (git master). (Please [download](https://nightly.link/gsantner/markor/workflows/build-android-project/master) and try the test version of Markor, named **Mordor**. Don't worry; Markor and Mordor appear as completely separate applications. You can install both side-by-side, and Markor's settings are not touched. If your desired feature is present, you don't need to open this issue. The change will be part of the next Markor update.
           required: true
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -18,7 +18,7 @@ body:
           required: true
         - label: Markor **is** up to date. See [Releases](https://github.com/gsantner/markor/tags) for the latest version. Updates are available from [F-Droid](https://f-droid.org/en/packages/net.gsantner.markor/) and GitHub. 
           required: true
-        - label: The wanted feature/enhancement is not present in the latest code version (git master). (Please [download](https://nightly.link/gsantner/markor/workflows/build-android-project/master) and try the test version of Markor, named **Mordor**. Don't worry; Markor and Mordor appear as completely separate applications. You can install both side-by-side, and Markor's settings are not touched. If your desired feature is present, you don't need to open this issue. The change will be part of the next Markor update.
+        - label: The wanted feature/enhancement is not present in the latest code version (git master). (Please [download](https://nightly.link/gsantner/markor/workflows/build-android-project/master) and try the test version of Markor, named **Mordor**. Don't worry; Markor and Mordor appear as completely separate applications. You can install both side-by-side, and Markor's settings are not touched. If your desired feature is present, you don't need to open this issue. The change will be part of the next Markor update.)
           required: true
   - type: textarea
     id: description


### PR DESCRIPTION
That last checklist item is ambiguous. Should you check the box or not if the answer is yes or no? I've changed the wording to make it more straightforward, and also harmonised the two versions in each template.