### PR TITLE
WebView: allow to embed into documents local .html, .md, .txt, and .pdf files (ViewerJS, PDF.js)

### DIFF
--- a/app/src/main/java/net/gsantner/markor/web/MarkorWebViewClient.java
+++ b/app/src/main/java/net/gsantner/markor/web/MarkorWebViewClient.java
@@ -46,7 +46,7 @@ public class MarkorWebViewClient extends GsWebViewClient {
                     File f = new File(str);
                     if (f.exists()) {
                         /* iframe: file.html | viewerjs/index.html#../demo.pdf | pdfjs/web/viewer.html?file=../../demo.pdf */
-                        if (str.endsWith(".html")) {
+                        if (str.endsWith(".html") || str.endsWith(".md") || str.endsWith(".txt")) {
                             return false;
                         }
                         file = f;

--- a/app/src/main/java/net/gsantner/markor/web/MarkorWebViewClient.java
+++ b/app/src/main/java/net/gsantner/markor/web/MarkorWebViewClient.java
@@ -42,9 +42,13 @@ public class MarkorWebViewClient extends GsWebViewClient {
             } else if (url.startsWith("file://")) {
                 MarkorContextUtils su = new MarkorContextUtils(view.getContext());
                 File file = new File(URLDecoder.decode(url.replace("file://", "").replace("+", "%2B")));
-                for (String str : new String[]{file.getAbsolutePath(), file.getAbsolutePath().replaceFirst("[#].*$", ""), file.getAbsolutePath() + ".md", file.getAbsolutePath() + ".txt"}) {
+                for (String str : new String[]{file.getAbsolutePath(), file.getAbsolutePath().replaceFirst("[#?].*$", ""), file.getAbsolutePath() + ".md", file.getAbsolutePath() + ".txt"}) {
                     File f = new File(str);
                     if (f.exists()) {
+                        /* iframe: file.html | viewerjs/index.html#../demo.pdf | pdfjs/web/viewer.html?file=../../demo.pdf */
+                        if (str.endsWith(".html")) {
+                            return false;
+                        }
                         file = f;
                         break;
                     }


### PR DESCRIPTION
Hello,

This is a trivial POC to allow embedding into documents local `.html .md .txt` files via `<iframe> <embed> <object>` tags.

This way it will be possible to insert into documents local `.pdf` files via a local copy of [ViewerJS](https://viewerjs.org) or [PDF.js](https://github.com/mozilla/pdf.js).

This PR may serve to test the possibility to implement a PDF viewer (maybe as an android_asset) #1097.

# Preview

![Markor_sample_pdf_iframe](https://github.com/gsantner/markor/assets/6450450/3eb5832a-f634-4695-86d2-04ca082f6d5e)

![Markor_sample_iframe](https://github.com/gsantner/markor/assets/6450450/3431c22d-f8d4-411e-9493-ed2a4f2855bf)

# Samples

NOTE: I chose to use [PDF.js v2.4.456-es5](https://github.com/mozilla/pdf.js/releases/download/v2.4.456/pdfjs-2.4.456-es5-dist.zip) since it's compatible with the [Pale Moon web browser](https://www.palemoon.org).

PS: To render markdown files on the desktop I use [Markdeep](https://casual-effects.com/markdeep) and to process `.vtt` subtitles and `.pdf` files [CivetWeb web server](https://github.com/civetweb/civetweb).

```
MAIN
|
|_demodoc.pdf
|
|_frame.html
|_frame.md
|_frame.txt
|
|_index.md
|
|_pdfjs-2.4.456-es5/
|                                        
|_viewerjs-0.5.8/
```

- [demodoc.pdf](https://viewerjs.org/demodoc.pdf)
- [PDF.js v2.4.456-es5](https://github.com/mozilla/pdf.js/releases/download/v2.4.456/pdfjs-2.4.456-es5-dist.zip)
- [ViewerJS v0.5.8](https://viewerjs.org/releases/viewerjs-0.5.8.zip)

```
wget https://viewerjs.org/demodoc.pdf

wget https://github.com/mozilla/pdf.js/releases/download/v2.4.456/pdfjs-2.4.456-es5-dist.zip
mkdir pdfjs-2.4.456-es5
7z x -opdfjs-2.4.456-es5 pdfjs-2.4.456-es5-dist.zip

wget https://viewerjs.org/releases/viewerjs-0.5.8.zip
7z x viewerjs-0.5.8.zip

cat <<EOF > frame.html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <title>Frame</title>
  </head>
  <body>
    This ia a frame.
  </body>
</html>
EOF

cat <<EOF > frame.md
# Markdown

This ia a frame.
EOF

cat <<EOF > frame.txt
Plain Text

This ia a frame.
EOF

cat <<EOF > index.md
This ia a test.

----

[frame.html](frame.html)

<embed width="320" height="240" src="frame.html"></embed>

<object width="320" height="240" data="frame.html"></object>

<iframe width="320" height="240" src="frame.html"></iframe>

----

[frame.md](frame.md)

<embed width="320" height="240" src="frame.md"></embed>

<object width="320" height="240" data="frame.md"></object>

<iframe width="320" height="240" src="frame.md"></iframe>

----

[frame.txt](frame.txt)

<embed width="320" height="240" src="frame.txt"></embed>

<object width="320" height="240" data="frame.txt"></object>

<iframe width="320" height="240" src="frame.txt"></iframe>

----

ViewerJS index.html#../../demodoc.pdf

<!-- doesn't work with #../../demodoc.pdf (i.e. w/o index.html) -->
<iframe width="320" height="452" src="viewerjs-0.5.8/ViewerJS/index.html#../../demodoc.pdf" allowfullscreen webkitallowfullscreen></iframe>

----

PDF.js viewer.html?file=../../demodoc.pdf

<iframe width="320" height="452" src="pdfjs-2.4.456-es5/web/viewer.html?file=../../demodoc.pdf" allowfullscreen webkitallowfullscreen></iframe>
EOF
```