### PR TITLE
Keep keyboard state onResume

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,7 +65,7 @@
             android:label="@string/app_name"
             android:launchMode="singleTop"
             android:taskAffinity=".activity.MainActivity"
-            android:windowSoftInputMode="stateAlwaysHidden|adjustResize">
+            android:windowSoftInputMode="stateUnchanged|adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -179,7 +179,7 @@
             android:parentActivityName=".activity.MainActivity"
             android:taskAffinity=".activity.DocumentActivity"
             android:theme="@style/AppTheme.Unified.StartupFlash"
-            android:windowSoftInputMode="stateAlwaysHidden|adjustResize"
+            android:windowSoftInputMode="stateUnchanged|adjustResize"
             tools:targetApi="lollipop">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
@@ -751,9 +751,9 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
         _format.getActions().recreateActionButtons(_textActionsBar, show ? ActionButtonBase.ActionItem.DisplayMode.VIEW : ActionButtonBase.ActionItem.DisplayMode.EDIT);
         if (show) {
             updateViewModeText();
-            _cu.hideSoftKeyboard(activity);
+            _cu.showSoftKeyboard(activity, false, _hlEditor);
             _hlEditor.clearFocus();
-            _hlEditor.postDelayed(() -> _cu.hideSoftKeyboard(activity), 300);
+            _hlEditor.postDelayed(() -> _cu.showSoftKeyboard(activity, false, _hlEditor), 300);
             fadeInOut(_webView, _primaryScrollView);
         } else {
             _webViewClient.setRestoreScrollY(_webView.getScrollY());

--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -26,6 +26,7 @@ import android.text.Spannable;
 import android.text.TextUtils;
 import android.util.Pair;
 import android.view.Gravity;
+import android.view.Window;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
@@ -511,9 +512,15 @@ public class MarkorDialogFactory {
     }
 
     // Restore the keyboard when dialog closes if required
+    // NOTE: This relies on the activity having unchanged as the default soft input mode
     private static void addRestoreKeyboard(final Activity activity, final DialogOptions options, final EditText edit, final Boolean restore) {
-        if (restore != null && restore) {
-            options.dismissCallback = (d) -> GsContextUtils.instance.setSoftKeyboardVisible(activity, true, edit);
+        if (restore != null && !restore) {
+            options.dismissCallback = (d) -> {
+                final Window w = activity.getWindow();
+                // Suppress opening the keyboard automatically again
+                w.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+                edit.postDelayed(() -> w.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_UNCHANGED), 1000);
+            };
         }
     }
 

--- a/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
@@ -2507,54 +2507,16 @@ public class GsContextUtils {
                 .show();
     }
 
-    public <T extends GsContextUtils> T setSoftKeyboardVisible(final Activity context, boolean visible, View... editView) {
-        if (context != null) {
-            final View v = (editView != null && editView.length > 0) ? (editView[0]) : (context.getCurrentFocus() != null && context.getCurrentFocus().getWindowToken() != null ? context.getCurrentFocus() : null);
-            final InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
-            if (v != null && imm != null) {
-                Runnable r = () -> {
-                    if (visible) {
-                        v.requestFocus();
-                        imm.showSoftInput(v, InputMethodManager.SHOW_FORCED);
-                    } else {
-                        imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
-                    }
-                };
-                r.run();
-                for (int d : new int[]{100, 350}) {
-                    v.postDelayed(r, d);
+    public <T extends GsContextUtils> T showSoftKeyboard(final Activity activity, final boolean show, final View ... view) {
+        if (activity != null) {
+            final InputMethodManager imm = (InputMethodManager) activity.getSystemService(Activity.INPUT_METHOD_SERVICE);
+            final View focus = (view != null && view.length > 0) ? view[0] : activity.getCurrentFocus();
+            if (imm != null && focus != null && focus.getWindowToken() != null) {
+                if (show) {
+                    imm.showSoftInput(focus, 0);
+                } else if (focus.getWindowToken() != null) {
+                    imm.hideSoftInputFromWindow(focus.getWindowToken(), 0);
                 }
-            }
-        }
-        return thisp();
-    }
-
-    public <T extends GsContextUtils> T hideSoftKeyboard(final Activity context) {
-        if (context != null) {
-            InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
-            if (imm != null && context.getCurrentFocus() != null && context.getCurrentFocus().getWindowToken() != null) {
-                imm.hideSoftInputFromWindow(context.getCurrentFocus().getWindowToken(), 0);
-            }
-        }
-        return thisp();
-    }
-
-    public <T extends GsContextUtils> T showSoftKeyboard(final Activity activity) {
-        if (activity != null) {
-            InputMethodManager imm = (InputMethodManager) activity.getSystemService(Activity.INPUT_METHOD_SERVICE);
-            if (imm != null && activity.getCurrentFocus() != null && activity.getCurrentFocus().getWindowToken() != null) {
-                showSoftKeyboard(activity, activity.getCurrentFocus());
-            }
-        }
-        return thisp();
-    }
-
-
-    public <T extends GsContextUtils> T showSoftKeyboard(final Activity activity, View textInputView) {
-        if (activity != null) {
-            InputMethodManager imm = (InputMethodManager) activity.getSystemService(Activity.INPUT_METHOD_SERVICE);
-            if (imm != null && textInputView != null) {
-                imm.showSoftInput(textInputView, InputMethodManager.SHOW_FORCED);
             }
         }
         return thisp();


### PR DESCRIPTION
Currently, the soft keyboard will close when one navigates away from and back to a markor document.

After this PR, the keyboard state will be remembered (by the android system).

The way keyboard state is remembered after a dialog closes is changed to handle the new behavior