### PR TITLE
Fix undo-redo crash on toolbar click, by @gsantner

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
@@ -346,16 +346,12 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
     }
 
     private void updateUndoRedoIconStates() {
-        if (_editTextUndoRedoHelper == null) {
-            return;
-        }
-
-        final boolean canUndo = _editTextUndoRedoHelper.getCanUndo();
+        final boolean canUndo = _editTextUndoRedoHelper != null && _editTextUndoRedoHelper.getCanUndo();
         if (_undoMenuItem != null && _undoMenuItem.isEnabled() != canUndo) {
             _undoMenuItem.setEnabled(canUndo).getIcon().mutate().setAlpha(canUndo ? 255 : 40);
         }
 
-        final boolean canRedo = _editTextUndoRedoHelper.getCanRedo();
+        final boolean canRedo = _editTextUndoRedoHelper != null && _editTextUndoRedoHelper.getCanRedo();
         if (_redoMenuItem != null && _redoMenuItem.isEnabled() != canRedo) {
             _redoMenuItem.setEnabled(canRedo).getIcon().mutate().setAlpha(canRedo ? 255 : 40);
         }
@@ -413,14 +409,14 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
         final int itemId = item.getItemId();
         switch (itemId) {
             case R.id.action_undo: {
-                if (_editTextUndoRedoHelper.getCanUndo()) {
+                if (_editTextUndoRedoHelper != null && _editTextUndoRedoHelper.getCanUndo()) {
                     _hlEditor.withAutoFormatDisabled(_editTextUndoRedoHelper::undo);
                     updateUndoRedoIconStates();
                 }
                 return true;
             }
             case R.id.action_redo: {
-                if (_editTextUndoRedoHelper.getCanRedo()) {
+                if (_editTextUndoRedoHelper != null && _editTextUndoRedoHelper.getCanRedo()) {
                     _hlEditor.withAutoFormatDisabled(_editTextUndoRedoHelper::redo);
                     updateUndoRedoIconStates();
                 }

--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -728,8 +728,8 @@ public class GsFileUtils {
         if (filesToSort != null) {
             try {
                 Collections.sort(filesToSort, mainComparator);
-            } catch (Exception ignored) {
-                ignored.printStackTrace();
+            } catch (Exception e) {
+                e.printStackTrace();
             }
         }
 


### PR DESCRIPTION
(Except the usual OutOfMemory errors) this undo-redo crash is the other most notable issue crashing Markor v2.10.4.

The issue is that the undo/redo buttons enabled state is currently only updated when the undoRedoHelper is not null. However there can seemingly be a case where the helper is still null, but the toolbar buttons remain clickable.

This PR properly updates the undo/redo toolbar buttons and adds a null check to the button execution code as well enable state code.

![image](https://user-images.githubusercontent.com/6735650/193454861-cb0257a6-355d-4b9d-8c33-d3d6dd2e2ad8.png)

![image](https://user-images.githubusercontent.com/6735650/193454881-880e57ca-fc45-4d94-aeaa-d73ad22974a6.png)
