### PR TITLE
Remove Trailing Space in Link Formating

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentShareIntoFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentShareIntoFragment.java
@@ -416,7 +416,7 @@ public class DocumentShareIntoFragment extends MarkorBaseFragment {
 
             link = link.replaceAll("(?m)(?<=&|\\?)(utm_|source|__mk_|ref|sprefix|crid|partner|promo|ad_sub|gclid|fbclid|msclkid).*?(&|$|\\s|\\))", "");
 
-            formattedLink = String.format("[%s](%s )",
+            formattedLink = String.format("[%s](%s)",
                     text.trim().replace("[", "\\[").replace("]", "\\]").replace("|", "/"),
                     link.trim().replace("(", "\\(").replace(")", "\\)")
             );


### PR DESCRIPTION
Hello !

If I share a URL from my Browser App into Markor - Quicknote, the result contains a space before the trailing ")" which results in vim not opening the URL and throwing an error instead.
IMHO the trailing Space is not needed and caused by a typo.

<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
