### PR TITLE
Fix NPE on devices that don't support widgets

### DIFF
--- a/app/thirdparty/java/other/writeily/widget/WrMarkorWidgetProvider.java
+++ b/app/thirdparty/java/other/writeily/widget/WrMarkorWidgetProvider.java
@@ -108,6 +108,10 @@ public class WrMarkorWidgetProvider extends AppWidgetProvider {
     public static void updateLauncherWidgets() {
         final Context context = ApplicationObject.get().getApplicationContext();
         final AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+        if (appWidgetManager == null) {
+            // The device does not support widgets.
+            return;
+        }
         final ComponentName comp = new ComponentName(context, WrMarkorWidgetProvider.class);
         final int[] appWidgetIds = appWidgetManager.getAppWidgetIds(comp);
 


### PR DESCRIPTION
Turns out, `AppWidgetManager.getInstance(context)` can return null:

* https://github.com/chromium/chromium/blob/08033c4b62f48e46e66f97be3a39c99ab9163402/chrome/android/java/src/org/chromium/chrome/browser/quickactionsearchwidget/QuickActionSearchWidgetProvider.java#L289
* https://github.com/tasks/tasks/blob/d25f859385e8301ae274835297f151125f7cefb7/app/src/main/java/org/tasks/widget/AppWidgetManager.kt#L18

I've tested that this change fixes Markor crash on the device.