### PR TITLE
Unify file opening functionalities, binary handling improvements, widget open non-supported files in external app

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
@@ -34,7 +34,6 @@ import com.google.android.material.navigation.NavigationBarView;
 
 import net.gsantner.markor.BuildConfig;
 import net.gsantner.markor.R;
-import net.gsantner.markor.format.FormatRegistry;
 import net.gsantner.markor.frontend.NewFileDialog;
 import net.gsantner.markor.frontend.filebrowser.MarkorFileBrowserFactory;
 import net.gsantner.markor.frontend.settings.MarkorPermissionChecker;
@@ -398,13 +397,7 @@ public class MainActivity extends MarkorBaseActivity implements GsFileBrowserFra
 
                 @Override
                 public void onFsViewerSelected(String request, File file, final Integer lineNumber) {
-                    if (FormatRegistry.isTextFile(file)) {
-                        DocumentActivity.launch(MainActivity.this, file, null, null, lineNumber);
-                    } else if (file.getName().toLowerCase().endsWith(".apk")) {
-                        _cu.requestApkInstallation(MainActivity.this, file);
-                    } else {
-                        DocumentActivity.askUserIfWantsToOpenFileInThisApp(MainActivity.this, file);
-                    }
+                    DocumentActivity.handleFileClick(MainActivity.this, file, lineNumber);
                 }
             });
         }

--- a/app/src/main/java/net/gsantner/markor/format/FormatRegistry.java
+++ b/app/src/main/java/net/gsantner/markor/format/FormatRegistry.java
@@ -40,7 +40,6 @@ import net.gsantner.markor.frontend.textview.ListHandler;
 import net.gsantner.markor.frontend.textview.SyntaxHighlighterBase;
 import net.gsantner.markor.model.AppSettings;
 import net.gsantner.markor.model.Document;
-import net.gsantner.opoc.util.GsFileUtils;
 
 import java.io.File;
 import java.util.Locale;
@@ -73,22 +72,20 @@ public class FormatRegistry {
             CONVERTER_EMBEDBINARY,
     };
 
-    public static boolean isTextFile(final String absolutePath) {
-        return isTextFile(new File(absolutePath));
-    }
-
-    public static boolean isTextFile(final File file) {
-        if (file == null) {
-            return false;
-        }
-        final String filepath = file.getAbsolutePath().toLowerCase(Locale.ROOT);
-        for (TextConverterBase converter : CONVERTERS) {
-            if (converter.isFileOutOfThisFormat(filepath)) {
-                return true;
+    public static boolean isFileSupported(final File file, final boolean... textOnly) {
+        boolean textonly = textOnly != null && textOnly.length > 0 && textOnly[0];
+        if (file != null) {
+            final String filepath = file.getAbsolutePath().toLowerCase(Locale.ROOT);
+            for (TextConverterBase converter : CONVERTERS) {
+                if (textonly && converter instanceof EmbedBinaryTextConverter) {
+                    continue;
+                }
+                if (converter.isFileOutOfThisFormat(filepath)) {
+                    return true;
+                }
             }
         }
-
-        return GsFileUtils.isTextFile(file);
+        return false;
     }
 
     public interface TextFormatApplier {

--- a/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextConverter.java
@@ -90,10 +90,6 @@ public class PlaintextTextConverter extends TextConverterBase {
 
     @Override
     protected boolean isFileOutOfThisFormat(String filepath, String extWithDot) {
-        boolean ok = EXT.contains(extWithDot) || _appSettings.isExtOpenWithThisApp(extWithDot);
-        if (!ok) {
-            ok = GsFileUtils.getMimeType(new File(filepath)).startsWith("text/");
-        }
-        return ok;
+        return EXT.contains(extWithDot) || _appSettings.isExtOpenWithThisApp(extWithDot) || GsFileUtils.isTextFile(new File(filepath));
     }
 }

--- a/app/src/main/java/net/gsantner/markor/frontend/filesearch/FileSearchEngine.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/filesearch/FileSearchEngine.java
@@ -225,7 +225,7 @@ public class FileSearchEngine {
                         }
 
                         if (_config.isSearchInContent) {
-                            if (!FormatRegistry.isTextFile(f.getName())) {
+                            if (!FormatRegistry.isFileSupported(f, true)) {
                                 continue;
                             }
                             List<Pair<String, Integer>> contentMatches = getContentMatches(f, _config.isOnlyFirstContentMatch);

--- a/app/src/main/java/net/gsantner/markor/web/MarkorWebViewClient.java
+++ b/app/src/main/java/net/gsantner/markor/web/MarkorWebViewClient.java
@@ -11,16 +11,12 @@ package net.gsantner.markor.web;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import net.gsantner.markor.ApplicationObject;
 import net.gsantner.markor.activity.DocumentActivity;
-import net.gsantner.markor.activity.MainActivity;
-import net.gsantner.markor.format.FormatRegistry;
 import net.gsantner.markor.model.AppSettings;
-import net.gsantner.markor.model.Document;
 import net.gsantner.markor.util.MarkorContextUtils;
 
 import java.io.File;
@@ -50,27 +46,14 @@ public class MarkorWebViewClient extends WebViewClient {
             } else if (url.startsWith("file://")) {
                 MarkorContextUtils su = new MarkorContextUtils(view.getContext());
                 File file = new File(URLDecoder.decode(url.replace("file://", "")));
-                String mimetype;
                 for (String str : new String[]{file.getAbsolutePath(), file.getAbsolutePath().replaceFirst("[#].*$", ""), file.getAbsolutePath() + ".md", file.getAbsolutePath() + ".txt"}) {
                     File f = new File(str);
-                    if (f.exists() && FormatRegistry.isTextFile(f)) {
+                    if (f.exists()) {
                         file = f;
                         break;
                     }
                 }
-                if (file.isDirectory()) {
-                    _activity.startActivity(new Intent(_activity, MainActivity.class)
-                            .putExtra(Document.EXTRA_PATH, file));
-                } else if (FormatRegistry.isTextFile(file)) {
-                    _activity.startActivity(new Intent(_activity, DocumentActivity.class)
-                            .putExtra(Document.EXTRA_PATH, file));
-                } else if (file.getName().toLowerCase().endsWith(".apk")) {
-                    su.requestApkInstallation(context, file);
-                } else if ((mimetype = su.getMimeType(_activity, url)) != null) {
-                    su.viewFileInOtherApp(context, file, mimetype);
-                } else {
-                    su.viewFileInOtherApp(context, file, null);
-                }
+                DocumentActivity.handleFileClick(_activity, file, null);
             } else {
                 MarkorContextUtils su = new MarkorContextUtils(_activity);
                 AppSettings settings = ApplicationObject.settings();

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
@@ -238,7 +238,7 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
             }
         }
         for (final File f : _filesystemViewerAdapter.getCurrentSelection()) {
-            selTextFilesOnly &= FormatRegistry.isTextFile(f);
+            selTextFilesOnly &= FormatRegistry.isFileSupported(f, true);
             selWritable &= f.canWrite();
             selDirectoriesOnly &= f.isDirectory();
         }
@@ -495,7 +495,7 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
             case R.id.action_fs_copy_to_clipboard: {
                 if (_filesystemViewerAdapter.areItemsSelected()) {
                     File file = new ArrayList<>(_filesystemViewerAdapter.getCurrentSelection()).get(0);
-                    if (FormatRegistry.isTextFile(file)) {
+                    if (FormatRegistry.isFileSupported(file, true)) {
                         _cu.setClipboard(getContext(), GsFileUtils.readTextFileFast(file).first);
                         Toast.makeText(getContext(), R.string.clipboard, Toast.LENGTH_SHORT).show();
                         _filesystemViewerAdapter.unselectAll();

--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -646,7 +646,7 @@ public class GsFileUtils {
         return (doti < 0) ? name : name.substring(0, doti);
     }
 
-    /// Get the file extension of the file
+    /// Get the file extension of the file, including dot
     public static String getFilenameExtension(final File file) {
         final String name = file.getName().replace(".jenc", "");
         final int doti = name.lastIndexOf(".");

--- a/app/thirdparty/java/other/writeily/model/WrMarkorSingleton.java
+++ b/app/thirdparty/java/other/writeily/model/WrMarkorSingleton.java
@@ -14,7 +14,6 @@ import android.content.Context;
 
 import androidx.documentfile.provider.DocumentFile;
 
-import net.gsantner.markor.format.FormatRegistry;
 import net.gsantner.markor.frontend.MarkorDialogFactory;
 import net.gsantner.markor.util.MarkorContextUtils;
 import net.gsantner.opoc.util.GsFileUtils;
@@ -123,10 +122,7 @@ public class WrMarkorSingleton {
     }
 
     private enum ConflictResolution {
-        KEEP_BOTH,
-        OVERWRITE,
-        SKIP,
-        ASK
+        KEEP_BOTH, OVERWRITE, SKIP, ASK
     }
 
     public void moveOrCopySelected(final List<File> files, final File destDir, final Activity activity, final boolean isMove) {
@@ -145,14 +141,7 @@ public class WrMarkorSingleton {
         }
     }
 
-    private void _moveOrCopySelected(
-            final Stack<File> files,
-            final File destDir,
-            final Activity activity,
-            final boolean isMove,
-            ConflictResolution resolution,
-            boolean preserveResolution
-    ) {
+    private void _moveOrCopySelected(final Stack<File> files, final File destDir, final Activity activity, final boolean isMove, ConflictResolution resolution, boolean preserveResolution) {
         while (!files.empty()) {
             final File file = files.pop();
             final File dest = new File(destDir, file.getName());
@@ -167,18 +156,17 @@ public class WrMarkorSingleton {
                 } else if (resolution == ConflictResolution.ASK) {
                     // Put the file back in
                     files.push(file);
-                    MarkorDialogFactory.showCopyMoveConflictDialog(
-                            activity, file.getName(), destDir.getName(), files.size() > 1, (option) -> {
-                                ConflictResolution res = ConflictResolution.ASK;
-                                if (option == 0 || option == 3) {
-                                    res = ConflictResolution.KEEP_BOTH;
-                                } else if (option == 1 || option == 4) {
-                                    res = ConflictResolution.OVERWRITE;
-                                } else if (option == 2 || option == 5) {
-                                    res = ConflictResolution.SKIP;
-                                }
-                                _moveOrCopySelected(files, destDir, activity, isMove, res, option > 2);
-                            });
+                    MarkorDialogFactory.showCopyMoveConflictDialog(activity, file.getName(), destDir.getName(), files.size() > 1, (option) -> {
+                        ConflictResolution res = ConflictResolution.ASK;
+                        if (option == 0 || option == 3) {
+                            res = ConflictResolution.KEEP_BOTH;
+                        } else if (option == 1 || option == 4) {
+                            res = ConflictResolution.OVERWRITE;
+                        } else if (option == 2 || option == 5) {
+                            res = ConflictResolution.SKIP;
+                        }
+                        _moveOrCopySelected(files, destDir, activity, isMove, res, option > 2);
+                    });
                     return; // Process will be continued by callback
                 }
                 resolution = preserveResolution ? resolution : ConflictResolution.ASK;
@@ -229,7 +217,7 @@ public class WrMarkorSingleton {
             if (!f.getName().startsWith(".")) {
                 if (f.isDirectory()) {
                     files.add(f);
-                } else if (FormatRegistry.isTextFile(f)) {
+                } else {
                     addedFiles.add(f);
                 }
             }


### PR DESCRIPTION
##  Unify file opening functionalities
Previously file click at file manager, at WebView, at widget, at Document launcher, each had own implementations for how to open a file internally (i.e. editor) or external with other app/browser.

## binary handling improvements
* Make sure in-content-file search also ignores files out of BinaryEmbedFormat. 
* Otherwise i.e. jpg would be scanned as text. Though jpg is binary only supported in View-Mode by img-src. 
* Copy-paste filemanager toolbar action was also unintentionally enabled

## Widget open non-supported files in external app
* Just like filemanager on MainScreen use the same (new) means to check to open files internally at Edit/View-Mode, or open external in other app. Thus works in the same way when you would click a file at the mainscreen filemanager.
* Closes #1845 #1840