### PR TITLE
FileSearch: Sort search results alphabetically, closes #1864

### DIFF
--- a/app/src/main/java/net/gsantner/markor/frontend/filesearch/FileSearchEngine.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/filesearch/FileSearchEngine.java
@@ -207,7 +207,7 @@ public class FileSearchEngine {
             if (_isCanceled && _result.size() == 0) {
                 cancel(true);
             }
-
+            Collections.sort(_result, (o1, o2) -> o1.path.compareToIgnoreCase(o2.path));
             return _result;
         }
 


### PR DESCRIPTION
I fixed a part of issue #1864 by alphabetically ranking the search results in Marder Files.

Before:
![IMG_8289](https://github.com/gsantner/markor/assets/125285502/5ee9c8f1-24fe-468f-b97b-22d92893e9f4)

After:
![IMG_8288](https://github.com/gsantner/markor/assets/125285502/34a12296-f57f-4174-ab51-97ea5aca1d9a)