### PR TITLE
Don't use textsize in highlighting

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/asciidoc/AsciidocSyntaxHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/asciidoc/AsciidocSyntaxHighlighter.java
@@ -242,11 +242,9 @@ public class AsciidocSyntaxHighlighter extends SyntaxHighlighterBase {
 
         if (_highlightBiggerHeadings) {
             createSpanForMatches(HEADING_ASCIIDOC, new WrAsciidocHeaderSpanCreator(_spannable,
-                    _isDarkMode ? AD_FORECOLOR_DARK_HEADING : AD_FORECOLOR_LIGHT_HEADING,
-                    _textSize));
+                    _isDarkMode ? AD_FORECOLOR_DARK_HEADING : AD_FORECOLOR_LIGHT_HEADING));
             createSpanForMatches(HEADING_MD, new WrMarkdownHeaderSpanCreator(_spannable,
-                    _isDarkMode ? AD_FORECOLOR_DARK_HEADING : AD_FORECOLOR_LIGHT_HEADING,
-                    _textSize));
+                    _isDarkMode ? AD_FORECOLOR_DARK_HEADING : AD_FORECOLOR_LIGHT_HEADING));
         } else {
             createSpanForMatches(HEADING, new HighlightSpan().setForeColor(
                     _isDarkMode ? AD_FORECOLOR_DARK_HEADING : AD_FORECOLOR_LIGHT_HEADING));

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownSyntaxHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownSyntaxHighlighter.java
@@ -66,7 +66,7 @@ public class MarkdownSyntaxHighlighter extends SyntaxHighlighterBase {
         createSmallBlueLinkSpans();
 
         if (_highlightBiggerHeadings) {
-            createSpanForMatches(HEADING, new WrMarkdownHeaderSpanCreator(_spannable, MD_COLOR_HEADING, _textSize));
+            createSpanForMatches(HEADING, new WrMarkdownHeaderSpanCreator(_spannable, MD_COLOR_HEADING));
         } else {
             createColorSpanForMatches(HEADING, MD_COLOR_HEADING);
         }

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtSyntaxHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtSyntaxHighlighter.java
@@ -41,18 +41,16 @@ public class TodoTxtSyntaxHighlighter extends TodoTxtBasicSyntaxHighlighter {
         super.generateSpans();
 
         // Paragraph space and divider half way up the space
-        createSpanForMatches(LINE_OF_TEXT, matcher -> new ParagraphDividerSpan(_textColor, _textSize));
+        createSpanForMatches(LINE_OF_TEXT, matcher -> new ParagraphDividerSpan(_textColor));
     }
 
     // Adds spacing and divider line between paragraphs
     public static class ParagraphDividerSpan implements LineBackgroundSpan, LineHeightSpan, UpdateLayout {
         private final int _lineColor;
-        private final float _spacing;
         private Integer _origAscent = null;
 
-        public ParagraphDividerSpan(@ColorInt int lineColor, float spacing) {
+        public ParagraphDividerSpan(@ColorInt int lineColor) {
             _lineColor = lineColor;
-            _spacing = spacing;
         }
 
         @Override
@@ -60,7 +58,8 @@ public class TodoTxtSyntaxHighlighter extends TodoTxtBasicSyntaxHighlighter {
             if (start > 0 && text.charAt(start - 1) == '\n') {
                 paint.setColor(_lineColor);
                 paint.setStrokeWidth(0);
-                canvas.drawLine(left, top + _spacing / 2, right, top + _spacing / 2, paint);
+                final float spacing = paint.getTextSize();
+                canvas.drawLine(left, top + spacing / 2, right, top + spacing / 2, paint);
             }
         }
 
@@ -70,7 +69,7 @@ public class TodoTxtSyntaxHighlighter extends TodoTxtBasicSyntaxHighlighter {
                 _origAscent = fm.ascent;
             }
             boolean isFirstLineInParagraph = start > 0 && text.charAt(start - 1) == '\n';
-            fm.ascent = (isFirstLineInParagraph) ? fm.ascent - (int) _spacing : _origAscent;
+            fm.ascent = (isFirstLineInParagraph) ? fm.ascent - (int) fm. : _origAscent;
         }
     }
 }

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtSyntaxHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtSyntaxHighlighter.java
@@ -69,7 +69,7 @@ public class TodoTxtSyntaxHighlighter extends TodoTxtBasicSyntaxHighlighter {
                 _origAscent = fm.ascent;
             }
             boolean isFirstLineInParagraph = start > 0 && text.charAt(start - 1) == '\n';
-            fm.ascent = (isFirstLineInParagraph) ? fm.ascent - (int) fm. : _origAscent;
+            fm.ascent = (isFirstLineInParagraph) ? (2 * _origAscent) : _origAscent;
         }
     }
 }

--- a/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextSyntaxHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextSyntaxHighlighter.java
@@ -96,7 +96,7 @@ public class WikitextSyntaxHighlighter extends SyntaxHighlighterBase {
         createUnderlineHexColorsSpans();
 
         if (_isWikitextBiggerHeadings) {
-            createSpanForMatches(HEADING, new WrWikitextHeaderSpanCreator(_spannable, Colors.COLOR_HEADING, _textSize));
+            createSpanForMatches(HEADING, new WrWikitextHeaderSpanCreator(_spannable, Colors.COLOR_HEADING));
         } else {
             createColorSpanForMatches(HEADING, Colors.COLOR_HEADING);
         }

--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -465,7 +465,7 @@ public class MarkorDialogFactory {
             final EditText text,
             final GsCallback.b1<TodoTxtTask> filter
     ) {
-        DialogOptions dopt = new DialogOptions();
+        final DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
         final List<TodoTxtTask> allTasks = TodoTxtTask.getAllTasks(text.getText());
         final List<String> lines = new ArrayList<>();

--- a/app/src/main/java/net/gsantner/markor/frontend/textview/SyntaxHighlighterBase.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/textview/SyntaxHighlighterBase.java
@@ -68,7 +68,6 @@ public abstract class SyntaxHighlighterBase {
 
     // Configuration - to be set on a call to configure
     protected int _delay = LONG_HIGHLIGHTING_DELAY;
-    protected float _textSize = 1;
     protected int _tabSize = 1;
     protected boolean _isDarkMode = false;
     protected int _textColor = Color.BLACK;
@@ -90,7 +89,6 @@ public abstract class SyntaxHighlighterBase {
         _fontFamily = _appSettings.getFontFamily();
         _textColor = _appSettings.getEditorForegroundColor();
         if (paint != null) {
-            _textSize = paint.getTextSize();
             _tabSize = (int) (_appSettings.getTabWidth() * paint.measureText(" "));
         }
         return this;
@@ -442,7 +440,7 @@ public abstract class SyntaxHighlighterBase {
     }
 
     protected final void createSmallBlueLinkSpans() {
-        createSpanForMatches(Patterns.WEB_URL, new HighlightSpan().setForeColor(0xff1ea3fd).setItalic(true).setTextSize(_textSize * 0.85f));
+        createSpanForMatches(Patterns.WEB_URL, new HighlightSpan().setForeColor(0xff1ea3fd).setItalic(true).setTextScale(0.85f));
     }
 
     protected final void createUnderlineHexColorsSpans() {
@@ -456,7 +454,7 @@ public abstract class SyntaxHighlighterBase {
         public Boolean italic = null;
         public Boolean underline = null;
         public Boolean strikethrough = null;
-        public Float textSize = null;
+        public Float textScale = null;
         public @ColorInt
         Integer foregroundColor = null;
         public @ColorInt
@@ -473,8 +471,8 @@ public abstract class SyntaxHighlighterBase {
             return this;
         }
 
-        public HighlightSpan setTextSize(Float size) {
-            textSize = size;
+        public HighlightSpan setTextScale(Float scale) {
+            textScale = scale;
             return this;
         }
 
@@ -528,8 +526,8 @@ public abstract class SyntaxHighlighterBase {
                 tp.bgColor = backgroundColor;
             }
 
-            if (textSize != null) {
-                tp.setTextSize(textSize);
+            if (textScale != null) {
+                tp.setTextSize(tp.getTextSize() * textScale);
             }
         }
 
@@ -544,7 +542,7 @@ public abstract class SyntaxHighlighterBase {
                     .setItalic(italic)
                     .setUnderline(underline)
                     .setStrike(strikethrough)
-                    .setTextSize(textSize);
+                    .setTextScale(textScale);
         }
     }
 }

--- a/app/thirdparty/java/other/writeily/format/WrProportionalHeaderSpanCreator.java
+++ b/app/thirdparty/java/other/writeily/format/WrProportionalHeaderSpanCreator.java
@@ -15,41 +15,39 @@ import androidx.annotation.NonNull;
 
 public class WrProportionalHeaderSpanCreator {
 
-    private final float _textSize;
     private final int _color;
 
-    public WrProportionalHeaderSpanCreator(final float textSize, final int color) {
-        _textSize = textSize;
+    public WrProportionalHeaderSpanCreator(final int color) {
         _color = color;
     }
 
     public Object createHeaderSpan(final float proportion) {
-        return new LargerHeaderSpan(_color, _textSize * proportion);
+        return new LargerHeaderSpan(_color, proportion);
     }
 
     public static class LargerHeaderSpan extends MetricAffectingSpan {
 
         final @ColorInt
         int _color;
-        final float _textSize;
+        final float _proportion;
 
-        public LargerHeaderSpan(final @ColorInt int color, final float textSize) {
+        public LargerHeaderSpan(final @ColorInt int color, final float proportion) {
             _color = color;
-            _textSize = textSize;
+            _proportion = proportion;
         }
 
         @Override
         public void updateMeasureState(@NonNull TextPaint textPaint) {
             textPaint.setFakeBoldText(true);
             textPaint.setColor(_color);
-            textPaint.setTextSize(_textSize);
+            textPaint.setTextSize(textPaint.getTextSize() * _proportion);
         }
 
         @Override
         public void updateDrawState(@NonNull TextPaint textPaint) {
             textPaint.setFakeBoldText(true);
             textPaint.setColor(_color);
-            textPaint.setTextSize(_textSize);
+            textPaint.setTextSize(textPaint.getTextSize() * _proportion);
         }
     }
 }

--- a/app/thirdparty/java/other/writeily/format/asciidoc/WrAsciidocHeaderSpanCreator.java
+++ b/app/thirdparty/java/other/writeily/format/asciidoc/WrAsciidocHeaderSpanCreator.java
@@ -23,9 +23,9 @@ public class WrAsciidocHeaderSpanCreator implements GsCallback.r1<Object, Matche
     private final CharSequence _text;
     private final WrProportionalHeaderSpanCreator _spanCreator;
 
-    public WrAsciidocHeaderSpanCreator(final CharSequence text, int color, final float textSize) {
+    public WrAsciidocHeaderSpanCreator(final CharSequence text, int color) {
         _text = text;
-        _spanCreator = new WrProportionalHeaderSpanCreator(textSize, color);
+        _spanCreator = new WrProportionalHeaderSpanCreator(color);
     }
 
     public Object callback(Matcher m) {

--- a/app/thirdparty/java/other/writeily/format/markdown/WrMarkdownHeaderSpanCreator.java
+++ b/app/thirdparty/java/other/writeily/format/markdown/WrMarkdownHeaderSpanCreator.java
@@ -22,9 +22,9 @@ public class WrMarkdownHeaderSpanCreator implements GsCallback.r1<Object, Matche
     private final CharSequence _text;
     private final WrProportionalHeaderSpanCreator _spanCreator;
 
-    public WrMarkdownHeaderSpanCreator(final CharSequence text, int color, final float textSize) {
+    public WrMarkdownHeaderSpanCreator(final CharSequence text, int color) {
         _text = text;
-        _spanCreator = new WrProportionalHeaderSpanCreator(textSize, color);
+        _spanCreator = new WrProportionalHeaderSpanCreator(color);
     }
 
     public Object callback(final Matcher m) {

--- a/app/thirdparty/java/other/writeily/format/wikitext/WrWikitextHeaderSpanCreator.java
+++ b/app/thirdparty/java/other/writeily/format/wikitext/WrWikitextHeaderSpanCreator.java
@@ -23,9 +23,9 @@ public class WrWikitextHeaderSpanCreator implements GsCallback.r1<Object, Matche
     private final CharSequence _text;
     private final WrProportionalHeaderSpanCreator _spanCreator;
 
-    public WrWikitextHeaderSpanCreator(final CharSequence text, int color, final float fontSize) {
+    public WrWikitextHeaderSpanCreator(final CharSequence text, int color) {
         _text = text;
-        _spanCreator = new WrProportionalHeaderSpanCreator(fontSize, color);
+        _spanCreator = new WrProportionalHeaderSpanCreator(color);
     }
 
     public Object callback(final Matcher m) {


### PR DESCRIPTION
This addresses #1961. 

Issue was that we required a _textSize, which wasn't configured when highlighter was used outside of hleditor.

Solution is to just not use a _textSize, and use the proportion directly where ever required