### PR TITLE
Detect empty generally non-detectable files as text/plain, closes #1863

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -480,7 +480,7 @@ public class GsFileUtils {
             } catch (Exception ignored) {
             }
             if (GsTextUtils.isNullOrEmpty(t) || t.contains("not found")) {
-            } else if (t.equals("ascii text")) {
+            } else if (t.equals("ascii text") || t.contains("empty")) {
                 return "text/plain";
             } else if (t.contains("text") || t.contains("script")) {
                 return "text/" + t.replace(" ", "-");


### PR DESCRIPTION
Some days ago I did major improvements to text file & mime-type detection at <https://github.com/gsantner/markor/commit/327cc556b646e0c353bb50fe0c738a69bd938ab4>. 

It can happen that you create a file, i.e. "hello.dummy", and when hello.dummy would contain text it perfectly fine opens as text. However when you create the file new it is returned as type "empty" instead of "text/plain". So at time of creating this new "hello.dummy" it won't be openable even though it would be when it would contain content.

The change in this PR also marks files returned with mime "empty" as a openable textfile, replacing empty with text/plain. 

This PR and previously mentioned change closes #1863 as now all textfiles are available to use for snippets.