### PR TITLE
Subscript with tildes

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
@@ -18,7 +18,7 @@ import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
 import com.vladsch.flexmark.ext.emoji.EmojiExtension;
 import com.vladsch.flexmark.ext.emoji.EmojiImageType;
 import com.vladsch.flexmark.ext.footnotes.FootnoteExtension;
-import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughSubscriptExtension;
 import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
 import com.vladsch.flexmark.ext.gitlab.GitLabExtension;
 import com.vladsch.flexmark.ext.ins.InsExtension;
@@ -125,7 +125,7 @@ public class MarkdownTextConverter extends TextConverterBase {
     //########################
     // See https://github.com/vsch/flexmark-java/wiki/Extensions#tables
     private static final List<Extension> flexmarkExtensions = Arrays.asList(
-            StrikethroughExtension.create(),
+            StrikethroughSubscriptExtension.create()
             AutolinkExtension.create(),
             InsExtension.create(),
             FlexmarkKatexExtension.KatexExtension.create(),

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownTextConverter.java
@@ -125,7 +125,7 @@ public class MarkdownTextConverter extends TextConverterBase {
     //########################
     // See https://github.com/vsch/flexmark-java/wiki/Extensions#tables
     private static final List<Extension> flexmarkExtensions = Arrays.asList(
-            StrikethroughSubscriptExtension.create()
+            StrikethroughSubscriptExtension.create(),
             AutolinkExtension.create(),
             InsExtension.create(),
             FlexmarkKatexExtension.KatexExtension.create(),


### PR DESCRIPTION
Hey there,  
this is a small enhancement: I switched the strikethrough extension in order to include extended syntax for subscript characters.

Now, in order to write something like **CO<sub>2</sub>** you can just type `CO~2~` instead of `CO<sub>2</sub>`.

Tested it in Android Studio, works fine and no other functionalities are affected.



<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
