### PR TITLE
Todo.txt advanced search system

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
@@ -232,7 +232,6 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
             updateUndoRedoIconStates();
         });
         _hlEditor.addTextChangedListener(GsTextWatcherAdapter.after(s -> debounced.run()));
-
     }
 
     @Override

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
@@ -232,6 +232,7 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
             updateUndoRedoIconStates();
         });
         _hlEditor.addTextChangedListener(GsTextWatcherAdapter.after(s -> debounced.run()));
+
     }
 
     @Override

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
@@ -209,11 +209,11 @@ public class TodoTxtActionButtons extends ActionButtonBase {
 
         switch (action) {
             case R.string.abid_todotxt_add_context: {
-                MarkorDialogFactory.showSttKeySearchDialog(getActivity(), _hlEditor, R.string.browse_by_context, true, true, TodoTxtFilter.CONTEXT);
+                MarkorDialogFactory.showSttKeySearchDialog(getActivity(), _hlEditor, R.string.browse_by_context, true, true, TodoTxtFilter.TYPE.CONTEXT);
                 return true;
             }
             case R.string.abid_todotxt_add_project: {
-                MarkorDialogFactory.showSttKeySearchDialog(getActivity(), _hlEditor, R.string.browse_by_project, true, true, TodoTxtFilter.PROJECT);
+                MarkorDialogFactory.showSttKeySearchDialog(getActivity(), _hlEditor, R.string.browse_by_project, true, true, TodoTxtFilter.TYPE.PROJECT);
                 return true;
             }
             case R.string.abid_todotxt_sort_todo: {

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
@@ -29,6 +29,8 @@ import net.gsantner.markor.frontend.textview.TextViewUtils;
 import net.gsantner.markor.model.Document;
 import net.gsantner.opoc.util.GsFileUtils;
 
+import org.w3c.dom.Text;
+
 import java.io.File;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -108,18 +110,14 @@ public class TodoTxtActionButtons extends ActionButtonBase {
                 final List<String> contexts = new ArrayList<>();
                 contexts.addAll(TodoTxtTask.getContexts(TodoTxtTask.getAllTasks(_hlEditor.getText())));
                 contexts.addAll(new TodoTxtTask(_appSettings.getTodotxtAdditionalContextsAndProjects()).getContexts());
-                MarkorDialogFactory.showSttContextDialog(getActivity(), contexts, (context) -> {
-                    insertUniqueItem((context.charAt(0) == '@') ? context : "@" + context);
-                });
+                MarkorDialogFactory.showInsertItemsDialog(getActivity(), R.string.insert_context, contexts, _hlEditor, context -> insertUniqueItem(context, "@"));
                 return true;
             }
             case R.string.abid_todotxt_add_project: {
                 final List<String> projects = new ArrayList<>();
                 projects.addAll(TodoTxtTask.getProjects(TodoTxtTask.getAllTasks(_hlEditor.getText())));
                 projects.addAll(new TodoTxtTask(_appSettings.getTodotxtAdditionalContextsAndProjects()).getProjects());
-                MarkorDialogFactory.showSttProjectDialog(getActivity(), projects, (project) -> {
-                    insertUniqueItem((project.charAt(0) == '+') ? project : "+" + project);
-                });
+                MarkorDialogFactory.showInsertItemsDialog(getActivity(), R.string.insert_project, projects, _hlEditor, project -> insertUniqueItem(project, "+"));
                 return true;
             }
             case R.string.abid_todotxt_priority: {
@@ -142,7 +140,8 @@ public class TodoTxtActionButtons extends ActionButtonBase {
                 return true;
             }
             case R.string.abid_todotxt_archive_done_tasks: {
-                MarkorDialogFactory.showSttArchiveDialog(getActivity(), (callbackPayload) -> {
+                final String last = _appSettings.getLastTodoDoneName(_document.getPath());
+                MarkorDialogFactory.showSttArchiveDialog(getActivity(), last, (callbackPayload) -> {
                     callbackPayload = Document.normalizeFilename(callbackPayload);
 
                     final ArrayList<TodoTxtTask> keep = new ArrayList<>();
@@ -182,7 +181,7 @@ public class TodoTxtActionButtons extends ActionButtonBase {
                             );
                         }
                     }
-                    _appSettings.setLastTodoUsedArchiveFilename(callbackPayload);
+                    _appSettings.setLastTodoDoneName(_document.getPath(), callbackPayload);
                 });
                 return true;
             }
@@ -209,11 +208,11 @@ public class TodoTxtActionButtons extends ActionButtonBase {
 
         switch (action) {
             case R.string.abid_todotxt_add_context: {
-                MarkorDialogFactory.showSttKeySearchDialog(getActivity(), _hlEditor, R.string.browse_by_context, true, true, TodoTxtFilter.TYPE.CONTEXT);
+                MarkorDialogFactory.showSttKeySearchDialog(getActivity(), _hlEditor, R.string.browse_by_context, true, true, TextViewUtils.isImeOpen(_hlEditor), TodoTxtFilter.TYPE.CONTEXT);
                 return true;
             }
             case R.string.abid_todotxt_add_project: {
-                MarkorDialogFactory.showSttKeySearchDialog(getActivity(), _hlEditor, R.string.browse_by_project, true, true, TodoTxtFilter.TYPE.PROJECT);
+                MarkorDialogFactory.showSttKeySearchDialog(getActivity(), _hlEditor, R.string.browse_by_project, true, true, TextViewUtils.isImeOpen(_hlEditor), TodoTxtFilter.TYPE.PROJECT);
                 return true;
             }
             case R.string.abid_todotxt_sort_todo: {
@@ -247,8 +246,13 @@ public class TodoTxtActionButtons extends ActionButtonBase {
         return true;
     }
 
-    private void insertUniqueItem(String item) {
+    private void insertUniqueItem(String item, final String prefix) {
+        // Prepare item
+        if (prefix != null) {
+            item = item.startsWith(prefix) ? item : prefix + item;
+        }
         item = item.trim().replace(" ", "_");
+
         // Pattern to match <space><literal string><space OR end of line>
         // i.e. to check if a word is present in the line
         final Pattern pattern = Pattern.compile(String.format("\\s\\Q%s\\E(:?\\s|$)", item));

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
@@ -29,8 +29,6 @@ import net.gsantner.markor.frontend.textview.TextViewUtils;
 import net.gsantner.markor.model.Document;
 import net.gsantner.opoc.util.GsFileUtils;
 
-import org.w3c.dom.Text;
-
 import java.io.File;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -39,7 +37,6 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.regex.Pattern;
 
-//TODO
 public class TodoTxtActionButtons extends ActionButtonBase {
 
     private static final String LAST_SORT_ORDER_KEY = TodoTxtActionButtons.class.getCanonicalName() + "_last_sort_order_key";

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
@@ -228,7 +228,8 @@ public class TodoTxtFilter {
             final CharSequence expression = parseQuery(task, processed);
             final boolean accept = evaluateExpression(expression);
             return accept;
-        } catch (EmptyStackException e) {
+        } catch (EmptyStackException | IllegalArgumentException e) {
+            // TODO - display a useful message somehow
             return false;
         }
     }
@@ -354,7 +355,7 @@ public class TodoTxtFilter {
             } else if (op == '!') {
                 stack.push(toChar(rhs == 'F'));
             } else {
-                return;
+                throw new IllegalArgumentException("Unexpected character");
             }
         }
     }
@@ -366,7 +367,7 @@ public class TodoTxtFilter {
             if (c == ')') {
                 final char value = stack.pop();
                 if (stack.pop() != '(') {
-                    return false; // Bad expression
+                    throw new IllegalArgumentException("Mismatched parenthesis");
                 }
                 stack.push(value);
             } else {
@@ -374,6 +375,9 @@ public class TodoTxtFilter {
             }
             evaluateOperations(stack);
         }
-        return stack.size() == 1 && stack.pop() == 'T';
+        if (stack.size() == 1 && isValue(stack)) {
+            return stack.pop() == 'T';
+        }
+        throw new IllegalArgumentException("Malformed expression");
     }
 }

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
 
 public class TodoTxtFilter {
 

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
@@ -24,18 +24,19 @@ import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
 
 public class TodoTxtFilter {
 
     // Special query keywords
     // ----------------------------------------------------------------------------------------
 
-    public final static String QUERY_PRIORITY_NONE = Character.toString(TodoTxtTask.PRIORITY_NONE);
+    public final static String QUERY_PRIORITY_ANY = "pri";
     public final static String QUERY_DUE_TODAY = "due=";
     public final static String QUERY_DUE_OVERDUE = "due<";
     public final static String QUERY_DUE_FUTURE = "due>";
     public final static String QUERY_DUE_ANY = "due";
-    public final static String QUERY_DONE = "x";
+    public final static String QUERY_DONE = "done";
 
     // ----------------------------------------------------------------------------------------
 
@@ -122,8 +123,8 @@ public class TodoTxtFilter {
             nullKey = "!+";
             prefix = "+";
         } else if (type == TYPE.PRIORITY) {
-            nullKey = QUERY_PRIORITY_NONE;
-            prefix = "";
+            nullKey = "!" + QUERY_PRIORITY_ANY;
+            prefix = "pri:";
         } else { // type due
             nullKey = "!" + QUERY_DUE_ANY;
             prefix = "";
@@ -258,14 +259,18 @@ public class TodoTxtFilter {
     }
 
     // Evaluate a word (element) for truthyness or falsiness
+    // Step through all the possible conditions
     private static char evalElement(final TodoTxtTask task, final String element) {
 
-        // Prioritiy
         final boolean result;
-        if ((element.length() == 1) && element.matches("[A-Z]")) {
-            result = Character.toLowerCase(task.getPriority()) == Character.toLowerCase(element.charAt(0));
-        } else if (QUERY_PRIORITY_NONE.equals(element)) {
-            result = task.getPriority() == TodoTxtTask.PRIORITY_NONE;
+        if (element.startsWith(QUERY_PRIORITY_ANY)) {
+            if (QUERY_PRIORITY_ANY.equals(element)) {
+                result = task.getPriority() != TodoTxtTask.PRIORITY_NONE;
+            } else if (element.length() == 5 && element.charAt(3) == ':') {
+                result = task.getPriority() == element.charAt(4);
+            } else {
+                result = false;
+            }
         } else if (QUERY_DUE_TODAY.equals(element)) {
             result = task.getDueStatus() == TodoDueState.TODAY;
         } else if (QUERY_DUE_OVERDUE.equals(element)) {

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
@@ -2,9 +2,13 @@ package net.gsantner.markor.format.todotxt;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Pair;
 import android.widget.Toast;
 
+import androidx.annotation.VisibleForTesting;
+
 import net.gsantner.markor.R;
+import net.gsantner.markor.format.todotxt.TodoTxtTask.TodoDueState;
 import net.gsantner.opoc.model.GsSharedPreferencesPropertyBackend;
 import net.gsantner.opoc.wrapper.GsCallback;
 
@@ -13,116 +17,145 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.EmptyStackException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.Stack;
+import java.util.TreeSet;
 
 public class TodoTxtFilter {
 
+    // Special query keywords
+    // ----------------------------------------------------------------------------------------
+
+    public final static String[] QUERY_PRIORITY_NONE = {"nopriority", "nopri", Character.toString(TodoTxtTask.PRIORITY_NONE)};
+    public final static String[] QUERY_DUE_TODAY = {"today", "due"};
+    public final static String[] QUERY_DUE_OVERDUE = {"overdue", "past"};
+    public final static String[] QUERY_DUE_FUTURE = {"future"};
+    public final static String[] QUERY_DUE_NONE = {"nodue"};
+    public final static String[] QUERY_DONE = {"done"};
+    public final static String[] QUERY_CONTEXT_NONE = {"nocontext", "nocontexts"};
+    public final static String[] QUERY_PROJECT_NONE = {"noproject", "noprojects"};
+
+    // ----------------------------------------------------------------------------------------
+
     public static final String SAVED_TODO_VIEWS = "todo_txt__saved_todo_views";
-    public static final int MAX_RECENT_VIEWS = 5;
+    public static final String STRING_NONE = "-";
+    private static final String TITLE = "TITLE";
+    private static final String QUERY = "QUERY";
+    private static final String NULL_SENTINEL = "NULL SENTINEL";
 
-    // Used as enum for type
-    public static final String PROJECT = "todo_txt__view_type_project";
-    public static final String CONTEXT = "todo_txt__view_type_context";
-    public static final String PRIORITY = "todo_txt__view_type_priority";
-    public static final String DUE = "todo_txt__view_type_due-date";
 
-    private static final String TITLE = "title";
-    private static final String IS_AND = "is_and";
-    private static final String KEYS = "keys";
-    private static final String TYPE = "type";
+    public static final int MAX_RECENT_VIEWS = 10;
 
-    private static final String NULL_SENTINEL = "NULL SENTINEL"; // As this has a space, it isn't a valid context etc
+    public enum TYPE {
+        PROJECT, CONTEXT, PRIORITY, DUE
+    }
 
-    // For any type, return a function which maps a task -> a list of string keys
-    public static GsCallback.r1<List<String>, TodoTxtTask> keyGetter(final Context context, final String type) {
-        switch (type) {
-            case PROJECT:
-                return TodoTxtTask::getProjects;
-            case CONTEXT:
-                return TodoTxtTask::getContexts;
-            case PRIORITY:
-                return task -> task.getPriority() == TodoTxtTask.PRIORITY_NONE ? Collections.emptyList() : Collections.singletonList(Character.toString(task.getPriority()));
-            case DUE:
-                final Map<TodoTxtTask.TodoDueState, String> statusMap = new HashMap<>();
-                statusMap.put(TodoTxtTask.TodoDueState.TODAY, context.getString(R.string.due_today));
-                statusMap.put(TodoTxtTask.TodoDueState.OVERDUE, context.getString(R.string.due_overdue));
-                statusMap.put(TodoTxtTask.TodoDueState.FUTURE, context.getString(R.string.due_future));
-                return task -> task.getDueStatus() == TodoTxtTask.TodoDueState.NONE ? Collections.emptyList() : Collections.singletonList(statusMap.get(task.getDueStatus()));
+    public static class SttFilterKey {
+        public final String key;    // Name
+        public final int count;     // How many exist
+        public final String query;  // What to stick in the query
+
+        private SttFilterKey(String k, int c, String q) {
+            key = k;
+            count = c;
+            query = q;
+        }
+    }
+
+    public static List<SttFilterKey> getKeys(final Context context, final List<TodoTxtTask> tasks, final TYPE type) {
+        if (type == TYPE.PROJECT) {
+            return getStringListKeys(tasks, TodoTxtTask::getProjects);
+        } else if (type == TYPE.CONTEXT) {
+            return getStringListKeys(tasks, TodoTxtTask::getContexts);
+        } else if (type == TYPE.PRIORITY) {
+            return getStringListKeys(tasks, t -> t.getPriority() == TodoTxtTask.PRIORITY_NONE ? null : Collections.singletonList(Character.toString(Character.toUpperCase(t.getPriority()))));
+        } else if (type == TYPE.DUE) {
+            return getDueKeys(context, tasks);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private static List<SttFilterKey> getStringListKeys(final List<TodoTxtTask> tasks, final GsCallback.r1<List<String>, TodoTxtTask> keyGetter) {
+        final List<String> all = new ArrayList<>();
+        for (final TodoTxtTask task : tasks) {
+            final List<String> tKeys = keyGetter.callback(task);
+            all.addAll(tKeys == null || tKeys.isEmpty() ? Collections.singletonList(NULL_SENTINEL) : tKeys);
         }
 
-        return null;
+        final List<SttFilterKey> keys = new ArrayList<>();
+        final Set<String> unique = new TreeSet<>(all);
+        if (unique.remove(NULL_SENTINEL)) {
+            keys.add(new SttFilterKey(STRING_NONE, Collections.frequency(all, NULL_SENTINEL), null));
+        }
+        for (final String key : unique) {
+            keys.add(new SttFilterKey(key, Collections.frequency(all, key), key));
+        }
+
+        return keys;
     }
 
-    // For a list of keys and a task -> key mapping, return a function which selects tasks
-    public static GsCallback.b1<TodoTxtTask> taskSelector(
-            final Collection<String> keys,
-            final GsCallback.r1<List<String>, TodoTxtTask> keyGetter,
-            final boolean isAnd) {
+    public static List<SttFilterKey> getDueKeys(final Context context, final List<TodoTxtTask> tasks) {
+        final List<TodoTxtTask.TodoDueState> all = new ArrayList<>();
+        for (final TodoTxtTask task : tasks) {
+            all.add(task.getDueStatus());
+        }
+        final List<SttFilterKey> keys = new ArrayList<>();
+        keys.add(new SttFilterKey(context.getString(R.string.due_future), Collections.frequency(all, TodoDueState.FUTURE), TodoDueState.FUTURE.toString()));
+        keys.add(new SttFilterKey(context.getString(R.string.due_today), Collections.frequency(all, TodoDueState.TODAY), TodoDueState.TODAY.toString()));
+        keys.add(new SttFilterKey(context.getString(R.string.due_overdue), Collections.frequency(all, TodoDueState.OVERDUE), TodoDueState.OVERDUE.toString()));
+        keys.add(new SttFilterKey(STRING_NONE, Collections.frequency(all, TodoDueState.NONE), TodoDueState.NONE.toString()));
 
-        final Set<String> searchSet = new HashSet<>(keys);
-        final boolean noneIncluded = searchSet.remove(null);
+        return keys;
+    }
 
-        return (task) -> {
-            final List<String> taskKeys = keyGetter.callback(task);
-            if (task.isDone()) {
-                return false;
-            } else if (isAnd) {
-                return (taskKeys.isEmpty() && noneIncluded) || taskKeys.containsAll(searchSet);
+    // Convert a set of querty keys into a formatted query
+    public static String makeQuery(final Collection<String> keys, final boolean isAnd, final TodoTxtFilter.TYPE type) {
+        final String prefix;
+        final String nullKey;
+        if (type == TYPE.CONTEXT) {
+            nullKey = QUERY_CONTEXT_NONE[0];
+            prefix = "@";
+        } else if (type == TYPE.PROJECT) {
+            nullKey = QUERY_PROJECT_NONE[0];
+            prefix = "+";
+        } else if (type == TYPE.PRIORITY) {
+            nullKey = QUERY_PRIORITY_NONE[0];
+            prefix = "";
+        } else { // type due
+            nullKey = QUERY_DUE_NONE[0];
+            prefix = "";
+        }
+
+        final List<String> adjusted = new ArrayList<>();
+        for (final String key : keys) {
+            if (key != null) {
+                adjusted.add(prefix + key);
             } else {
-                return (taskKeys.isEmpty() && noneIncluded) || (!Collections.disjoint(searchSet, taskKeys));
+                adjusted.add(nullKey);
             }
-        };
+        }
+
+        return String.join(isAnd ? " & " : " | ", adjusted);
     }
 
-    public static class Group {
-        public String title;
-        public String queryType;
-        public List<String> keys;
-        public boolean isAnd;
-    }
-
-    /**
-     * Save a 'filter view' - Filters are saved as a json string in SAVED_TODO_VIEWS as array of objects
-     *
-     * @param context   context
-     * @param saveTitle title
-     * @param queryType query type (one of PRIORITY, CONTEXT, PRIORITY or DUE)
-     * @param selKeys   List of keys
-     * @param isAnd     Whether task should have ALL the keys or ANY
-     */
-    public static void saveFilter(final Context context, final String saveTitle, final String queryType, final Collection<String> selKeys, final boolean isAnd) {
-        /*
-         [{
-             TITLE: (string) tile string,
-             TYPE: (string) query type,
-             IS_AND: (boolean) if query is AND or ANY
-             KEYS: [ key1, key2, key3 ... ]
-          },
-          {.... }, {.... }]
-         */
+    public static void saveFilter(final Context context, final String title, final String query) {
         try {
             // Create the view dict
             final JSONObject obj = new JSONObject();
-            obj.put(TITLE, saveTitle);
-            obj.put(TYPE, queryType);
-            obj.put(IS_AND, isAnd);
-            final JSONArray keysArray = new JSONArray();
-            for (final String key : selKeys) {
-                keysArray.put(key != null ? key : NULL_SENTINEL);
-            }
-            obj.put(KEYS, keysArray);
+            obj.put(TITLE, title);
+            obj.put(QUERY, query);
 
-            // Load the existing list of views
+            // This oldArray / newArray approach needed as array.remove is api 19+
             final JSONArray newArray = new JSONArray();
             newArray.put(obj);
 
-            // This oldArray / newArray approach needed as array.remove is api 19+
+            // Load the existing list of views and append the required number to the newArray
             final SharedPreferences pref = context.getSharedPreferences(GsSharedPreferencesPropertyBackend.SHARED_PREF_APP, Context.MODE_PRIVATE);
             final JSONArray oldArray = new JSONArray(pref.getString(SAVED_TODO_VIEWS, "[]"));
             final int addCount = Math.min(MAX_RECENT_VIEWS - 1, oldArray.length());
@@ -137,11 +170,8 @@ public class TodoTxtFilter {
             e.printStackTrace();
             Toast.makeText(context, "𐄂", Toast.LENGTH_SHORT).show();
         }
-        Toast.makeText(context, String.format("✔ %s️", saveTitle), Toast.LENGTH_SHORT).show();
-    }
 
-    public static void saveFilter(final Context context, final Group gp) {
-        saveFilter(context, gp.title, gp.queryType, gp.keys, gp.isAnd);
+        Toast.makeText(context, String.format("✔ %s️", title), Toast.LENGTH_SHORT).show();
     }
 
     public static boolean deleteFilterIndex(final Context context, int index) {
@@ -170,25 +200,15 @@ public class TodoTxtFilter {
         }
     }
 
-    public static List<Group> loadSavedFilters(final Context context) {
+    public static List<Pair<String, String>> loadSavedFilters(final Context context) {
         final SharedPreferences pref = context.getSharedPreferences(GsSharedPreferencesPropertyBackend.SHARED_PREF_APP, Context.MODE_PRIVATE);
         try {
-            final List<Group> loadedViews = new ArrayList<>();
+            final List<Pair<String, String>> loadedViews = new ArrayList<>();
             final String jsonString = pref.getString(SAVED_TODO_VIEWS, "[]");
             final JSONArray array = new JSONArray(jsonString);
             for (int i = 0; i < array.length(); i++) {
                 final JSONObject obj = array.getJSONObject(i);
-                final Group gp = new Group();
-                gp.isAnd = obj.optBoolean(IS_AND, false);
-                gp.title = obj.optString(TITLE, "UNTITLED");
-                gp.queryType = obj.getString(TYPE);
-                gp.keys = new ArrayList<>();
-                final JSONArray keysArray = obj.getJSONArray(KEYS);
-                for (int j = 0; j < keysArray.length(); j++) {
-                    final String key = keysArray.getString(j);
-                    gp.keys.add(NULL_SENTINEL.equals(key) ? null : key);
-                }
-                loadedViews.add(gp);
+                loadedViews.add(Pair.create(obj.getString(TITLE), obj.getString(QUERY)));
             }
             return loadedViews;
         } catch (JSONException e) {
@@ -196,5 +216,170 @@ public class TodoTxtFilter {
             pref.edit().remove(SAVED_TODO_VIEWS).apply();
         }
         return Collections.emptyList();
+    }
+
+    // Query matching
+    // -------------------------------------------------------------------------------------------
+
+    public static boolean isMatchQuery(final TodoTxtTask task, final CharSequence query) {
+        try {
+            final String processed = preProcess(query);
+            final CharSequence expression = parseQuery(task, processed);
+            final boolean accept = shuntingYard(expression);
+            return accept;
+        } catch (EmptyStackException e) {
+            return false;
+        }
+    }
+
+    // Pre-process the query to simplify the syntax
+    private static String preProcess(final CharSequence query) {
+        return query.toString()
+                .replace(" AND ", " & ")
+                .replace(" and ", " & ")
+                .replace("&&", "&")
+                .replace(" OR ", " | ")
+                .replace(" or ", " | ")
+                .replace("||", "|")
+                .replaceAll("([( ])NOT ", "$1| ")
+                .replaceAll("([( ])not ", "$1| ")
+                .replace(" ", "");
+    }
+
+    // Is this char an operator
+    private static boolean isOperator(final char c) {
+        return c == '&' || c == '|' || c == '!';
+    }
+
+    // Is this char an a syntax element
+    private static boolean isSyntax(final char c) {
+        return c == ' ' || c == '(' || c == ')' || isOperator(c);
+    }
+
+    // Parse a query into an expression.
+    // i.e. evaluate the elements in the query to true or false
+    @VisibleForTesting
+    public static String parseQuery(final TodoTxtTask task, final CharSequence query) {
+        final StringBuilder expression = new StringBuilder();
+        final StringBuilder buffer = new StringBuilder();
+        for (int i = 0; i < query.length(); i++) {
+            final char c = query.charAt(i);
+            if (isSyntax(c)) {
+                if (buffer.length() > 0) {
+                    expression.append(evalElement(task, buffer.toString()));
+                    buffer.setLength(0);
+                }
+                expression.append(c);
+            } else {
+                buffer.append(c);
+            }
+        }
+
+        // Add the last element
+        if (buffer.length() > 0) {
+            expression.append(evalElement(task, buffer.toString()));
+        }
+
+        return expression.toString();
+    }
+
+    // Evaluate a word (element) for truthyness or falsiness
+    private static char evalElement(final TodoTxtTask task, final String element) {
+
+        // Prioritiy
+        final boolean result;
+        if ((element.length() == 1) && element.matches("[A-Z]")) {
+            result = Character.toLowerCase(task.getPriority()) == Character.toLowerCase(element.charAt(0));
+        } else if (Arrays.asList(QUERY_PRIORITY_NONE).contains(element)) {
+            result = task.getPriority() == TodoTxtTask.PRIORITY_NONE;
+        } else if (Arrays.asList(QUERY_DUE_TODAY).contains(element)) {
+            result = task.getDueStatus() == TodoDueState.TODAY;
+        } else if (Arrays.asList(QUERY_DUE_OVERDUE).contains(element)) {
+            result = task.getDueStatus() == TodoDueState.OVERDUE;
+        } else if (Arrays.asList(QUERY_DUE_FUTURE).contains(element)) {
+            result = task.getDueStatus() == TodoDueState.FUTURE;
+        } else if (Arrays.asList(QUERY_DUE_NONE).contains(element)) {
+            result = task.getDueStatus() == TodoDueState.NONE;
+        } else if (Arrays.asList(QUERY_DONE).contains(element)) {
+            result = task.isDone();
+        } else if (element.startsWith("@")) {
+            result = task.getContexts().contains(element.substring(1));
+        } else if (element.startsWith("+")) {
+            result = task.getProjects().contains(element.substring(1));
+        } else if (Arrays.asList(QUERY_CONTEXT_NONE).contains(element)) {
+            result = task.getContexts().isEmpty();
+        } else if (Arrays.asList(QUERY_PROJECT_NONE).contains(element)) {
+            result = task.getProjects().isEmpty();
+        } else {
+            result = false;
+        }
+
+        return result ? 'T' : 'F';
+    }
+
+    // Shunting yard expression evaluator
+    // ---------------------------------------------------------------------------------------------
+
+    // Is the top operation in the stack higher precedence that op
+    private static boolean stackIsHigher(final Stack<Character> ops, final char op) {
+        if (ops.isEmpty()) {
+            return false;
+        }
+
+        if (op == '!') {
+            return false;
+        } else if (op == '&') {
+            return ops.peek() == '!';
+        } else {
+            return ops.peek() != '('; // Everything is higher than OR
+        }
+    }
+
+    // Evaluate the top operator in the stack, pushing the result back into the stack
+    private static void evalTop(final Stack<Character> ops, final Stack<Boolean> values) {
+        // Remove operands from stack
+        final char op = ops.pop();
+        if (op == '!') {
+            values.push(!values.pop());
+        } else if (op == '|') {
+            values.push(values.pop() | values.pop());
+        } else if (op == '&') {
+            values.push(values.pop() & values.pop());
+        }
+    }
+
+    /**
+     * An implementation of the shunting yard expression evaluator for boolean expressions
+     * i.e. evaluate expressions of the form `T | F & !(T | F)` etc etc
+     *
+     * @param expression String expression to evaluate
+     * @return whether the expression evaluates to True or False (error = false)
+     */
+    @VisibleForTesting
+    public static boolean shuntingYard(final CharSequence expression) {
+        final Stack<Character> ops = new Stack<>();
+        final Stack<Boolean> values = new Stack<>();
+        for (int i = 0; i < expression.length(); i++) {
+            final char symbol = expression.charAt(i);
+
+            if (symbol == '(') {
+                ops.push(symbol);
+            } else if (isOperator(symbol)) {
+                // Evaluate per precedence
+                while (stackIsHigher(ops, symbol)) evalTop(ops, values);
+                ops.push(symbol);
+            } else if (symbol == 'T' || symbol == 'F') {
+                values.push(symbol == 'T');
+            } else if (symbol == ')') {
+                while (!ops.isEmpty() && ops.peek() != '(') evalTop(ops, values);
+                if (!ops.isEmpty() && ops.pop() != '(') {
+                    return false; // Should be at beginning or open paren
+                }
+            } else {
+                return false; // We have an unexpected symbol
+            }
+        }
+        while (!ops.isEmpty()) evalTop(ops, values);
+        return (values.size() == 1) && values.pop();
     }
 }

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
@@ -237,16 +237,10 @@ public class TodoTxtFilter {
     // Pre-process the query to simplify the syntax
     private static String preProcess(final CharSequence query) {
         return query.toString()
-                .replace(" AND ", " & ")
                 .replace(" and ", " & ")
-                .replace("&&", "&")
-                .replace(" OR ", " | ")
                 .replace(" or ", " | ")
-                .replace("||", "|")
-                .replaceAll("(\\(|\\s)NOT ", "$1! ")
-                .replaceAll("(\\(|\\s)not ", "$1! ")
-                .replace(" NOT ", " ! ")
-                .replace(" not ", " ! ")
+                .replaceAll("([( ])not ", "$1! ")
+                .replaceAll("^not ", "! ")
                 .replace(" ", "");
     }
 

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
@@ -139,7 +139,7 @@ public class TodoTxtFilter {
         }
 
         // We don't include done tasks by default
-        return String.join(isAnd ? " & " : " | ", adjusted) + " & !done";
+        return String.join(isAnd ? " & " : " | ", adjusted) + " & !" + QUERY_DONE;
     }
 
     public static void saveFilter(final Context context, final String title, final String query) {

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtFilter.java
@@ -262,14 +262,16 @@ public class TodoTxtFilter {
         final StringBuilder buffer = new StringBuilder();
         for (int i = 0; i < query.length(); i++) {
             final char c = query.charAt(i);
-            if (isSyntax(c)) {
-                if (buffer.length() > 0) {
-                    expression.append(evalElement(task, buffer.toString()));
-                    buffer.setLength(0);
+            if (!Character.isSpaceChar(c)) {
+                if (isSyntax(c)) {
+                    if (buffer.length() > 0) {
+                        expression.append(evalElement(task, buffer.toString()));
+                        buffer.setLength(0);
+                    }
+                    expression.append(c);
+                } else {
+                    buffer.append(c);
                 }
-                expression.append(c);
-            } else {
-                buffer.append(c);
             }
         }
 

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTask.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTask.java
@@ -13,6 +13,7 @@ import android.text.TextUtils;
 import android.widget.TextView;
 
 import net.gsantner.markor.frontend.textview.TextViewUtils;
+import net.gsantner.opoc.format.GsTextUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -226,7 +227,7 @@ public class TodoTxtTask {
     public TodoDueState getDueStatus() {
         if (dueStatus == null) {
             final String date = getDueDate();
-            if (TextUtils.isEmpty(date)) {
+            if (GsTextUtils.isNullOrEmpty(date)) {
                 dueStatus = TodoDueState.NONE;
             } else {
                 final int comp = date.compareTo(getToday());
@@ -355,8 +356,8 @@ public class TodoTxtTask {
         }
 
         private int compareNull(final String x, final String y) {
-            final int xi = TextUtils.isEmpty(x) ? 1 : 0;
-            final int yi = TextUtils.isEmpty(y) ? 1 : 0;
+            final int xi = GsTextUtils.isNullOrEmpty(x) ? 1 : 0;
+            final int yi = GsTextUtils.isNullOrEmpty(y) ? 1 : 0;
             return Integer.compare(xi, yi);
         }
 

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTask.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtTask.java
@@ -12,7 +12,10 @@ package net.gsantner.markor.format.todotxt;
 import android.text.TextUtils;
 import android.widget.TextView;
 
+import androidx.annotation.VisibleForTesting;
+
 import net.gsantner.markor.frontend.textview.TextViewUtils;
+import net.gsantner.opoc.format.GsTextUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -20,8 +23,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.EmptyStackException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Stack;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -57,7 +62,21 @@ public class TodoTxtTask {
     public static final char PRIORITY_NONE = '~';
 
     public enum TodoDueState {
-        NONE, OVERDUE, TODAY, FUTURE
+        NONE("nodue"),
+        OVERDUE("overdue"),
+        TODAY("today"),
+        FUTURE("future")
+        ;
+
+        private final String value;
+        TodoDueState(final String text) {
+            value = text;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
     }
 
     public static String getToday() {
@@ -150,8 +169,8 @@ public class TodoTxtTask {
     private String description = null;
     private TodoDueState dueStatus = null;
 
-    public TodoTxtTask(final String line) {
-        this.line = line;
+    public TodoTxtTask(final CharSequence line) {
+        this.line = line.toString();
     }
 
     public String getLine() {
@@ -226,7 +245,7 @@ public class TodoTxtTask {
     public TodoDueState getDueStatus() {
         if (dueStatus == null) {
             final String date = getDueDate();
-            if (TextUtils.isEmpty(date)) {
+            if (GsTextUtils.isNullOrEmpty(date)) {
                 dueStatus = TodoDueState.NONE;
             } else {
                 final int comp = date.compareTo(getToday());
@@ -354,31 +373,31 @@ public class TodoTxtTask {
             return difference;
         }
 
-        private int compareNull(final String x, final String y) {
-            final int xi = TextUtils.isEmpty(x) ? 1 : 0;
-            final int yi = TextUtils.isEmpty(y) ? 1 : 0;
+        private static int compareNull(final String x, final String y) {
+            final int xi = GsTextUtils.isNullOrEmpty(x) ? 1 : 0;
+            final int yi = GsTextUtils.isNullOrEmpty(y) ? 1 : 0;
             return Integer.compare(xi, yi);
         }
 
-        private int compareDone(final TodoTxtTask a, TodoTxtTask b) {
+        private static int compareDone(final TodoTxtTask a, TodoTxtTask b) {
             return Integer.compare(a.isDone() ? 1 : 0, b.isDone() ? 1 : 0);
         }
 
-        private int compare(final char x, final char y) {
+        private static int compare(final char x, final char y) {
             return compare(Character.toString(x), Character.toString(y));
         }
 
-        private int compare(final String[] x, final String[] y) {
+        private static int compare(final String[] x, final String[] y) {
             return compare(Arrays.asList(x), Arrays.asList(y));
         }
 
-        private int compare(final List<String> x, final List<String> y) {
+        private static int compare(final List<String> x, final List<String> y) {
             Collections.sort(x);
             Collections.sort(y);
             return compare(TextUtils.join("", x), TextUtils.join("", y));
         }
 
-        private int compare(final String x, final String y) {
+        private static int compare(final String x, final String y) {
             final int n = compareNull(x, y);
             if (n != 0) {
                 return n;
@@ -386,5 +405,141 @@ public class TodoTxtTask {
                 return x.trim().toLowerCase().compareTo(y.trim().toLowerCase());
             }
         }
+
+    }
+
+    // Query matching
+    // -------------------------------------------------------------------------------------------
+
+    public boolean isMatchQuery(final CharSequence query) {
+        try {
+            final CharSequence expression = parseQuery(query);
+            return shuntingYard(expression);
+        } catch (EmptyStackException e) {
+            return false;
+        }
+    }
+
+    private static boolean isOperator(final char c) {
+        return c == '&' || c == '|' || c == '!';
+    }
+
+    private static boolean isSyntax(final char c) {
+        return c == ' ' || c == '(' || c == ')' || isOperator(c);
+    }
+
+    public static boolean stackIsHigher(final Stack<Character> ops, final char op) {
+        if (ops.isEmpty()) {
+            return false;
+        }
+
+        if (op == '!') {
+            return false;
+        } else if (op == '&') {
+            return ops.peek() == '!';
+        } else {
+            return ops.peek() != '('; // Everything is higher than OR
+        }
+    }
+
+    public static void evalTop(final Stack<Character> ops, final Stack<Boolean> values) {
+        // Remove operands from stack
+        final char op = ops.pop();
+        if (op == '!') {
+            values.push(!values.pop());
+        } else if (op == '|') {
+            values.push(values.pop() | values.pop());
+        } else if (op == '&') {
+            values.push(values.pop() & values.pop());
+        }
+    }
+
+    /**
+     * An implementation of the shunting yard expression evaluator for boolean expressions
+     * i.e. evaluate expressions of the form `T | F & !(T | F)` etc etc
+     *
+     * @param expression String expression to evaluate
+     * @return whether the expression evaluates to True or False (error = false)
+     */
+    @VisibleForTesting
+    public static boolean shuntingYard(final CharSequence expression) {
+        final Stack<Character> ops = new Stack<>();
+        final Stack<Boolean> values = new Stack<>();
+        for (int i = 0; i < expression.length(); i++) {
+            final char symbol = expression.charAt(i);
+            if (symbol == '(') {
+                ops.push(symbol);
+            } else if (isOperator(symbol)) {
+                // Evaluate per precedence
+                while (stackIsHigher(ops, symbol)) evalTop(ops, values);
+                ops.push(symbol);
+            } else if (symbol == 'T' || symbol == 'F') {
+                values.push(symbol == 'T');
+            } else if (symbol == ')') {
+                while(!ops.isEmpty() && ops.peek() != '(') evalTop(ops, values);
+                if (!ops.isEmpty() && ops.pop() != '(') {
+                    return false; // Should be at end or paren
+                }
+            } else {
+                return false; // We have an unexpected symbol
+            }
+        }
+        while(!ops.isEmpty()) evalTop(ops, values);
+        return (values.size() == 1) && values.pop();
+    }
+
+    @VisibleForTesting
+    public String parseQuery(final CharSequence query) {
+        final StringBuilder expression = new StringBuilder();
+        final StringBuilder buffer = new StringBuilder();
+        for (int i = 0; i < query.length(); i++) {
+            final char c = query.charAt(i);
+            if (isSyntax(c)) {
+                if (buffer.length() > 0) {
+                    expression.append(evalElement(buffer.toString()) ? 'T' : 'F');
+                    buffer.setLength(0);
+                }
+                expression.append(c);
+            } else {
+                buffer.append(c);
+            }
+        }
+
+        if (buffer.length() > 0) {
+            expression.append(evalElement(buffer.toString()) ? 'T' : 'F');
+        }
+
+        return expression.toString();
+    }
+
+    @VisibleForTesting
+    public boolean evalElement(final String element) {
+
+        // Prioritiy
+        if ((element.length() == 1) && element.matches("[A-Z]")) {
+            return (getPriority() == element.charAt(0));
+        } else if (element.equals("~") || element.equals("nopri") || element.equals("nopriority")) {
+            return getPriority() == PRIORITY_NONE;
+        } else if (element.equals("today") || element.equals("due")) {
+            return getDueStatus() == TodoDueState.TODAY;
+        } else if (element.equals("past") || element.equals("overdue")) {
+            return getDueStatus() == TodoDueState.OVERDUE;
+        } else if (element.equals("future")) {
+            return getDueStatus() == TodoDueState.FUTURE;
+        } else if (element.equals("nodue")) {
+            return getDueStatus() == TodoDueState.NONE;
+        } else if (element.equals("done")) {
+            return isDone();
+        } else if (element.startsWith("@")) {
+            return getContexts().contains(element.substring(1));
+        } else if (element.startsWith("+")) {
+            return getProjects().contains(element.substring(1));
+        } else if (element.equals("nocontext") || element.equals("nocontexts")) {
+            return getContexts().isEmpty();
+        } else if (element.equals("noproject") || element.equals("noprojects")) {
+            return getProjects().isEmpty();
+        }
+
+        return false;
     }
 }

--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -49,6 +49,7 @@ import net.gsantner.markor.frontend.filesearch.FileSearchResultSelectorDialog;
 import net.gsantner.markor.frontend.textview.SyntaxHighlighterBase;
 import net.gsantner.markor.frontend.textview.TextViewUtils;
 import net.gsantner.markor.model.AppSettings;
+import net.gsantner.opoc.format.GsTextUtils;
 import net.gsantner.opoc.frontend.GsSearchOrCustomTextDialog;
 import net.gsantner.opoc.frontend.GsSearchOrCustomTextDialog.DialogOptions;
 import net.gsantner.opoc.util.GsContextUtils;
@@ -277,8 +278,10 @@ public class MarkorDialogFactory {
 
         // Add saved views
         final List<Pair<String, String>> savedViews = TodoTxtFilter.loadSavedFilters(activity);
-        for (int i = 0; i < savedViews.size(); i++) {
-            final int finalI = i; // Final so we can use it in callback
+        final List<Integer> indices = GsTextUtils.range(savedViews.size());
+        Collections.sort(indices, (a, b) -> savedViews.get(a).first.compareTo(savedViews.get(b).first));
+
+        for (final int i : indices) {
             // No icon for the saved searches
             final String title = savedViews.get(i).first;
             final String query = savedViews.get(i).second;
@@ -297,7 +300,7 @@ public class MarkorDialogFactory {
                     confirmDopt.isSearchEnabled = false;
                     confirmDopt.callback = (s) -> {
                         viewDialog.dismiss();
-                        TodoTxtFilter.deleteFilterIndex(activity, finalI);
+                        TodoTxtFilter.deleteFilterIndex(activity, i);
                     };
                     GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, confirmDopt);
                 };

--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -26,6 +26,7 @@ import android.text.Html;
 import android.text.InputType;
 import android.text.Spannable;
 import android.text.TextUtils;
+import android.util.Pair;
 import android.view.Gravity;
 import android.view.WindowManager;
 import android.widget.Button;
@@ -47,6 +48,7 @@ import net.gsantner.markor.frontend.textview.SyntaxHighlighterBase;
 import net.gsantner.markor.frontend.textview.TextViewUtils;
 import net.gsantner.markor.model.AppSettings;
 import net.gsantner.opoc.frontend.GsSearchOrCustomTextDialog;
+import net.gsantner.opoc.frontend.GsSearchOrCustomTextDialog.DialogOptions;
 import net.gsantner.opoc.util.GsContextUtils;
 import net.gsantner.opoc.util.GsFileUtils;
 import net.gsantner.opoc.wrapper.GsCallback;
@@ -55,10 +57,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
@@ -68,7 +68,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showSpecialKeyDialog(Activity activity, GsCallback.a1<String> callback) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         dopt.callback = callback;
         String[] actions = activity.getResources().getStringArray(R.array.textactions_press_key__text);
@@ -97,7 +97,7 @@ public class MarkorDialogFactory {
         addToList.callback(R.string.audio, R.id.action_attach_audio, R.drawable.ic_keyboard_voice_black_24dp);
         addToList.callback(R.string.date, R.id.action_attach_date, R.drawable.ic_access_time_black_24dp);
 
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         dopt.callback = str -> userCallback.callback(availableDataToActionMap.get(availableData.indexOf(str)));
         dopt.data = availableData;
@@ -111,7 +111,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showInsertTableRowDialog(final Activity activity, final boolean isHeader, GsCallback.a2<Integer, Boolean> callback) {
-        final GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        final DialogOptions dopt = new DialogOptions();
         final String PREF_LAST_USED_TABLE_SIZE = "pref_key_last_used_table_size";
         final int lastUsedTableSize = as().getInt(PREF_LAST_USED_TABLE_SIZE, 3);
         final List<String> availableData = new ArrayList<>();
@@ -148,7 +148,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showSttArchiveDialog(Activity activity, GsCallback.a1<String> callback) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         dopt.callback = callback;
         List<String> highlightedData = new ArrayList<>();
@@ -174,7 +174,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showSttSortDialogue(Activity activity, final GsCallback.a2<String, Boolean> callback) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         final List<String> availableData = new ArrayList<>();
         final List<Integer> availableDataToIconMap = new ArrayList<>();
@@ -234,7 +234,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showSttContextDialog(Activity activity, List<String> availableData, GsCallback.a1<String> callback) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         dopt.data = new ArrayList<>(new TreeSet<>(availableData));
         dopt.callback = callback;
@@ -249,7 +249,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showSttFilteringDialog(final Activity activity, final EditText text) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
 
         final List<String> options = new ArrayList<>();
@@ -258,49 +258,54 @@ public class MarkorDialogFactory {
 
         options.add(activity.getString(R.string.priority));
         icons.add(R.drawable.ic_star_black_24dp);
-        callbacks.add(() -> showSttKeySearchDialog(activity, text, R.string.browse_by_priority, false, false, TodoTxtFilter.PRIORITY));
+        callbacks.add(() -> showSttKeySearchDialog(activity, text, R.string.browse_by_priority, false, false, TodoTxtFilter.TYPE.PRIORITY));
 
         options.add(activity.getString(R.string.due_date));
         icons.add(R.drawable.ic_date_range_black_24dp);
-        callbacks.add(() -> showSttKeySearchDialog(activity, text, R.string.browse_by_due_date, false, false, TodoTxtFilter.DUE));
+        callbacks.add(() -> showSttKeySearchDialog(activity, text, R.string.browse_by_due_date, false, false, TodoTxtFilter.TYPE.DUE));
 
         options.add(activity.getString(R.string.project));
         icons.add(R.drawable.ic_new_label_black_24dp);
-        callbacks.add(() -> showSttKeySearchDialog(activity, text, R.string.browse_by_project, true, true, TodoTxtFilter.PROJECT));
+        callbacks.add(() -> showSttKeySearchDialog(activity, text, R.string.browse_by_project, true, true, TodoTxtFilter.TYPE.PROJECT));
 
         options.add(activity.getString(R.string.context));
         icons.add(R.drawable.gs_email_sign_black_24dp);
-        callbacks.add(() -> showSttKeySearchDialog(activity, text, R.string.browse_by_context, true, true, TodoTxtFilter.CONTEXT));
+        callbacks.add(() -> showSttKeySearchDialog(activity, text, R.string.browse_by_context, true, true, TodoTxtFilter.TYPE.CONTEXT));
 
-        options.add(activity.getString(R.string.completed));
-        icons.add(R.drawable.ic_check_black_24dp);
+        options.add(activity.getString(R.string.query));
+        icons.add(R.drawable.ic_extension_black_24dp);
         callbacks.add(() -> {
-            final GsSearchOrCustomTextDialog.DialogOptions dopt2 = makeSttLineSelectionDialog(activity, text, TodoTxtTask::isDone);
-            dopt2.highlighter = null; // Don't need the grey + strikeout highlighting. Makes it harder to see.
-            dopt2.titleText = R.string.completed;
+            final DialogOptions dopt2 = makeSttLineSelectionDialog(activity, text, t -> true);
+            dopt2.titleText = R.string.query;
+            final String[] queryHolder = new String[1];
+            dopt2.searchFunction = (query, line) -> {
+                queryHolder[0] = query.toString();
+                return TodoTxtFilter.isMatchQuery(new TodoTxtTask(line), query);
+            };
+            addSaveQuery(activity, dopt2, () -> queryHolder[0]);
             GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt2);
         });
 
         // Add saved views
-        final List<TodoTxtFilter.Group> savedViews = TodoTxtFilter.loadSavedFilters(activity);
+        final List<Pair<String, String>> savedViews = TodoTxtFilter.loadSavedFilters(activity);
         for (int i = 0; i < savedViews.size(); i++) {
             final int finalI = i; // Final so we can use it in callback
-            final TodoTxtFilter.Group gp = savedViews.get(i);
             // No icon for the saved searches
-            options.add(gp.title);
+            final String title = savedViews.get(i).first;
+            final String query = savedViews.get(i).second;
+            options.add(title);
             callbacks.add(() -> {
-                final GsSearchOrCustomTextDialog.DialogOptions doptView = makeSttLineSelectionDialog(
-                        activity, text, TodoTxtFilter.taskSelector(gp.keys, TodoTxtFilter.keyGetter(activity, gp.queryType), gp.isAnd));
+                final DialogOptions doptView = makeSttLineSelectionDialog(activity, text, t -> TodoTxtFilter.isMatchQuery(t, query));
                 doptView.titleText = R.string.search;
-                doptView.messageText = gp.title;
+                doptView.messageText = title + ": " + query;
 
                 // Delete view
                 doptView.neutralButtonText = R.string.delete;
                 doptView.neutralButtonCallback = viewDialog -> {
-                    final GsSearchOrCustomTextDialog.DialogOptions confirmDopt = new GsSearchOrCustomTextDialog.DialogOptions();
+                    final DialogOptions confirmDopt = new DialogOptions();
                     baseConf(activity, confirmDopt);
                     confirmDopt.titleText = R.string.confirm_delete;
-                    confirmDopt.messageText = gp.title;
+                    confirmDopt.messageText = title;
                     confirmDopt.isSearchEnabled = false;
                     confirmDopt.callback = (s) -> {
                         viewDialog.dismiss();
@@ -329,47 +334,40 @@ public class MarkorDialogFactory {
      * Will display a list of keys. The user can select multiple keys and a list of todos which match the keys will be displayed.
      * The user can then search and select one or more (filtered) todos.
      *
-     * @param activity  Context activity
-     * @param text      Edit Text with todos
-     * @param title     Dialog title
-     * @param queryType Key used with TodoTxtFilter
+     * @param activity      Context activity
+     * @param text          Edit Text with todos
+     * @param title         Dialog title
+     * @param enableSearch  Whether key search is enabled
+     * @param enableSearch  Whether 'and' keys makes sense / is enabled
+     * @param queryType     Key used with TodoTxtFilter
      */
-    public static void showSttKeySearchDialog(final Activity activity, final EditText text, final int title, final boolean enableSearch, final boolean enableAnd, final String queryType) {
+    public static void showSttKeySearchDialog(
+            final Activity activity,
+            final EditText text,
+            final int title,
+            final boolean enableSearch,
+            final boolean enableAnd,
+            final TodoTxtFilter.TYPE queryType
+    ) {
 
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        final DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
 
-        final GsCallback.r1<List<String>, TodoTxtTask> getKeys = TodoTxtFilter.keyGetter(activity, queryType);
+        // Populate options
+        // -------------------------------------
+
         final List<TodoTxtTask> allTasks = TodoTxtTask.getAllTasks(text.getText());
-
-        final List<String> keys = new ArrayList<>();
-        final int[] noneCount = {0}; // Using an array as we need a final var
-        for (final TodoTxtTask task : allTasks) {
-            if (!task.isDone()) {
-                final List<String> taskKeys = getKeys.callback(task);
-                noneCount[0] += (taskKeys.size() == 0) ? 1 : 0;
-                keys.addAll(taskKeys);
-            }
-        }
-
-        final List<String> options = new ArrayList<>(), data = new ArrayList<>();
-        final String countFormat = "%s (%d)";
-
-        // Add none case
-        final String noneString = "—";
-        if (noneCount[0] > 0) {
-            final String noneWithCount = String.format(countFormat, noneString, noneCount[0]);
-            options.add(noneWithCount);
-            dopt.highlightData = Collections.singletonList(noneWithCount);
-            data.add(""); // Dummy to make options match data
-        }
+        final List<TodoTxtFilter.SttFilterKey> keys = TodoTxtFilter.getKeys(activity, allTasks, queryType);
 
         // Add other cases
-        for (final String k : new TreeSet<>(keys)) {
-            options.add(String.format(countFormat, k, Collections.frequency(keys, k)));
-            data.add(k);
+        final List<String> data = new ArrayList<>();
+        for (final TodoTxtFilter.SttFilterKey k : keys) {
+            data.add(String.format("%s (%d)", k.key, k.count));
         }
-        dopt.data = options;
+        dopt.data = data;
+
+        // Set up _and_ key
+        // -------------------------------------
 
         final boolean[] useAnd = {false};
         if (enableAnd) {
@@ -383,50 +381,67 @@ public class MarkorDialogFactory {
             };
         }
 
+        // Other options
+        // -------------------------------------
         dopt.titleText = title;
         dopt.isSearchEnabled = enableSearch;
         dopt.searchHintText = R.string.search;
         dopt.isMultiSelectEnabled = true;
 
+        // Callback to actually show tasks
+        // -------------------------------------
         dopt.positionCallback = (keyIndices) -> {
 
-            final boolean noneIncluded = (noneCount[0] > 0) && keyIndices.size() > 0 && keyIndices.get(0) == 0;
-            final Set<String> selKeys = new HashSet<>();
-            for (int i = noneIncluded ? 1 : 0; i < keyIndices.size(); i++) {
-                selKeys.add(data.get(keyIndices.get(i)));
-            }
-            if (noneIncluded) {
-                selKeys.add(null);
+            // Build a query
+            final List<String> queryKeys = new ArrayList<>();
+            for (final Integer index : keyIndices) {
+                queryKeys.add(keys.get(index).query);
             }
 
-            final GsSearchOrCustomTextDialog.DialogOptions doptSel = makeSttLineSelectionDialog(
-                    activity, text, TodoTxtFilter.taskSelector(selKeys, getKeys, useAnd[0]));
-            doptSel.messageText = activity.getString(title);
+            final String query = TodoTxtFilter.makeQuery(queryKeys, useAnd[0], queryType);
 
-            // Callback to save view
-            doptSel.neutralButtonText = R.string.save;
-            doptSel.neutralButtonCallback = (dialog) -> {
-                // Get save name
-                final GsSearchOrCustomTextDialog.DialogOptions doptSave = new GsSearchOrCustomTextDialog.DialogOptions();
-                baseConf(activity, doptSave);
-                doptSave.titleText = R.string.name;
-                doptSave.searchHintText = R.string.empty_string;
-                doptSave.callback = saveTitle -> {
-                    if (!TextUtils.isEmpty(saveTitle)) {
-                        TodoTxtFilter.saveFilter(activity, saveTitle, queryType, selKeys, useAnd[0]);
-                    }
-                };
-                // Note that we do not dismiss the existing view
-                GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, doptSave);
-            };
+            final DialogOptions doptSel = makeSttLineSelectionDialog(activity, text, t -> TodoTxtFilter.isMatchQuery(t, query));
+            doptSel.messageText = activity.getString(title) + ": " + query;
+            addSaveQuery(activity, doptSel, () -> query);
 
             GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, doptSel);
         };
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
     }
 
-    public static GsSearchOrCustomTextDialog.DialogOptions makeSttLineSelectionDialog(final Activity activity, final EditText text, final GsCallback.b1<TodoTxtTask> filter) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+    private static void addSaveQuery(final Activity activity, final DialogOptions dopt, final GsCallback.s0 getQuery) {
+        // Callback to save view
+        dopt.neutralButtonText = R.string.save;
+        dopt.neutralButtonCallback = (dialog) -> {
+            final String query = getQuery.callback();
+            // Get save name
+            final DialogOptions doptSave = new DialogOptions();
+            baseConf(activity, doptSave);
+            doptSave.titleText = R.string.name;
+            doptSave.searchHintText = R.string.empty_string;
+            doptSave.callback = saveTitle -> {
+                if (!TextUtils.isEmpty(saveTitle)) {
+                    TodoTxtFilter.saveFilter(activity, saveTitle, query);
+                }
+            };
+            // Note that we do not dismiss the existing view
+            GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, doptSave);
+        };
+    }
+
+    /**
+     * Make a dialog for searching and selecting lines of a todo-txt file
+     * @param activity Activity
+     * @param text     EditText containing the todo.txt file
+     * @param filter   Filter selecting certain todos (by context, project etc etc)
+     * @return Dialogoptions for the dialog. Can be further modified by the caller
+     */
+    public static DialogOptions makeSttLineSelectionDialog(
+            final Activity activity,
+            final EditText text,
+            final GsCallback.b1<TodoTxtTask> filter
+    ) {
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         final List<TodoTxtTask> allTasks = TodoTxtTask.getAllTasks(text.getText());
         final List<String> lines = new ArrayList<>();
@@ -454,23 +469,21 @@ public class MarkorDialogFactory {
     }
 
     public static void showSttSearchDialog(final Activity activity, final EditText text) {
-        final GsSearchOrCustomTextDialog.DialogOptions dopt = makeSttLineSelectionDialog(activity, text, t -> true);
+        final DialogOptions dopt = makeSttLineSelectionDialog(activity, text, t -> true);
         dopt.titleText = R.string.search_documents;
         dopt.neutralButtonText = R.string.search_and_replace;
         dopt.neutralButtonCallback = (dialog) -> {
             dialog.dismiss();
             SearchAndReplaceTextDialog.showSearchReplaceDialog(activity, text.getText(), TextViewUtils.getSelection(text));
         };
-
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
     }
-
 
     /**
      * Allow to choose between Hexcolor / foreground / background color, pass back stringid
      */
     public static void showColorSelectionModeDialog(Activity activity, GsCallback.a1<Integer> callback) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
 
         final String hexcode = activity.getString(R.string.hexcode);
         final String fg = activity.getString(R.string.foreground);
@@ -496,7 +509,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showSttProjectDialog(Activity activity, List<String> availableData, GsCallback.a1<String> callback) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         dopt.data = new ArrayList<>(new TreeSet<>(availableData));
         dopt.callback = callback;
@@ -517,7 +530,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showSearchDialog(final Activity activity, final EditText text) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt2 = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt2 = new DialogOptions();
         baseConf(activity, dopt2);
         final Editable edit = text.getText();
         dopt2.data = Arrays.asList(edit.toString().split("\n", -1)); // Do not ignore empty lines
@@ -534,7 +547,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showHeadlineDialog(final String headlineFilterPattern, final Activity activity, final EditText text) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt2 = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt2 = new DialogOptions();
         baseConf(activity, dopt2);
         dopt2.positionCallback = (result) -> TextViewUtils.selectLines(text, result);
         dopt2.data = Arrays.asList(text.getText().toString().split("\n", -1));
@@ -542,13 +555,12 @@ public class MarkorDialogFactory {
         dopt2.searchHintText = R.string.search;
         dopt2.extraFilter = headlineFilterPattern;
         dopt2.isSearchEnabled = true;
-        dopt2.searchIsRegex = false;
         dopt2.gravity = Gravity.TOP;
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt2);
     }
 
     public static void showIndentSizeDialog(final Activity activity, final int indent, final GsCallback.a1<String> callback) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         dopt.callback = callback;
         dopt.data = Arrays.asList("1", "2", "4", "8");
@@ -561,7 +573,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showFontSizeDialog(final Activity activity, final int currentSize, final GsCallback.a1<Integer> callback) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         dopt.callback = (selectedDialogValueAsString -> callback.callback(Integer.parseInt(selectedDialogValueAsString)));
         final int minFontSize = 1;
@@ -580,7 +592,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showPriorityDialog(Activity activity, char selectedPriority, GsCallback.a1<String> callback) {
-        GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         dopt.callback = callback;
 
@@ -616,7 +628,7 @@ public class MarkorDialogFactory {
 
     @SuppressLint("StringFormatMatches")
     public static void showCopyMoveConflictDialog(final Activity activity, final String fileName, final String destName, final boolean multiple, final GsCallback.a1<Integer> callback) {
-        final GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        final DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         dopt.positionCallback = (result) -> callback.callback(result.get(0));
         final List<String> data = new ArrayList<>();
@@ -641,7 +653,7 @@ public class MarkorDialogFactory {
 
     public static void showSetPasswordDialog(final Activity activity) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            final GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+            final DialogOptions dopt = new DialogOptions();
             baseConf(activity, dopt);
             dopt.isSearchEnabled = true;
             dopt.titleText = R.string.file_encryption_password;
@@ -680,7 +692,7 @@ public class MarkorDialogFactory {
     }
 
     public static void showInsertSnippetDialog(final Activity activity, final GsCallback.a1<String> callback) {
-        final GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
+        final DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
 
         final Map<String, File> texts = getSnippets(as());
@@ -694,7 +706,7 @@ public class MarkorDialogFactory {
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
     }
 
-    public static void baseConf(Activity activity, GsSearchOrCustomTextDialog.DialogOptions dopt) {
+    public static void baseConf(Activity activity, DialogOptions dopt) {
         dopt.isDarkDialog = GsContextUtils.instance.isDarkModeEnabled(activity);
         dopt.clearInputIcon = R.drawable.ic_baseline_clear_24;
         dopt.textColor = ContextCompat.getColor(activity, R.color.primary_text);

--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -473,6 +473,7 @@ public class MarkorDialogFactory {
         return dopt;
     }
 
+    // Search dialog for todo.txt
     public static void showSttSearchDialog(final Activity activity, final EditText text) {
         final DialogOptions dopt = makeSttLineSelectionDialog(activity, text, t -> true);
         dopt.titleText = R.string.search_documents;
@@ -526,33 +527,19 @@ public class MarkorDialogFactory {
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
     }
 
-    public static void showSttContextDialog(Activity activity, List<String> availableData, GsCallback.a1<String> callback) {
-        DialogOptions dopt = new DialogOptions();
-        baseConf(activity, dopt);
-        dopt.data = new ArrayList<>(new TreeSet<>(availableData));
-        dopt.callback = callback;
-        dopt.titleText = R.string.insert_context;
-        dopt.isMultiSelectEnabled = true;
-        dopt.positionCallback = (result) -> {
-            for (final Integer i : result) {
-                callback.callback(dopt.data.get(i).toString());
-            }
-        };
-        GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
-    }
-
+    // Insert items
     public static void showInsertItemsDialog(
             final Activity activity,
             final @StringRes int title,
             final List<String> data,
-            final @Nullable EditText text,
+            final @Nullable EditText text,              // Passed in here for keyboard restore
             final GsCallback.a1<String> insertCallback
     ) {
         GsSearchOrCustomTextDialog.DialogOptions dopt = new GsSearchOrCustomTextDialog.DialogOptions();
         baseConf(activity, dopt);
         dopt.data = new ArrayList<>(new TreeSet<>(data));
         dopt.callback = insertCallback;
-        dopt.titleText = R.string.insert_project;
+        dopt.titleText = title;
         dopt.searchHintText = R.string.search_or_custom;
         dopt.isMultiSelectEnabled = true;
         dopt.positionCallback = (result) -> {
@@ -566,11 +553,13 @@ public class MarkorDialogFactory {
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
     }
 
+    // Get a callback which applies highligting spans to a todo.txt line
     private static GsCallback.a1<Spannable> getSttHighlighter() {
         final SyntaxHighlighterBase h = new TodoTxtBasicSyntaxHighlighter(as()).configure();
         return s -> h.setSpannable(s).recompute().applyAll();
     }
 
+    // Basic search dialog
     public static void showSearchDialog(final Activity activity, final EditText text) {
         final DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);

--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -325,13 +325,13 @@ public class MarkorDialogFactory {
      * Will display a list of keys. The user can select multiple keys and a list of todos which match the keys will be displayed.
      * The user can then search and select one or more (filtered) todos.
      *
-     * @param activity      Context activity
-     * @param text          Edit Text with todos
-     * @param title         Dialog title
-     * @param enableSearch  Whether key search is enabled
-     * @param enableAnd     Whether 'and' keys makes sense / is enabled
-     * @param showIme       Whether to show IME when done (if == true)
-     * @param queryType     Key used with TodoTxtFilter
+     * @param activity     Context activity
+     * @param text         Edit Text with todos
+     * @param title        Dialog title
+     * @param enableSearch Whether key search is enabled
+     * @param enableAnd    Whether 'and' keys makes sense / is enabled
+     * @param showIme      Whether to show IME when done (if == true)
+     * @param queryType    Key used with TodoTxtFilter
      */
     public static void showSttKeySearchDialog(
             final Activity activity,
@@ -439,6 +439,7 @@ public class MarkorDialogFactory {
 
     /**
      * Make a dialog for searching and selecting lines of a todo-txt file
+     *
      * @param activity Activity
      * @param text     EditText containing the todo.txt file
      * @param filter   Filter selecting certain todos (by context, project etc etc)

--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -407,8 +407,10 @@ public class MarkorDialogFactory {
     }
 
     private static void setQueryTitle(final DialogOptions dopt, final String subTitle, final String query) {
+        // Remove the actual title
         dopt.titleText = 0;
-        dopt.messageText = Html.fromHtml(String.format("<h2>%s</h2><small>%s</small>", subTitle, query));
+        // Use a message text with 2 lines and a bold name
+        dopt.messageText = Html.fromHtml(String.format("<b>%s</b><br><small>%s</small>", subTitle, query));
     }
 
     // Add the save query dialog
@@ -483,10 +485,12 @@ public class MarkorDialogFactory {
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
     }
 
+    // Restore the keyboard when dialog closes if keyboard is open when dialog was called
     private static void addRestoreKeyboard(final Activity activity, final DialogOptions options, final EditText edit) {
         addRestoreKeyboard(activity, options, edit, TextViewUtils.isImeOpen(edit));
     }
 
+    // Restore the keyboard when dialog closes if required
     private static void addRestoreKeyboard(final Activity activity, final DialogOptions options, final EditText edit, final Boolean restore) {
         if (restore != null && restore) {
             options.dismissCallback = (d) -> GsContextUtils.instance.setSoftKeyboardVisible(activity, true, edit);

--- a/app/src/main/java/net/gsantner/markor/frontend/textview/TextViewUtils.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/textview/TextViewUtils.java
@@ -10,6 +10,7 @@
 package net.gsantner.markor.frontend.textview;
 
 import android.graphics.Rect;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.Editable;
@@ -17,6 +18,8 @@ import android.text.InputFilter;
 import android.text.Layout;
 import android.text.Selection;
 import android.text.TextUtils;
+import android.view.View;
+import android.view.WindowInsets;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -636,5 +639,13 @@ public final class TextViewUtils extends GsTextUtils {
 
     public static boolean checkRange(final int length, final int... indices) {
         return indices != null && indices.length >= 2 && inRange(0, length, indices) && indices[1] > indices[0];
+    }
+
+    // Check if keyboard open. Only available after android 11 :(
+    public static Boolean isImeOpen(final View view) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return view.getRootWindowInsets().isVisible(WindowInsets.Type.ime());
+        }
+        return null; // Uncertain
     }
 }

--- a/app/src/main/java/net/gsantner/markor/model/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/model/AppSettings.java
@@ -286,10 +286,6 @@ public class AppSettings extends GsSharedPreferencesPropertyBackend {
         return getInt(R.string.pref_key__editor_line_spacing, 100) / 100f;
     }
 
-    public void setLastTodoUsedArchiveFilename(String value) {
-        setString(R.string.pref_key__todotxt__last_used_archive_filename, value);
-    }
-
     public String getLastTodoUsedArchiveFilename() {
         return getString(R.string.pref_key__todotxt__last_used_archive_filename, "todo.archive.txt");
     }
@@ -355,6 +351,22 @@ public class AppSettings extends GsSharedPreferencesPropertyBackend {
     private static final String PREF_PREFIX_AUTO_FORMAT = "PREF_PREFIX_AUTO_FORMAT";
     private static final String PREF_PREFIX_VIEW_SCROLL_X = "PREF_PREFIX_VIEW_SCROLL_X";
     private static final String PREF_PREFIX_VIEW_SCROLL_Y = "PREF_PREFIX_VIEW_SCROLL_Y";
+    private static final String PREF_PREFIX_TODO_DONE_NAME = "PREF_PREFIX_TODO_DONE_NAME";
+
+    public void setLastTodoDoneName(final String path, final String name) {
+        if (fexists(path)) {
+            setString(PREF_PREFIX_TODO_DONE_NAME + path, name);
+        }
+    }
+
+    public String getLastTodoDoneName(final String path) {
+        final String def = getLastTodoUsedArchiveFilename();
+        if (!fexists(path)) {
+            return def;
+        } else {
+            return getString(PREF_PREFIX_TODO_DONE_NAME + path, def);
+        }
+    }
 
     public void setLastEditPosition(final String path, final int pos) {
         if (fexists(path)) {

--- a/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
@@ -171,7 +171,7 @@ public class GsTextUtils {
 
     // Not null, not empty, not spaces only
     public static boolean isNullOrEmpty(final CharSequence str) {
-        return str == null || str.toString().trim().isEmpty();
+        return str == null || str.length() == 0 || str.toString().trim().isEmpty();
     }
 
     /**

--- a/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
@@ -9,6 +9,8 @@
 #########################################################*/
 package net.gsantner.opoc.format;
 
+import android.text.Html;
+import android.text.Spanned;
 import android.util.Base64;
 
 import org.json.JSONArray;

--- a/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
@@ -9,8 +9,6 @@
 #########################################################*/
 package net.gsantner.opoc.format;
 
-import android.text.Html;
-import android.text.Spanned;
 import android.util.Base64;
 
 import org.json.JSONArray;
@@ -247,7 +245,7 @@ public class GsTextUtils {
         return null;
     }
 
-    public static List<Integer> range(final int ... ops) {
+    public static List<Integer> range(final int... ops) {
         int start = 0, end = 0, step = 1;
         if (ops != null) {
             if (ops.length == 1) {

--- a/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
@@ -21,6 +21,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Random;
 
 @SuppressWarnings({"unused", "SpellCheckingInspection"})
@@ -244,5 +245,29 @@ public class GsTextUtils {
         } catch (Exception ignored) {
         }
         return null;
+    }
+
+    public static List<Integer> range(final int ... ops) {
+        int start = 0, end = 0, step = 1;
+        if (ops != null) {
+            if (ops.length == 1) {
+                end = ops[0];
+            } else if (ops.length == 2) {
+                start = ops[0];
+                end = ops[1];
+            } else if (ops.length >= 3) {
+                start = ops[0];
+                end = ops[1];
+                step = ops[2];
+            }
+        }
+
+        final List<Integer> values = new ArrayList<>();
+        while (start < end) {
+            values.add(start);
+            start += step;
+        }
+
+        return values;
     }
 }

--- a/app/src/main/java/net/gsantner/opoc/frontend/GsSearchOrCustomTextDialog.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/GsSearchOrCustomTextDialog.java
@@ -410,6 +410,7 @@ public class GsSearchOrCustomTextDialog {
             final TextView subTitle = new TextView(context, null, android.R.attr.textAppearanceMedium);
             subTitle.setPadding(0, dopt.titleText == 0 ? 0 : paddingBetween, 0, 0);
             subTitle.setText(dopt.messageText);
+            subTitle.setTextIsSelectable(true);
             titleLayout.addView(subTitle, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
         }
 

--- a/app/src/main/java/net/gsantner/opoc/frontend/GsSearchOrCustomTextDialog.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/GsSearchOrCustomTextDialog.java
@@ -13,6 +13,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Typeface;
@@ -89,12 +90,9 @@ public class GsSearchOrCustomTextDialog {
         public GsCallback.a1<Spannable> highlighter = null;
         public String extraFilter = null;
         public List<Integer> preSelected = null;
-        // Constraint, item to test
-        public GsCallback.b2<CharSequence, CharSequence> searchFunction = GsSearchOrCustomTextDialog::standardSearch;
-        // Check if constraint is valid
-        public GsCallback.b1<CharSequence> queryValidator = null;
-
         public GsCallback.a1<AlertDialog> neutralButtonCallback = null;
+        public GsCallback.b2<CharSequence, CharSequence> searchFunction = GsSearchOrCustomTextDialog::standardSearch;
+        public GsCallback.a1<DialogInterface> dismissCallback = null;
 
         @ColorInt
         public int textColor = 0xFF000000;
@@ -262,6 +260,10 @@ public class GsSearchOrCustomTextDialog {
         listLayout.weight = 1;
         mainLayout.addView(listView, listLayout);
 
+        if (dopt.dismissCallback != null) {
+            dialogBuilder.setOnDismissListener(dopt.dismissCallback::callback);
+        }
+
         dialogBuilder.setView(mainLayout)
                 .setOnCancelListener(null)
                 .setNegativeButton(dopt.cancelButtonText, (dialogInterface, i) -> dialogInterface.dismiss());
@@ -393,19 +395,20 @@ public class GsSearchOrCustomTextDialog {
         titleLayout.setOrientation(LinearLayout.VERTICAL);
         titleLayout.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
         titleLayout.setGravity(Gravity.CENTER_VERTICAL | Gravity.START);
-        titleLayout.setPadding(paddingSide, paddingSide, paddingSide, paddingBetween);
+        titleLayout.setPadding(paddingSide, 2 * paddingBetween, paddingSide, paddingBetween);
 
         if (dopt.titleText != 0) {
             final TextView title = new TextView(context, null, android.R.attr.windowTitleStyle);
             title.setSingleLine();
             title.setEllipsize(TextUtils.TruncateAt.END);
             title.setText(dopt.titleText);
+            title.setPadding(0, 0, 0, 0);
             titleLayout.addView(title, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
         }
 
         if (!TextUtils.isEmpty(dopt.messageText)) {
             final TextView subTitle = new TextView(context, null, android.R.attr.textAppearanceMedium);
-            subTitle.setPadding(0, paddingBetween, 0, 0);
+            subTitle.setPadding(0, dopt.titleText == 0 ? 0 : paddingBetween, 0, 0);
             subTitle.setText(dopt.messageText);
             titleLayout.addView(subTitle, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
         }
@@ -443,10 +446,10 @@ public class GsSearchOrCustomTextDialog {
         TooltipCompat.setTooltipText(clearButton, context.getString(android.R.string.cancel));
         clearButton.setColorFilter(dopt.isDarkDialog ? Color.WHITE : Color.parseColor("#ff505050"));
         clearButton.setOnClickListener((v) -> searchEditText.setText(""));
+        clearButton.setPadding(margin, 0, margin, 0);
 
         final LinearLayout.LayoutParams clearLp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.MATCH_PARENT, 0);
         clearLp.gravity = Gravity.END | Gravity.CENTER_VERTICAL;
-        clearLp.setMargins(margin, 0, (int) (margin * 1.5), 0);
         searchLayout.addView(clearButton, clearLp);
 
         return searchLayout;

--- a/app/src/main/java/net/gsantner/opoc/frontend/GsSearchOrCustomTextDialog.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/GsSearchOrCustomTextDialog.java
@@ -86,10 +86,13 @@ public class GsSearchOrCustomTextDialog {
         public int dialogHeightDp = WindowManager.LayoutParams.WRAP_CONTENT;
         public int gravity = Gravity.NO_GRAVITY;
         public int searchInputType = InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
-        public boolean searchIsRegex = false;
         public GsCallback.a1<Spannable> highlighter = null;
         public String extraFilter = null;
         public List<Integer> preSelected = null;
+        // Constraint, item to test
+        public GsCallback.b2<CharSequence, CharSequence> searchFunction = GsSearchOrCustomTextDialog::standardSearch;
+        // Check if constraint is valid
+        public GsCallback.b1<CharSequence> queryValidator = null;
 
         public GsCallback.a1<AlertDialog> neutralButtonCallback = null;
 
@@ -199,15 +202,11 @@ public class GsSearchOrCustomTextDialog {
                     final List<Integer> resList = new ArrayList<>();
 
                     if (_dopt.data != null) {
-                        final String fil = constraint.toString();
-                        final boolean emptySearch = fil.isEmpty();
+                        final boolean emptySearch = constraint.length() == 0;
                         for (int i = 0; i < _dopt.data.size(); i++) {
                             final String str = _dopt.data.get(i).toString();
                             final boolean matchExtra = (_extraPattern == null) || _extraPattern.matcher(str).find();
-                            final Locale locale = Locale.getDefault();
-                            final boolean matchNormal = str.toLowerCase(locale).contains(fil.toLowerCase(locale));
-                            final boolean matchRegex = _dopt.searchIsRegex && (str.matches(fil));
-                            if (matchExtra && (matchNormal || matchRegex || emptySearch)) {
+                            if (matchExtra && (emptySearch || _dopt.searchFunction.callback(constraint, str))) {
                                 resList.add(i);
                             }
                         }
@@ -220,6 +219,11 @@ public class GsSearchOrCustomTextDialog {
                 }
             };
         }
+    }
+
+    public static boolean standardSearch(final CharSequence constraint, final CharSequence text) {
+        final Locale locale = Locale.getDefault();
+        return text.toString().toLowerCase(locale).contains(constraint.toString().toLowerCase(locale));
     }
 
     public static void showMultiChoiceDialogWithSearchFilterUI(final Activity activity, final DialogOptions dopt) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,6 +448,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="due_today">Due today</string>
     <string name="due_future">Due in future</string>
     <string name="completed">Completed</string>
+    <string name="query">Query</string>
     <string name="match_any">Match Any</string>
     <string name="match_all">Match All</string>
     <string name="dynamic_notebook_root_links">Dynamic search for notebook root</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,7 +448,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="due_today">Due today</string>
     <string name="due_future">Due in future</string>
     <string name="completed">Completed</string>
-    <string name="query">Query</string>
+    <string name="advanced_filtering">Advanced filtering</string>
     <string name="match_any">Match Any</string>
     <string name="match_all">Match All</string>
     <string name="dynamic_notebook_root_links">Dynamic search for notebook root</string>

--- a/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
+++ b/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
@@ -1,0 +1,39 @@
+package net.gsantner.markor.format.todotxt;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class TodoTxtQuerySyntaxTests {
+
+    private String strip(final String in) {
+        return in.replace(" ", "");
+    }
+
+    @Test
+    public void ParseQuery() {
+        final String query = "(A | B | C) & !+work & overdue & future";
+        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(A) 2000-01-01 go to +work"), query)).isEqualTo(strip("(T | F | F) & !T & F & F"));
+        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(B) 2000-01-01 go to +work due:2000-01-01"), query)).isEqualTo(strip("(F | T | F) & !T & T & F"));
+        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(D) 2000-01-01 go to work due:9999-01-01"), query)).isEqualTo(strip("(F | T | F) & !T & F & T"));
+    }
+
+    @Test
+    public void EvaluateExpression() {
+        assertThat(TodoTxtFilter.shuntingYard(strip("T"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("F"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.shuntingYard(strip("!T"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.shuntingYard(strip("!F"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("!(F)"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("(!F)"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("(!(F))"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("!(!(F))"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.shuntingYard(strip("T | F"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("T & F"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.shuntingYard(strip("T | T | T | T | F"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("F | F | F | F | T"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("!(T | F) & (T | F)"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.shuntingYard(strip("!(T | F) | (T | F)"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("!(T | F | F) & (T | F) | (F & (!T) | T)"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.shuntingYard(strip("!!!!!!F"))).isEqualTo(false);
+    }
+}

--- a/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
+++ b/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
@@ -14,7 +14,7 @@ public class TodoTxtQuerySyntaxTests {
         final String query = "(A | B | C) & !+work & overdue & future";
         assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(A) 2000-01-01 go to +work"), query)).isEqualTo(strip("(T | F | F) & !T & F & F"));
         assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(B) 2000-01-01 go to +work due:2000-01-01"), query)).isEqualTo(strip("(F | T | F) & !T & T & F"));
-        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(D) 2000-01-01 go to work due:9999-01-01"), query)).isEqualTo(strip("(F | T | F) & !T & F & T"));
+        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(D) 2000-01-01 go to work due:9999-01-01"), query)).isEqualTo(strip("(F | F | F) & !F & F & T"));
     }
 
     @Test

--- a/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
+++ b/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
@@ -11,10 +11,16 @@ public class TodoTxtQuerySyntaxTests {
 
     @Test
     public void ParseQuery() {
-        final String query = "(A | B | C) & !+work & overdue & future";
-        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(A) 2000-01-01 go to +work"), query)).isEqualTo(strip("(T | F | F) & !T & F & F"));
-        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(B) 2000-01-01 go to +work due:2000-01-01"), query)).isEqualTo(strip("(F | T | F) & !T & T & F"));
-        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(D) 2000-01-01 go to work due:9999-01-01"), query)).isEqualTo(strip("(F | F | F) & !F & F & T"));
+        final String query = "(A | B | C) & !+work & due< & due> | !+ | @";
+
+        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(A) 2000-01-01 go to +work"), query))
+                .isEqualTo(strip("(T | F | F) & !T & F & F | !T | F"));
+
+        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(B) 2000-01-01 go to +work due:2000-01-01"), query))
+                .isEqualTo(strip("(F | T | F) & !T & T & F | !T | F"));
+
+        assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(D) 2000-01-01 go to @work due:9999-01-01"), query))
+                .isEqualTo(strip("(F | F | F) & !F & F & T| !F | T"));
     }
 
     @Test

--- a/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
+++ b/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
@@ -1,4 +1,5 @@
 package net.gsantner.markor.format.todotxt;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;

--- a/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
+++ b/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
@@ -11,7 +11,7 @@ public class TodoTxtQuerySyntaxTests {
 
     @Test
     public void ParseQuery() {
-        final String query = "(A | B | C) & !+work & due< & due> | !+ | @";
+        final String query = "(pri:A | pri:B | pri:C) & !+work & due< & due> | !+ | @";
 
         assertThat(TodoTxtFilter.parseQuery(new TodoTxtTask("(A) 2000-01-01 go to +work"), query))
                 .isEqualTo(strip("(T | F | F) & !T & F & F | !T | F"));

--- a/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
+++ b/app/src/test/java/net/gsantner/markor/format/todotxt/TodoTxtQuerySyntaxTests.java
@@ -18,22 +18,24 @@ public class TodoTxtQuerySyntaxTests {
     }
 
     @Test
-    public void EvaluateExpression() {
-        assertThat(TodoTxtFilter.shuntingYard(strip("T"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("F"))).isEqualTo(false);
-        assertThat(TodoTxtFilter.shuntingYard(strip("!T"))).isEqualTo(false);
-        assertThat(TodoTxtFilter.shuntingYard(strip("!F"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("!(F)"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("(!F)"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("(!(F))"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("!(!(F))"))).isEqualTo(false);
-        assertThat(TodoTxtFilter.shuntingYard(strip("T | F"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("T & F"))).isEqualTo(false);
-        assertThat(TodoTxtFilter.shuntingYard(strip("T | T | T | T | F"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("F | F | F | F | T"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("!(T | F) & (T | F)"))).isEqualTo(false);
-        assertThat(TodoTxtFilter.shuntingYard(strip("!(T | F) | (T | F)"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("!(T | F | F) & (T | F) | (F & (!T) | T)"))).isEqualTo(true);
-        assertThat(TodoTxtFilter.shuntingYard(strip("!!!!!!F"))).isEqualTo(false);
+    public void EvaluateExpressionTest() {
+        assertThat(TodoTxtFilter.evaluateExpression(strip("T"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("F"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("!T"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("!F"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("!(F)"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("(!F)"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("(!(F))"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("!(!(F))"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("T | F"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("T & F"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("T | T | T | T | F"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("F | F | F | F | T"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("!(T | F) & (T | F)"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("!(T | F) | (T | F)"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("!(T | F | F) & (T | F) | (F & (!T) | T)"))).isEqualTo(true);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("!!!!!!F"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("T | T | T & F"))).isEqualTo(false);
+        assertThat(TodoTxtFilter.evaluateExpression(strip("F & F & F | T & T"))).isEqualTo(true);
     }
 }


### PR DESCRIPTION
In this PR I have created a fully functional advanced search / filter system for todo.txt

For example `@home & (pri:A | pri:B)` will return tasks with priority A or B and which have the context @home. The existing filter system has been updated to work on top of this query language (i.e. by generating the appropriate query).

This is now fully functional and works correctly.

Remaining tasks:
- [x] Document the query language
- [ ] Add more unit tests
- [x] More testing

Other fixes in this PR include:
1. Done file is now remembered per file (each todo.txt file can have it's own done file)
2. If the keyboard was open when a dialog was opened, we will open the keyboard again when the dialog is closed (this is only enabled in some dialogs where it seemed to be useful / easy to implement)