### PR TITLE
File browser & file listing performance improvements: Add generic method to replace file references with GsFileWithMetadataCache counterparts

### DIFF
--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -667,12 +667,10 @@ public class MarkorDialogFactory {
         }
 
         // Read all files in snippets folder with appropriate extension
-        // Create a map of sippet title -> text
-        final String[] ls = folder.list();
-        for (final String name : ls == null ? new String[]{} : ls) {
-            final File item = new File(folder, name);
-            if (item.exists() && item.canRead() && GsFileUtils.isTextFile(item)) {
-                texts.put(name, item);
+        // Create a map of snippet title -> text
+        for (final File f : GsFileUtils.replaceFilesWithCachedVariants(folder.listFiles())) {
+            if (f.exists() && f.canRead() && GsFileUtils.isTextFile(f)) {
+                texts.put(f.getName(), f);
             }
         }
         return texts;

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
@@ -557,15 +557,10 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
                         }
                     }
 
-                    // Optimization - convert found File's to FileWithCachedData
-                    // Sorting invokes a lot of filesystem i/o calls which do consume much time
-                    // Changing sort order: Reuse information if available
-                    for (int i = 0; i < _adapterData.size(); i++) {
-                        final File o = _adapterData.remove(i);
-                        final int at = oldAdapterData.indexOf(o);
-                        _adapterData.add(i, at >= 0 ? oldAdapterData.get(at) : new GsFileWithMetadataCache(o));
-                    }
+                    // Convert found File's to FileWithCachedData to optimize performance
+                    GsFileUtils.replaceFilesWithCachedVariants(_adapterData);
 
+                    // Sort files
                     GsFileUtils.sortFiles(_adapterData, _dopt.sortByType, _dopt.sortFolderFirst, _dopt.sortReverse);
 
                     if (canGoUp(_currentFolder)) {

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
@@ -36,7 +36,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import net.gsantner.markor.R;
 import net.gsantner.opoc.util.GsContextUtils;
 import net.gsantner.opoc.util.GsFileUtils;
-import net.gsantner.opoc.wrapper.GsFileWithMetadataCache;
 
 import java.io.File;
 import java.io.FilenameFilter;

--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -15,6 +15,7 @@ import android.util.Pair;
 
 import net.gsantner.opoc.format.GsTextUtils;
 import net.gsantner.opoc.wrapper.GsCallback;
+import net.gsantner.opoc.wrapper.GsFileWithMetadataCache;
 import net.gsantner.opoc.wrapper.GsHashMap;
 
 import java.io.BufferedInputStream;
@@ -734,5 +735,26 @@ public class GsFileUtils {
         }
 
         return mainComparator;
+    }
+
+    public static List<File> replaceFilesWithCachedVariants(final File[] files) {
+        ArrayList<File> list = new ArrayList<>(Arrays.asList(files != null ? files : new File[0]));
+        return replaceFilesWithCachedVariants(list);
+    }
+
+    /**
+     * Optimization: convert {@link File}s to FileWithCachedData
+     * For example sorting invokes a lot of filesystem i/o calls which comes with performance penalty
+     */
+    public static List<File> replaceFilesWithCachedVariants(final List<File> files) {
+        for (int i = 0; i < files.size(); i++) {
+            if (files.get(i) instanceof GsFileWithMetadataCache) {
+                continue;
+            }
+            final File o = files.remove(i);
+            final int at = files.indexOf(o);
+            files.add(i, at >= 0 ? files.get(at) : new GsFileWithMetadataCache(o));
+        }
+        return files;
     }
 }

--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -458,17 +458,11 @@ public class GsFileUtils {
         } catch (Exception ignored) {
         }
 
-        if (file.exists() && file.isFile()) {
-            try (InputStream is = new BufferedInputStream(new FileInputStream(file))) {
-                if (!GsTextUtils.isNullOrEmpty(t = Files.probeContentType(file.toPath()))) {
-                    return t;
-                }
-            } catch (Exception ignored) {
+        try {
+            if (!GsTextUtils.isNullOrEmpty(t = URLConnection.guessContentTypeFromName(file.getName().replace(".jenc", "")))) {
+                return t;
             }
-        }
-
-        if (!GsTextUtils.isNullOrEmpty(t = URLConnection.guessContentTypeFromName(file.getName().replace(".jenc", "")))) {
-            return t;
+        } catch (Exception ignored) {
         }
 
         // Try extracting by running shell file -b on the file - for textfiles this very often results in "ASCII text"
@@ -483,10 +477,10 @@ public class GsFileUtils {
             } catch (Exception ignored) {
             }
             if (GsTextUtils.isNullOrEmpty(t) || t.contains("not found")) {
-            } else if (t.equals("ascii text") || t.contains("empty")) {
+            } else if (t.contains("ascii text") || t.contains("empty")) {
                 return "text/plain";
             } else if (t.contains("text") || t.contains("script")) {
-                return "text/" + t.replace(" ", "-");
+                return "text/x-" + t.replaceAll("(\\s|-)*script(\\s|-)*", "").replace(" ", "-");
             }
         } catch (Exception ignored) {
         }

--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -13,6 +13,8 @@ import android.annotation.SuppressLint;
 import android.text.TextUtils;
 import android.util.Pair;
 
+import androidx.annotation.Nullable;
+
 import net.gsantner.opoc.format.GsTextUtils;
 import net.gsantner.opoc.wrapper.GsCallback;
 import net.gsantner.opoc.wrapper.GsFileWithMetadataCache;
@@ -737,7 +739,7 @@ public class GsFileUtils {
         return mainComparator;
     }
 
-    public static List<File> replaceFilesWithCachedVariants(final File[] files) {
+    public static List<File> replaceFilesWithCachedVariants(@Nullable final File[] files) {
         ArrayList<File> list = new ArrayList<>(Arrays.asList(files != null ? files : new File[0]));
         return replaceFilesWithCachedVariants(list);
     }
@@ -746,7 +748,9 @@ public class GsFileUtils {
      * Optimization: convert {@link File}s to FileWithCachedData
      * For example sorting invokes a lot of filesystem i/o calls which comes with performance penalty
      */
-    public static List<File> replaceFilesWithCachedVariants(final List<File> files) {
+    public static List<File> replaceFilesWithCachedVariants(@Nullable List<File> files) {
+        files = (files == null ? new ArrayList<>() : files);
+
         for (int i = 0; i < files.size(); i++) {
             if (files.get(i) instanceof GsFileWithMetadataCache) {
                 continue;

--- a/app/src/main/java/net/gsantner/opoc/wrapper/GsFileWithMetadataCache.java
+++ b/app/src/main/java/net/gsantner/opoc/wrapper/GsFileWithMetadataCache.java
@@ -20,7 +20,7 @@ public class GsFileWithMetadataCache extends File {
     private Integer cHashCode;
     private Boolean cCanRead, cCanWrite, cExists, cIsAbsolute, cIsDirectory, cIsFile;
     private Long cLastModified, cLength;
-    private String cAbsolutePath;
+    private String cAbsolutePath, cName;
     private File cAbsoluteFile;
     private String[] cList;
 
@@ -44,7 +44,6 @@ public class GsFileWithMetadataCache extends File {
         super(f.getPath());
     }
 
-
     @NonNull
     @Override
     public synchronized String getAbsolutePath() {
@@ -52,6 +51,15 @@ public class GsFileWithMetadataCache extends File {
             cAbsolutePath = super.getAbsolutePath();
         }
         return cAbsolutePath;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        if (cName == null) {
+            cName = super.getName();
+        }
+        return cName;
     }
 
     @NonNull


### PR DESCRIPTION
File browser & file listing performance improvements: Add generic method to replace file references with GsFileWithMetadataCache counterparts

related to #1863 , #1872 - also use caching and sort files for snippets