### PR TITLE
Zim: use correct numbered list regex for view mode (closes #1729)

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextTextConverter.java
@@ -34,8 +34,6 @@ import java.util.regex.Pattern;
  */
 @SuppressWarnings("WeakerAccess")
 public class WikitextTextConverter extends TextConverterBase {
-    private static final Pattern LIST_ORDERED_LETTERS = Pattern.compile("^\t*([\\d]+\\.|[a-zA-Z]+\\.) ");
-
     /**
      * First, convert Wikitext to regular Markor markdown. Then, calls the regular converter.
      *
@@ -75,7 +73,7 @@ public class WikitextTextConverter extends TextConverterBase {
         replaceAllMatchesInLine(currentLine, Pattern.compile("^'''$"), fullMatch -> "```");  // preformatted multiline
 
         // unordered list syntax is compatible with markdown
-        replaceAllMatchesInLinePartially(currentLine, LIST_ORDERED_LETTERS, "[0-9a-zA-Z]+\\.", "1.");    // why does this work?
+        replaceAllMatchesInLinePartially(currentLine, WikitextSyntaxHighlighter.LIST_ORDERED, "[0-9a-zA-Z]+\\.", "1.");    // why does this work?
         replaceAllMatchesInLine(currentLine, WikitextSyntaxHighlighter.CHECKLIST, this::convertChecklist);
 
         replaceAllMatchesInLine(currentLine, WikitextSyntaxHighlighter.SUPERSCRIPT, fullMatch -> String.format("<sup>%s</sup>",


### PR DESCRIPTION
This PR changes the used regex for converting zim numbered lists to Markdown, which is needed for view mode.
The old regex was too greedy and considered whole words followed by a dot as list items, e.g. "Wikipedia. some other text" was converted to "1. some other text".
Old regex:
`^\t*([\\d]+\\.|[a-zA-Z]+\\.) `
New regex (already used for edit mode highlighting and working well there):
`(?<=((\n|^)(\s{0,10})))(\d+|[a-zA-Z])(\.)(?= )`

This PR fixes #1729 .