### PR TITLE
Zim: Fix NPE for non-resolvable relative links with unreachable notebook dir (closes #1882) + Add compatibility support for anchor links

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextLinkResolver.java
+++ b/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextLinkResolver.java
@@ -1,5 +1,6 @@
 package net.gsantner.markor.format.wikitext;
 
+import net.gsantner.opoc.format.GsTextUtils;
 import net.gsantner.opoc.util.GsFileUtils;
 
 import org.apache.commons.io.FilenameUtils;
@@ -74,7 +75,7 @@ public class WikitextLinkResolver {
 
         // inner page references are not yet supported - for compatibility just get the page
         wikitextPath = stripInnerPageReference(wikitextPath);
-        if ("".equals(wikitextPath)) {
+        if (GsTextUtils.isNullOrEmpty(wikitextPath)) {
             return null;
         }
 

--- a/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextLinkResolver.java
+++ b/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextLinkResolver.java
@@ -29,7 +29,8 @@ public class WikitextLinkResolver {
 
         SUBPAGE_PATH(Pattern.compile("\\+(.*)")),
         TOPLEVEL_PATH(Pattern.compile(":(.*)")),
-        RELATIVE_PATH(Pattern.compile("[^/]+")), // do not match weblinks
+        RELATIVE_PATH(Pattern.compile("[^#/]+")), // no weblinks, no inner page references
+        PATH_WITH_INNER_PAGE_REFERENCE(Pattern.compile("(.*)#(.+)")),
         WEBLINK(Pattern.compile("^[a-z]+://.+"));
         // TODO: external file links
         // TODO: interwiki links
@@ -71,6 +72,12 @@ public class WikitextLinkResolver {
             _isWebLink = false;
         }
 
+        // inner page references are not yet supported - for compatibility just get the page
+        wikitextPath = stripInnerPageReference(wikitextPath);
+        if ("".equals(wikitextPath)) {
+            return null;
+        }
+
         Matcher subpageMatcher = Patterns.SUBPAGE_PATH.pattern.matcher(wikitextPath);
         if (subpageMatcher.matches()) {
             String folderForSubpagesOfCurrentPage = _currentPage.getPath().replace(".txt", "");
@@ -102,6 +109,15 @@ public class WikitextLinkResolver {
         return wikitextPath; // just return the original path in case the link cannot be resolved (might be a URL)
     }
 
+    private String stripInnerPageReference(String wikitextPath) {
+        Matcher pathWithInnerPageReferenceMatcher = Patterns.PATH_WITH_INNER_PAGE_REFERENCE.pattern.matcher(wikitextPath);
+        if (pathWithInnerPageReferenceMatcher.matches()) {
+            String pagePath = pathWithInnerPageReferenceMatcher.group(1);
+            return pagePath;
+        }
+        return wikitextPath;
+    }
+
     private File findNotebookRootDir(File currentPage) {
         if (currentPage != null && currentPage.exists()) {
             if (GsFileUtils.join(currentPage, "notebook.zim").exists()) {
@@ -114,7 +130,9 @@ public class WikitextLinkResolver {
     }
 
     private String findFirstPageTraversingUpToRoot(File currentPage, String relativeLinkToCheck) {
-        if (currentPage.equals(_notebookRootDir)) {
+        // if the notebook directory is set incorrectly/cannot be reached,
+        // dynamic traversal can go up to the root of the filesystem - thus the null-check
+        if (currentPage == null || currentPage.equals(_notebookRootDir)) {
             return null;
         }
 


### PR DESCRIPTION
This PR fixes the issue described in #1882 by introducing an additional null-check. In case that a relative page link cannot be resolved AND the notebook directory is set incorrectly/not reachable from the current page, Markor stops the traversal now at the root of the filesystem and doesn't throw an exception any more (which could be observed e.g. when entering view mode for pages with such links).

Additionally, compatibility support for links with inner page references is added. Zim 0.74.0 introduced "link anchors", which can be inserted somewhere in a page, and referenced and jumped to directly by writing something like `[[#my-anchor]]` or `[[+MyPage:OtherPage#some-heading-in-the-page]]`. Pages to these links could not be resolved in Markor up to now. Still, there's no support for jumping to these anchors - the anchor parts are in fact just ignored for now - but it is now possible again to open the referenced page of the link.