### PR TITLE
Reworked attachments

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1096,6 +1096,10 @@
         <package android:name="org.mozilla.focus" />
 
         <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+
+        <intent>
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="https" />
         </intent>

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
@@ -293,7 +293,6 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
 
         // Edit / Preview switch
         menu.findItem(R.id.action_edit).setVisible(isText && _isPreviewVisible);
-        menu.findItem(R.id.submenu_attach).setVisible(false);
         menu.findItem(R.id.action_preview).setVisible(isText && !_isPreviewVisible);
         menu.findItem(R.id.action_search).setVisible(isText && !_isPreviewVisible);
         menu.findItem(R.id.action_search_view).setVisible(isText && _isPreviewVisible);
@@ -516,24 +515,6 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
                 _cu.draftEmail(getActivity(), "Debug Log " + getString(R.string.app_name_real), text, "debug@localhost.lan");
                 return true;
             }
-
-            case R.id.action_attach_color: {
-                _format.getActions().showColorPickerDialog();
-                return true;
-            }
-            case R.id.action_attach_date: {
-                DatetimeFormatDialog.showDatetimeFormatDialog(activity, _hlEditor);
-                return true;
-            }
-            case R.id.action_attach_audio:
-            case R.id.action_attach_file:
-            case R.id.action_attach_image:
-            case R.id.action_attach_link: {
-                int actionId = (itemId == R.id.action_attach_audio ? 4 : (itemId == R.id.action_attach_image ? 2 : 3));
-                AttachLinkOrFileDialog.showInsertImageOrLinkDialog(actionId, _document.getFormat(), activity, _hlEditor, _document.getFile());
-                return true;
-            }
-
             case R.id.action_load_epub: {
                 MarkorFileBrowserFactory.showFileDialog(new GsFileBrowserOptions.SelectionListenerAdapter() {
                                                             @Override

--- a/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
@@ -468,6 +468,12 @@ public class MainActivity extends MarkorBaseActivity implements GsFileBrowserFra
         restoreDefaultToolbar();
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        _cu.extractResultFromActivityResult(this, requestCode, resultCode, data);
+    }
+
     /**
      * Restores the default toolbar. Used when changing the tab or moving to another activity
      * while {@link GsFileBrowserFragment} action mode is active (e.g. when renaming a file)

--- a/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
+++ b/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
@@ -547,6 +547,7 @@ public abstract class ActionButtonBase {
     // Some actions common to multiple file types
     // Can be called _explicitly_ by a derived class
     protected final boolean runCommonAction(final @StringRes int action) {
+        final Editable text = _hlEditor.getText();
         switch (action) {
             case R.string.abid_common_unordered_list_char: {
                 runRegularPrefixAction(_appSettings.getUnorderedListCharacter() + " ", true);
@@ -564,34 +565,20 @@ public abstract class ActionButtonBase {
                 DatetimeFormatDialog.showDatetimeFormatDialog(getActivity(), _hlEditor);
                 return true;
             }
-            case R.string.abid_common_time_insert_timestamp: {
-
-            }
             case R.string.abid_common_accordion: {
                 _hlEditor.insertOrReplaceTextOnCursor("<details markdown='1'><summary>" + rstr(R.string.expand_collapse) + "</summary>\n" + HighlightingEditor.PLACE_CURSOR_HERE_TOKEN + "\n\n</details>");
                 return true;
             }
-            case R.string.abid_common_attach_something: {
-                MarkorDialogFactory.showAttachSomethingDialog(getActivity(), itemId -> {
-                    switch (itemId) {
-                        case R.id.action_attach_color: {
-                            showColorPickerDialog();
-                            break;
-                        }
-                        case R.id.action_attach_date: {
-                            DatetimeFormatDialog.showDatetimeFormatDialog(getActivity(), _hlEditor);
-                            break;
-                        }
-                        case R.id.action_attach_audio:
-                        case R.id.action_attach_file:
-                        case R.id.action_attach_image:
-                        case R.id.action_attach_link: {
-                            int actionId = (itemId == R.id.action_attach_audio ? 4 : (itemId == R.id.action_attach_image ? 2 : 3));
-                            AttachLinkOrFileDialog.showInsertImageOrLinkDialog(actionId, _document.getFormat(), getActivity(), _hlEditor, _document.getFile());
-                            break;
-                        }
-                    }
-                });
+            case R.string.abid_common_insert_audio: {
+                AttachLinkOrFileDialog.showInsertImageOrLinkDialog(AttachLinkOrFileDialog.AUDIO_ACTION, _document.getFormat(), getActivity(), text, _document.getFile());
+                return true;
+            }
+            case R.string.abid_common_insert_link: {
+                AttachLinkOrFileDialog.showInsertImageOrLinkDialog(AttachLinkOrFileDialog.FILE_OR_LINK_ACTION, _document.getFormat(), getActivity(), text, _document.getFile());
+                return true;
+            }
+            case R.string.abid_common_insert_image: {
+                AttachLinkOrFileDialog.showInsertImageOrLinkDialog(AttachLinkOrFileDialog.IMAGE_ACTION, _document.getFormat(), getActivity(), text, _document.getFile());
                 return true;
             }
             case R.string.abid_common_ordered_list_renumber: {
@@ -619,7 +606,7 @@ public abstract class ActionButtonBase {
             }
             case R.string.abid_common_open_link_browser: {
                 String url;
-                if ((url = GsTextUtils.tryExtractUrlAroundPos(_hlEditor.getText().toString(), _hlEditor.getSelectionStart())) != null) {
+                if ((url = GsTextUtils.tryExtractUrlAroundPos(text.toString(), _hlEditor.getSelectionStart())) != null) {
                     if (url.endsWith(")")) {
                         url = url.substring(0, url.length() - 1);
                     }
@@ -633,13 +620,12 @@ public abstract class ActionButtonBase {
             }
             case R.string.abid_common_new_line_below: {
                 // Go to end of line, works with wrapped lines too
-                _hlEditor.setSelection(TextViewUtils.getLineEnd(_hlEditor.getText(), TextViewUtils.getSelection(_hlEditor)[1]));
+                _hlEditor.setSelection(TextViewUtils.getLineEnd(text, TextViewUtils.getSelection(_hlEditor)[1]));
                 _hlEditor.simulateKeyPress(KeyEvent.KEYCODE_ENTER);
                 return true;
             }
             case R.string.abid_common_delete_lines: {
                 final int[] sel = TextViewUtils.getLineSelection(_hlEditor);
-                final Editable text = _hlEditor.getText();
                 final boolean lastLine = sel[1] == text.length();
                 final boolean firstLine = sel[0] == 0;
                 text.delete(sel[0] - (lastLine && !firstLine ? 1 : 0), sel[1] + (lastLine ? 0 : 1));

--- a/app/src/main/java/net/gsantner/markor/format/asciidoc/AsciidocActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/asciidoc/AsciidocActionButtons.java
@@ -14,7 +14,6 @@ import androidx.annotation.StringRes;
 
 import net.gsantner.markor.R;
 import net.gsantner.markor.format.ActionButtonBase;
-import net.gsantner.markor.frontend.AttachLinkOrFileDialog;
 import net.gsantner.markor.frontend.MarkorDialogFactory;
 import net.gsantner.markor.frontend.textview.TextViewUtils;
 import net.gsantner.markor.model.Document;
@@ -32,131 +31,68 @@ public class AsciidocActionButtons extends ActionButtonBase {
     @Override
     public List<ActionItem> getActiveActionList() {
         final ActionItem[] TMA_ACTIONS = {
-                new ActionItem(R.string.abid_asciidoc_checkbox_list,
-                        R.drawable.ic_check_box_black_24dp, R.string.check_list),
-                new ActionItem(
-                        R.string.abid_asciidoc_unordered_list_char, R.drawable.ic_list_black_24dp,
-                        R.string.unordered_list),
-                new ActionItem(R.string.abid_asciidoc_ordered_list_char,
-                        R.drawable.ic_format_list_numbered_black_24dp, R.string.ordered_list),
-
-                new ActionItem(R.string.abid_asciidoc_indent_level,
-                        R.drawable.ic_baseline_keyboard_double_arrow_right_24,
-                        R.string.indent_level),
-                new ActionItem(R.string.abid_asciidoc_deindent_level,
-                        R.drawable.ic_baseline_keyboard_double_arrow_left_24,
-                        R.string.deindent_level),
-
-                new ActionItem(R.string.abid_common_indent,
-                        R.drawable.ic_format_indent_increase_black_24dp, R.string.indent),
-                new ActionItem(R.string.abid_common_deindent,
-                        R.drawable.ic_format_indent_decrease_black_24dp, R.string.deindent),
-                new ActionItem(R.string.abid_asciidoc_squarebrackets,
-                        R.drawable.ic_baseline_data_array_24, R.string.squarebrackets),
-                new ActionItem(R.string.abid_common_special_key, R.drawable.ic_keyboard_black_24dp,
-                        R.string.special_key),
+                new ActionItem(R.string.abid_asciidoc_checkbox_list, R.drawable.ic_check_box_black_24dp, R.string.check_list),
+                new ActionItem(R.string.abid_asciidoc_unordered_list_char, R.drawable.ic_list_black_24dp, R.string.unordered_list),
+                new ActionItem(R.string.abid_asciidoc_ordered_list_char, R.drawable.ic_format_list_numbered_black_24dp, R.string.ordered_list),
+                new ActionItem(R.string.abid_asciidoc_indent_level, R.drawable.ic_baseline_keyboard_double_arrow_right_24, R.string.indent_level),
+                new ActionItem(R.string.abid_asciidoc_deindent_level, R.drawable.ic_baseline_keyboard_double_arrow_left_24, R.string.deindent_level),
+                new ActionItem(R.string.abid_common_indent, R.drawable.ic_format_indent_increase_black_24dp, R.string.indent),
+                new ActionItem(R.string.abid_common_deindent, R.drawable.ic_format_indent_decrease_black_24dp, R.string.deindent),
+                new ActionItem(R.string.abid_asciidoc_squarebrackets, R.drawable.ic_baseline_data_array_24, R.string.squarebrackets),
+                new ActionItem(R.string.abid_common_special_key, R.drawable.ic_keyboard_black_24dp, R.string.special_key),
                 // similar to abid_common_special_key, but separate menu
-                new ActionItem(R.string.abid_asciidoc_special_key,
-                        R.drawable.asciidoc_icon_black_24dp, R.string.asciidoc_special_key),
-
-                new ActionItem(R.string.abid_common_insert_snippet,
-                        R.drawable.ic_baseline_file_copy_24, R.string.insert_snippet),
-                new ActionItem(R.string.abid_asciidoc_h1, R.drawable.format_header_1,
-                        R.string.heading_1),
-                new ActionItem(R.string.abid_asciidoc_h2, R.drawable.format_header_2,
-                        R.string.heading_2),
-                new ActionItem(R.string.abid_asciidoc_h3, R.drawable.format_header_3,
-                        R.string.heading_3),
-//                new ActionItem(R.string.abid_asciidoc_h4, R.drawable.format_header_4,
-//                        R.string.heading_4),
-//                new ActionItem(R.string.abid_asciidoc_h5, R.drawable.format_header_5,
-//                        R.string.heading_5),
-
-                new ActionItem(R.string.abid_asciidoc_bold, R.drawable.ic_format_bold_black_24dp,
-                        R.string.bold),
-                new ActionItem(R.string.abid_asciidoc_italic,
-                        R.drawable.ic_format_italic_black_24dp, R.string.italic),
-                new ActionItem(
-                        R.string.abid_asciidoc_monospace, R.drawable.ic_code_black_24dp,
-                        R.string.inline_code),
-                new ActionItem(R.string.abid_asciidoc_underline,
-                        R.drawable.ic_format_underlined_black_24dp, R.string.underline),
-                new ActionItem(
-                        R.string.abid_asciidoc_highlight, R.drawable.ic_highlight_black_24dp,
-                        R.string.highlighted),
-                new ActionItem(R.string.abid_asciidoc_linethrough,
-                        R.drawable.ic_format_strikethrough_black_24dp, R.string.strikeout),
-                new ActionItem(
-                        R.string.abid_asciidoc_overline, R.drawable.ic_baseline_format_overline_24,
-                        R.string.inline_code),
-                new ActionItem(R.string.abid_asciidoc_superscript, R.drawable.ic_baseline_superscript_24,
-                        R.string.inline_code),
-                new ActionItem(R.string.abid_asciidoc_subscript,
-                        R.drawable.ic_baseline_subscript_24
-                        , R.string.inline_code),
-                new ActionItem(
-                        R.string.abid_asciidoc_break_thematic, R.drawable.ic_more_horiz_black_24dp,
-                        R.string.horizontal_line),
-                new ActionItem(R.string.abid_asciidoc_block_quote,
-                        R.drawable.ic_format_quote_black_24dp, R.string.quote),
+                new ActionItem(R.string.abid_asciidoc_special_key, R.drawable.asciidoc_icon_black_24dp, R.string.asciidoc_special_key),
+                new ActionItem(R.string.abid_common_insert_snippet, R.drawable.ic_baseline_file_copy_24, R.string.insert_snippet),
+                new ActionItem(R.string.abid_asciidoc_h1, R.drawable.format_header_1, R.string.heading_1),
+                new ActionItem(R.string.abid_asciidoc_h2, R.drawable.format_header_2, R.string.heading_2),
+                new ActionItem(R.string.abid_asciidoc_h3, R.drawable.format_header_3, R.string.heading_3),
+                // new ActionItem(R.string.abid_asciidoc_h4, R.drawable.format_header_4, R.string.heading_4),
+                // new ActionItem(R.string.abid_asciidoc_h5, R.drawable.format_header_5, R.string.heading_5),
+                new ActionItem(R.string.abid_asciidoc_bold, R.drawable.ic_format_bold_black_24dp, R.string.bold),
+                new ActionItem(R.string.abid_asciidoc_italic, R.drawable.ic_format_italic_black_24dp, R.string.italic),
+                new ActionItem(R.string.abid_asciidoc_monospace, R.drawable.ic_code_black_24dp, R.string.inline_code),
+                new ActionItem(R.string.abid_asciidoc_underline, R.drawable.ic_format_underlined_black_24dp, R.string.underline),
+                new ActionItem(R.string.abid_asciidoc_highlight, R.drawable.ic_highlight_black_24dp, R.string.highlighted),
+                new ActionItem(R.string.abid_asciidoc_linethrough, R.drawable.ic_format_strikethrough_black_24dp, R.string.strikeout),
+                new ActionItem(R.string.abid_asciidoc_overline, R.drawable.ic_baseline_format_overline_24, R.string.inline_code),
+                new ActionItem(R.string.abid_asciidoc_superscript, R.drawable.ic_baseline_superscript_24, R.string.inline_code),
+                new ActionItem(R.string.abid_asciidoc_subscript, R.drawable.ic_baseline_subscript_24, R.string.inline_code),
+                new ActionItem(R.string.abid_asciidoc_break_thematic, R.drawable.ic_more_horiz_black_24dp, R.string.horizontal_line),
+                new ActionItem(R.string.abid_asciidoc_block_quote, R.drawable.ic_format_quote_black_24dp, R.string.quote),
+                new ActionItem(R.string.abid_common_insert_image, R.drawable.ic_image_black_24dp, R.string.insert_image),
+                new ActionItem(R.string.abid_common_insert_link, R.drawable.ic_link_black_24dp, R.string.insert_link),
+                new ActionItem(R.string.abid_common_insert_audio, R.drawable.ic_keyboard_voice_black_24dp, R.string.audio),
                 // TODO: Implement later
-//                new ActionItem(R.string.abid_common_web_jump_to_table_of_contents,
-//                        R.drawable.ic_list_black_24dp, R.string.table_of_contents,
-//                        ActionItem.DisplayMode.VIEW),
+                // new ActionItem(R.string.abid_common_web_jump_to_table_of_contents, R.drawable.ic_list_black_24dp, R.string.table_of_contents, ActionItem.DisplayMode.VIEW),
                 // TODO: Implement Table Generator later
-                // new ActionItem(R.string.abid_asciidoc_table_insert_columns, R.drawable
-                // .ic_view_module_black_24dp, R.string.table),
-
-                //similar to other formats:
-                new ActionItem(R.string.abid_common_delete_lines, R.drawable.ic_delete_black_24dp,
-                        R.string.delete_lines),
-                new ActionItem(
-                        R.string.abid_common_open_link_browser,
-                        R.drawable.ic_open_in_browser_black_24dp,
-                        R.string.open_link),
+                // new ActionItem(R.string.abid_asciidoc_table_insert_columns, R.drawable.ic_view_module_black_24dp, R.string.table),
+                // similar to other formats:
+                new ActionItem(R.string.abid_common_delete_lines, R.drawable.ic_delete_black_24dp, R.string.delete_lines),
+                new ActionItem(R.string.abid_common_open_link_browser, R.drawable.ic_open_in_browser_black_24dp, R.string.open_link),
                 // a different icon was used than in other formats, so that you can distinguish
                 // it from opening in the browser
-                new ActionItem(R.string.abid_common_view_file_in_other_app,
-                        R.drawable.ic_baseline_open_in_new_24, R.string.open_with,
-                        ActionItem.DisplayMode.ANY),
-                new ActionItem(
-                        R.string.abid_common_attach_something, R.drawable.ic_attach_file_black_24dp,
-                        R.string.attach),
-                new ActionItem(R.string.abid_common_time,
-                        R.drawable.ic_access_time_black_24dp, R.string.date_and_time),
-                new ActionItem(
-                        R.string.abid_common_new_line_below,
-                        R.drawable.ic_baseline_keyboard_return_24,
-                        R.string.start_new_line_below),
-                new ActionItem(
-                        R.string.abid_common_move_text_one_line_up,
-                        R.drawable.ic_baseline_arrow_upward_24,
-                        R.string.move_text_one_line_up),
-                new ActionItem(
-                        R.string.abid_common_move_text_one_line_down,
-                        R.drawable.ic_baseline_arrow_downward_24, R.string.move_text_one_line_down),
-                new ActionItem(R.string.abid_common_web_jump_to_very_top_or_bottom,
-                        R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom,
-                        ActionItem.DisplayMode.VIEW),
-                new ActionItem(
-                        R.string.abid_common_rotate_screen, R.drawable.ic_rotate_left_black_24dp,
-                        R.string.rotate, ActionItem.DisplayMode.ANY),
-
+                new ActionItem(R.string.abid_common_view_file_in_other_app, R.drawable.ic_baseline_open_in_new_24, R.string.open_with, ActionItem.DisplayMode.ANY),
+                new ActionItem(R.string.abid_common_time, R.drawable.ic_access_time_black_24dp, R.string.date_and_time),
+                new ActionItem(R.string.abid_common_new_line_below, R.drawable.ic_baseline_keyboard_return_24, R.string.start_new_line_below),
+                new ActionItem(R.string.abid_common_move_text_one_line_up, R.drawable.ic_baseline_arrow_upward_24, R.string.move_text_one_line_up),
+                new ActionItem(R.string.abid_common_move_text_one_line_down, R.drawable.ic_baseline_arrow_downward_24, R.string.move_text_one_line_down),
+                new ActionItem(R.string.abid_common_web_jump_to_very_top_or_bottom, R.drawable.ic_vertical_align_center_black_24dp, R.string.jump_to_bottom, ActionItem.DisplayMode.VIEW),
+                new ActionItem(R.string.abid_common_rotate_screen, R.drawable.ic_rotate_left_black_24dp, R.string.rotate, ActionItem.DisplayMode.ANY),
         };
 
         return Arrays.asList(TMA_ACTIONS);
     }
 
-// indent deindent:
+    // indent deindent:
 
-// implemented two different indent deindent
+    // implemented two different indent deindent
 
-// a "normal" one for blank characters only
-// another one that will change the level of headers and lists
-// Pseudologics for the level changer:
-// * indent level: the first character is added as a prefix
-// * deindent level: the first character is removed, but only if something remains after
-// '===' => '== ' => '= ' => '= ' (no further removal)
+    // a "normal" one for blank characters only
+    // another one that will change the level of headers and lists
+    // Pseudologics for the level changer:
+    // * indent level: the first character is added as a prefix
+    // * deindent level: the first character is removed, but only if something remains after
+    // '===' => '== ' => '= ' => '= ' (no further removal)
 
     @Override
     public boolean onActionClick(final @StringRes int action) {
@@ -297,14 +233,6 @@ public class AsciidocActionButtons extends ActionButtonBase {
             }
             case R.string.abid_asciidoc_break_page: {
                 runAsciidocInlineAction("<<<\n", "", "");
-                return true;
-            }
-
-            case R.string.abid_asciidoc_insert_link:
-            case R.string.abid_asciidoc_insert_image: {
-                AttachLinkOrFileDialog.showInsertImageOrLinkDialog(
-                        action == R.string.abid_asciidoc_insert_image ? 2 : 3,
-                        _document.getFormat(), getActivity(), _hlEditor, _document.getFile());
                 return true;
             }
             //this is an additional extra menu, analogous to special_key menu

--- a/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/markdown/MarkdownActionButtons.java
@@ -16,7 +16,6 @@ import androidx.annotation.StringRes;
 
 import net.gsantner.markor.R;
 import net.gsantner.markor.format.ActionButtonBase;
-import net.gsantner.markor.frontend.AttachLinkOrFileDialog;
 import net.gsantner.markor.frontend.MarkorDialogFactory;
 import net.gsantner.markor.frontend.textview.AutoTextFormatter;
 import net.gsantner.markor.frontend.textview.TextViewUtils;
@@ -52,7 +51,9 @@ public class MarkdownActionButtons extends ActionButtonBase {
                 new ActionItem(R.string.abid_markdown_italic, R.drawable.ic_format_italic_black_24dp, R.string.italic),
                 new ActionItem(R.string.abid_common_delete_lines, R.drawable.ic_delete_black_24dp, R.string.delete_lines),
                 new ActionItem(R.string.abid_common_open_link_browser, R.drawable.ic_open_in_browser_black_24dp, R.string.open_link),
-                new ActionItem(R.string.abid_common_attach_something, R.drawable.ic_attach_file_black_24dp, R.string.attach),
+                new ActionItem(R.string.abid_common_insert_link, R.drawable.ic_link_black_24dp, R.string.insert_link),
+                new ActionItem(R.string.abid_common_insert_image, R.drawable.ic_image_black_24dp, R.string.insert_image),
+                new ActionItem(R.string.abid_common_insert_audio, R.drawable.ic_keyboard_voice_black_24dp, R.string.audio),
                 new ActionItem(R.string.abid_common_special_key, R.drawable.ic_keyboard_black_24dp, R.string.special_key),
                 new ActionItem(R.string.abid_common_time, R.drawable.ic_access_time_black_24dp, R.string.date_and_time),
                 new ActionItem(R.string.abid_markdown_code_inline, R.drawable.ic_code_black_24dp, R.string.inline_code),
@@ -138,11 +139,6 @@ public class MarkdownActionButtons extends ActionButtonBase {
                 MarkorDialogFactory.showInsertTableRowDialog(getActivity(), false, this::insertTableRow);
                 return true;
             }
-            case R.string.abid_markdown_insert_link:
-            case R.string.abid_markdown_insert_image: {
-                AttachLinkOrFileDialog.showInsertImageOrLinkDialog(action == R.string.abid_markdown_insert_image ? 2 : 3, _document.getFormat(), getActivity(), _hlEditor, _document.getFile());
-                return true;
-            }
             default: {
                 return runCommonAction(action);
             }
@@ -153,7 +149,7 @@ public class MarkdownActionButtons extends ActionButtonBase {
     @Override
     public boolean onActionLongClick(final @StringRes int action) {
         switch (action) {
-            case R.string.abid_markdown_insert_image: {
+            case R.string.abid_common_insert_image: {
                 int pos = _hlEditor.getSelectionStart();
                 _hlEditor.getText().insert(pos, "<img style=\"width:auto;max-height: 256px;\" src=\"\" />");
                 _hlEditor.setSelection(pos + 48);

--- a/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextActionButtons.java
@@ -16,7 +16,6 @@ import androidx.annotation.StringRes;
 import net.gsantner.markor.R;
 import net.gsantner.markor.activity.DocumentActivity;
 import net.gsantner.markor.format.ActionButtonBase;
-import net.gsantner.markor.frontend.AttachLinkOrFileDialog;
 import net.gsantner.markor.frontend.MarkorDialogFactory;
 import net.gsantner.markor.frontend.textview.AutoTextFormatter;
 import net.gsantner.markor.frontend.textview.TextViewUtils;
@@ -70,8 +69,8 @@ public class WikitextActionButtons extends ActionButtonBase {
                 new ActionItem(R.string.abid_common_deindent, R.drawable.ic_format_indent_decrease_black_24dp, R.string.deindent),
                 new ActionItem(R.string.abid_wikitext_h4, R.drawable.format_header_4, R.string.heading_4),
                 new ActionItem(R.string.abid_wikitext_h5, R.drawable.format_header_5, R.string.heading_5),
-                new ActionItem(R.string.abid_wikitext_insert_image, R.drawable.ic_image_black_24dp, R.string.insert_image),
-                new ActionItem(R.string.abid_wikitext_insert_link, R.drawable.ic_link_black_24dp, R.string.insert_link),
+                new ActionItem(R.string.abid_common_insert_image, R.drawable.ic_image_black_24dp, R.string.insert_image),
+                new ActionItem(R.string.abid_common_insert_link, R.drawable.ic_link_black_24dp, R.string.insert_link),
                 new ActionItem(R.string.abid_common_new_line_below, R.drawable.ic_baseline_keyboard_return_24, R.string.start_new_line_below),
                 new ActionItem(R.string.abid_common_move_text_one_line_up, R.drawable.ic_baseline_arrow_upward_24, R.string.move_text_one_line_up),
                 new ActionItem(R.string.abid_common_move_text_one_line_down, R.drawable.ic_baseline_arrow_downward_24, R.string.move_text_one_line_down),
@@ -146,13 +145,6 @@ public class WikitextActionButtons extends ActionButtonBase {
             //       runInlineAction("----\n");
             //       return true;
             // }
-            case R.string.abid_wikitext_insert_link:
-                AttachLinkOrFileDialog.showInsertImageOrLinkDialog(AttachLinkOrFileDialog.FILE_OR_LINK_ACTION, _document.getFormat(), getActivity(), _hlEditor, _document.getFile());
-                return true;
-            case R.string.abid_wikitext_insert_image: {
-                AttachLinkOrFileDialog.showInsertImageOrLinkDialog(AttachLinkOrFileDialog.IMAGE_ACTION, _document.getFormat(), getActivity(), _hlEditor, _document.getFile());
-                return true;
-            }
             case R.string.abid_common_indent:
                 runRegexReplaceAction(WikitextReplacePatternGenerator.indentOneTab());
                 runRenumberOrderedListIfRequired();
@@ -179,13 +171,13 @@ public class WikitextActionButtons extends ActionButtonBase {
                 runRegexReplaceAction(WikitextReplacePatternGenerator.removeCheckbox());
                 return true;
             }
-            case R.string.abid_wikitext_insert_link: {
+            case R.string.abid_common_insert_link: {
                 int pos = _hlEditor.getSelectionStart();
                 _hlEditor.getText().insert(pos, "[[]]");
                 _hlEditor.setSelection(pos + 2);
                 return true;
             }
-            case R.string.abid_wikitext_insert_image: {
+            case R.string.abid_common_insert_image: {
                 int pos = _hlEditor.getSelectionStart();
                 _hlEditor.getText().insert(pos, "{{}}");
                 _hlEditor.setSelection(pos + 2);

--- a/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
@@ -10,8 +10,6 @@
 package net.gsantner.markor.frontend;
 
 import android.app.Activity;
-import android.app.AlertDialog;
-import android.app.Dialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.text.Editable;
@@ -20,6 +18,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
@@ -28,9 +27,10 @@ import net.gsantner.markor.R;
 import net.gsantner.markor.format.FormatRegistry;
 import net.gsantner.markor.format.markdown.MarkdownSyntaxHighlighter;
 import net.gsantner.markor.frontend.filebrowser.MarkorFileBrowserFactory;
-import net.gsantner.markor.frontend.textview.HighlightingEditor;
+import net.gsantner.markor.frontend.textview.TextViewUtils;
 import net.gsantner.markor.model.AppSettings;
 import net.gsantner.markor.util.MarkorContextUtils;
+import net.gsantner.opoc.format.GsTextUtils;
 import net.gsantner.opoc.frontend.GsAudioRecordOmDialog;
 import net.gsantner.opoc.frontend.filebrowser.GsFileBrowserOptions;
 import net.gsantner.opoc.util.GsFileUtils;
@@ -40,13 +40,21 @@ import net.gsantner.opoc.wrapper.GsHashMap;
 import java.io.File;
 import java.util.regex.Matcher;
 
-@SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
 public class AttachLinkOrFileDialog {
     public final static int IMAGE_ACTION = 2, FILE_OR_LINK_ACTION = 3, AUDIO_ACTION = 4;
 
-    @SuppressWarnings("RedundantCast")
-    public static Dialog showInsertImageOrLinkDialog(final int action, final int textFormatId, final Activity activity, final HighlightingEditor _hlEditor, final File currentWorkingFile) {
+    public static void showInsertImageOrLinkDialog(
+            final int action,
+            final int textFormatId,
+            final Activity activity,
+            final Editable text,
+            final File currentFile
+    ) {
+        final int[] sel = TextViewUtils.getSelection(text);
+
         final AppSettings _appSettings = ApplicationObject.settings();
+        final File attachmentDir = _appSettings.getAttachmentFolder(currentFile);
+
         final androidx.appcompat.app.AlertDialog.Builder builder = new androidx.appcompat.app.AlertDialog.Builder(activity);
         final View view = activity.getLayoutInflater().inflate(R.layout.select_path_dialog, (ViewGroup) null);
         final EditText inputPathName = view.findViewById(R.id.ui__select_path_dialog__name);
@@ -57,211 +65,164 @@ public class AttachLinkOrFileDialog {
         final Button buttonPictureEdit = view.findViewById(R.id.ui__select_path_dialog__edit_picture);
         final Button buttonAudioRecord = view.findViewById(R.id.ui__select_path_dialog__record_audio);
 
-        final int startCursorPos = _hlEditor.getSelectionStart();
-        buttonAudioRecord.setVisibility(action == AUDIO_ACTION ? View.VISIBLE : View.GONE);
-        buttonPictureCamera.setVisibility(action == IMAGE_ACTION ? View.VISIBLE : View.GONE);
-        buttonPictureGallery.setVisibility(action == IMAGE_ACTION ? View.VISIBLE : View.GONE);
-        buttonPictureEdit.setVisibility(action == IMAGE_ACTION ? View.VISIBLE : View.GONE);
+        final boolean isActionImage = action == IMAGE_ACTION;
+        final boolean isActionAudio = action == AUDIO_ACTION;
+        final boolean isActionLink = action == FILE_OR_LINK_ACTION;
+
+        buttonAudioRecord.setVisibility(isActionAudio ? View.VISIBLE : View.GONE);
+        buttonPictureCamera.setVisibility(isActionImage ? View.VISIBLE : View.GONE);
+        buttonPictureGallery.setVisibility(isActionImage ? View.VISIBLE : View.GONE);
+        buttonPictureEdit.setVisibility(isActionImage ? View.VISIBLE : View.GONE);
+
         final int actionTitle;
         final String formatTemplate;
-        switch (action) {
-            default:
-            case FILE_OR_LINK_ACTION: {
-                actionTitle = R.string.insert_link;
-                formatTemplate = new GsHashMap<Integer, String>().load(
-                        FormatRegistry.FORMAT_MARKDOWN, "[{{ template.title }}]({{ template.link }})",
-                        FormatRegistry.FORMAT_ASCIIDOC, "link:{{ template.link }}[{{ template.title }}]",
-                        FormatRegistry.FORMAT_WIKITEXT, "[[{{ template.link }}|{{ template.title }}]]"
-                ).getOrDefault(textFormatId, "<a href='{{ template.link }}'>{{ template.title }}</a>");
-                break;
-            }
-            case IMAGE_ACTION: {
-                actionTitle = R.string.insert_image;
-                formatTemplate = new GsHashMap<Integer, String>().load(
-                        FormatRegistry.FORMAT_MARKDOWN, "![{{ template.title }}]({{ template.link }})",
-                        FormatRegistry.FORMAT_ASCIIDOC, "image::{{ template.link }}[\"{{ template.title }}\"]",
-                        FormatRegistry.FORMAT_WIKITEXT, "{{{{ template.link }}}}"
-                ).getOrDefault(textFormatId, "<img style='width:auto;max-height: 256px;' alt='{{ template.title }}' src='{{ template.link }}' />");
-                break;
-            }
-            case AUDIO_ACTION: {
-                formatTemplate = "<audio src='{{ template.link }}' controls><a href='{{ template.link }}'>{{ template.title }}</a></audio>";
-                actionTitle = R.string.audio;
-                break;
-            }
-
+        if (isActionImage) {
+            actionTitle = R.string.insert_image;
+            formatTemplate = new GsHashMap<Integer, String>().load(
+                    FormatRegistry.FORMAT_MARKDOWN, "![{{ template.title }}]({{ template.link }})",
+                    FormatRegistry.FORMAT_ASCIIDOC, "image::{{ template.link }}[\"{{ template.title }}\"]",
+                    FormatRegistry.FORMAT_WIKITEXT, "{{{{ template.link }}}}"
+            ).getOrDefault(textFormatId, "<img style='width:auto;max-height: 256px;' alt='{{ template.title }}' src='{{ template.link }}' />");
+        } else if (isActionAudio) {
+            formatTemplate = "<audio src='{{ template.link }}' controls><a href='{{ template.link }}'>{{ template.title }}</a></audio>";
+            actionTitle = R.string.audio;
+        } else {
+            actionTitle = R.string.insert_link;
+            formatTemplate = new GsHashMap<Integer, String>().load(
+                    FormatRegistry.FORMAT_MARKDOWN, "[{{ template.title }}]({{ template.link }})",
+                    FormatRegistry.FORMAT_ASCIIDOC, "link:{{ template.link }}[{{ template.title }}]",
+                    FormatRegistry.FORMAT_WIKITEXT, "[[{{ template.link }}|{{ template.title }}]]"
+            ).getOrDefault(textFormatId, "<a href='{{ template.link }}'>{{ template.title }}</a>");
         }
 
         // Extract filepath if using Markdown
         if (textFormatId == FormatRegistry.FORMAT_MARKDOWN) {
-            if (_hlEditor.hasSelection()) {
-                String selected_text = "";
-                try {
-                    selected_text = _hlEditor.getText().subSequence(_hlEditor.getSelectionStart(), _hlEditor.getSelectionEnd()).toString();
-                } catch (Exception ignored) {
-                }
-                inputPathName.setText(selected_text);
-            } else if (_hlEditor.getText().toString().isEmpty()) {
+            if (sel[0] > 0 && sel[1] > 0 && sel[0] != sel[1]) {
+                inputPathName.setText(text.subSequence(sel[0], sel[1]));
+            } else if (text.length() == 0) {
                 inputPathName.setText("");
             } else {
-                final Editable contentText = _hlEditor.getText();
-                int lineStartidx = Math.max(startCursorPos, 0);
-                int lineEndidx = Math.min(startCursorPos, contentText.length() - 1);
-                lineStartidx = Math.min(lineEndidx, lineStartidx);
-                for (; lineStartidx > 0; lineStartidx--) {
-                    if (contentText.charAt(lineStartidx) == '\n') {
-                        break;
-                    }
+                final int[] lineSel = TextViewUtils.getLineSelection(text, sel);
+                final String line = text.subSequence(lineSel[0], lineSel[1]).toString();
+                final Matcher m;
+                if (isActionImage) {
+                    m = MarkdownSyntaxHighlighter.ACTION_IMAGE_PATTERN.matcher(line);
+                } else {
+                    m = MarkdownSyntaxHighlighter.ACTION_LINK_PATTERN.matcher(line);
                 }
-                for (; lineEndidx < contentText.length(); lineEndidx++) {
-                    if (contentText.charAt(lineEndidx) == '\n') {
-                        break;
-                    }
-                }
-
-                final String line = contentText.subSequence(lineStartidx, lineEndidx).toString();
-                Matcher m = (action == FILE_OR_LINK_ACTION ? MarkdownSyntaxHighlighter.ACTION_LINK_PATTERN : MarkdownSyntaxHighlighter.ACTION_IMAGE_PATTERN).matcher(line);
-                if (m.find() && startCursorPos > lineStartidx + m.start() && startCursorPos < m.end() + lineStartidx) {
-                    int stat = lineStartidx + m.start();
-                    int en = lineStartidx + m.end();
-                    _hlEditor.setSelection(stat, en);
+                if (m.find()) {
                     inputPathName.setText(m.group(1));
                     inputPathUrl.setText((m.group(2)));
+                    sel[0] = m.start() + lineSel[0];
+                    sel[1] = m.end() + lineSel[0];
                 }
             }
         }
 
+        // Source, dest to be written when the user hits accept
+        final GsCallback.a2<String, String> insertLink = (title, path) -> {
+            if (TextViewUtils.isNullOrEmpty(path)) {
+                return;
+            }
+
+            String newText = formatTemplate
+                    .replace("{{ template.title }}", title)
+                    .replace("{{ template.link }}", path);
+
+            if (textFormatId == FormatRegistry.FORMAT_WIKITEXT && newText.endsWith("|]]")) {
+                newText = newText.replaceFirst("\\|]]$", "]]");
+            }
+
+            if (!text.subSequence(sel[0], sel[1]).equals(newText)) {
+                text.replace(sel[0], sel[1], newText);
+            }
+        };
+
+        builder.setView(view)
+                .setTitle(actionTitle)
+                .setPositiveButton(android.R.string.ok, (dialog, id) -> {
+                    final String title = inputPathName.getText().toString().trim().replace(")", "\\)");
+
+                    final String path = inputPathUrl.getText().toString().trim()
+                            .replace(")", "\\)")
+                            .replace(" ", "%20")  // Workaround for parser - cannot deal with spaces and have other entities problems
+                            .replace("{{%20site.baseurl%20}}", "{{ site.baseurl }}"); // Disable space encoding for Jekyll
+
+                    insertLink.callback(title, path);
+                });
+
+        final AlertDialog dialog = builder.show();
+
+        final GsCallback.a1<File> insertFileLink = (file) -> {
+            // If path is not under notebook, copy it to the res folder
+            if (!GsFileUtils.isChild(_appSettings.getNotebookDirectory(), file)) {
+                final File local = GsFileUtils.findNonConflictingDest(attachmentDir, file.getName());
+                attachmentDir.mkdirs();
+                GsFileUtils.copyFile(file, local);
+                file = local;
+            }
+            final String title = GsFileUtils.getFilenameWithoutExtension(file);
+            final String path = GsFileUtils.relativePath(currentFile, file);
+            insertLink.callback(title, path);
+            dialog.dismiss();
+        };
 
         // Inserts path relative if inside savedir, else absolute. asks to copy file if not in savedir
         final GsFileBrowserOptions.SelectionListener fsListener = new GsFileBrowserOptions.SelectionListenerAdapter() {
             @Override
             public void onFsViewerSelected(final String request, final File file, final Integer lineNumber) {
-                final File saveDir = _appSettings.getNotebookDirectory();
-                String text = null;
-                boolean isInSaveDir = GsFileUtils.isChild(saveDir, file) && GsFileUtils.isChild(saveDir, currentWorkingFile);
-                boolean isInCurrentDir = currentWorkingFile.getAbsolutePath().startsWith(file.getParentFile().getAbsolutePath());
-                if (isInCurrentDir || isInSaveDir) {
-                    text = GsFileUtils.relativePath(currentWorkingFile, file);
-                } else if ("abs_if_not_relative".equals(request)) {
-                    text = file.getAbsolutePath();
-                } else {
-                    String filename = file.getName();
-                    if ("audio_record_om_dialog".equals(request)) {
-                        filename = GsAudioRecordOmDialog.generateFilename(file).getName();
-                    }
-                    File targetCopy = new File(currentWorkingFile.getParentFile(), filename);
-                    showCopyFileToDirDialog(activity, file, targetCopy, false, (cbRetValSuccess, cbRestValTargetFile) -> onFsViewerSelected("abs_if_not_relative", cbRestValTargetFile, null));
-                }
-                if (text == null) {
-                    text = file.getAbsolutePath();
-                }
+                inputPathUrl.setText(GsFileUtils.relativePath(currentFile, file));
 
-                inputPathUrl.setText(text);
-
-                if (inputPathName.getText().toString().isEmpty()) {
-                    text = file.getName();
-                    text = text.contains(".") ? text.substring(0, text.lastIndexOf('.')) : text;
-                    inputPathName.setText(text);
-                }
-                text = inputPathUrl.getText().toString();
-                try {
-                    if (text.startsWith("../assets/") && currentWorkingFile.getParentFile().getName().equals("_posts")) {
-                        text = "{{ site.baseurl }}" + text.substring(2);
-                        inputPathUrl.setText(text);
-                    }
-                } catch (Exception ignored) {
+                if (TextViewUtils.isNullOrEmpty(inputPathName.getText())) {
+                    inputPathName.setText(GsFileUtils.getFilenameWithoutExtension(file));
                 }
             }
 
             @Override
             public void onFsViewerConfig(GsFileBrowserOptions.Options dopt) {
-                if (currentWorkingFile != null) {
-                    dopt.rootFolder = currentWorkingFile.getParentFile();
-                }
+                dopt.rootFolder = currentFile.getParentFile();
             }
         };
 
-        // Request camera / gallery picture button handling
         final MarkorContextUtils shu = new MarkorContextUtils(activity);
-        final BroadcastReceiver lbr = shu.receiveResultFromLocalBroadcast(activity, (intent, lbr_ref) -> {
-                    fsListener.onFsViewerSelected("pic", new File(intent.getStringExtra(MarkorContextUtils.EXTRA_FILEPATH)), null);
-                },
-                false, MarkorContextUtils.REQUEST_CAMERA_PICTURE + "", MarkorContextUtils.REQUEST_PICK_PICTURE + "");
-        final File targetFolder = currentWorkingFile != null ? currentWorkingFile.getParentFile() : _appSettings.getNotebookDirectory();
-        buttonPictureCamera.setOnClickListener(button -> shu.requestCameraPicture(activity, targetFolder));
+        final BroadcastReceiver br = shu.receiveResultFromLocalBroadcast(
+                activity,
+                (intent, _br) -> insertFileLink.callback(new File(intent.getStringExtra(MarkorContextUtils.EXTRA_FILEPATH))),
+                true,
+                "" + MarkorContextUtils.REQUEST_CAMERA_PICTURE, "" + MarkorContextUtils.REQUEST_PICK_PICTURE
+        );
+        dialog.setOnDismissListener(d -> LocalBroadcastManager.getInstance(activity).unregisterReceiver(br));
+
+        // Get picture from camera
+        buttonPictureCamera.setOnClickListener(button -> shu.requestCameraPicture(activity, attachmentDir));
+
+        // Get picture from gallery
         buttonPictureGallery.setOnClickListener(button -> shu.requestGalleryPicture(activity));
 
+        // Browse filesystem
         buttonBrowseFilesystem.setOnClickListener(button -> {
             if (activity instanceof AppCompatActivity) {
                 AppCompatActivity a = (AppCompatActivity) activity;
-                GsCallback.b2<Context, File> f = action == AUDIO_ACTION ? MarkorFileBrowserFactory.IsMimeAudio : (action == FILE_OR_LINK_ACTION ? null : MarkorFileBrowserFactory.IsMimeImage);
+                GsCallback.b2<Context, File> f = isActionAudio ? MarkorFileBrowserFactory.IsMimeAudio : (isActionLink ? null : MarkorFileBrowserFactory.IsMimeImage);
                 MarkorFileBrowserFactory.showFileDialog(fsListener, a.getSupportFragmentManager(), activity, f);
             }
         });
 
-        // Audio Record -> fs listener with arg file,"audio_record"
-        buttonAudioRecord.setOnClickListener(v -> GsAudioRecordOmDialog.showAudioRecordDialog(activity, R.string.record_audio, cbValAudioRecordFilepath -> fsListener.onFsViewerSelected("audio_record_om_dialog", cbValAudioRecordFilepath, null)));
+        // Audio Record
+        buttonAudioRecord.setOnClickListener(v -> GsAudioRecordOmDialog.showAudioRecordDialog(
+                activity, R.string.record_audio, insertFileLink
+        ));
 
+        // Edit picture
         buttonPictureEdit.setOnClickListener(v -> {
             String filepath = inputPathUrl.getText().toString().replace("%20", " ");
             if (!filepath.startsWith("/")) {
-                filepath = new File(currentWorkingFile.getParent(), filepath).getAbsolutePath();
+                filepath = new File(currentFile.getParent(), filepath).getAbsolutePath();
             }
             File file = new File(filepath);
             if (file.exists() && file.isFile()) {
                 shu.requestPictureEdit(activity, file);
             }
         });
-
-        builder.setView(view)
-                .setTitle(actionTitle)
-                .setOnDismissListener(dialog -> LocalBroadcastManager.getInstance(activity).unregisterReceiver(lbr))
-                .setNegativeButton(R.string.cancel, (dialogInterface, i) -> {
-                    if (_hlEditor.hasSelection()) {
-                        _hlEditor.setSelection(startCursorPos);
-                    }
-                })
-                .setPositiveButton(android.R.string.ok, (dialog, id) -> {
-                    try {
-                        String title = inputPathName.getText().toString().replace(")", "\\)");
-                        String url = inputPathUrl.getText().toString().trim().replace(")", "\\)").replace(" ", "%20");  // Workaround for parser - cannot deal with spaces and have other entities problems
-                        url = url.replace("{{%20site.baseurl%20}}", "{{ site.baseurl }}"); // Disable space encoding for Jekyll
-                        String newText = formatTemplate.replace("{{ template.title }}", title).replace("{{ template.link }}", url);
-                        if (textFormatId == FormatRegistry.FORMAT_WIKITEXT && newText.endsWith("|]]")) {
-                            newText = newText.replaceFirst("\\|]]$", "]]");
-                        }
-                        if (_hlEditor.hasSelection()) {
-                            _hlEditor.getText().replace(_hlEditor.getSelectionStart(), _hlEditor.getSelectionEnd(), newText);
-                            _hlEditor.setSelection(_hlEditor.getSelectionStart());
-                        } else {
-                            _hlEditor.getText().insert(_hlEditor.getSelectionStart(), newText);
-                        }
-                    } catch (Exception ignored) {
-                    }
-                });
-        return builder.show();
-    }
-
-    public static Dialog showCopyFileToDirDialog(final Activity activity, final File srcFile, final File tarFile, boolean disableCancel, final GsCallback.a2<Boolean, File> copyFileFinishedCallback) {
-        final GsCallback.a1<File> copyToDirInvocation = cbValTargetFile -> new MarkorContextUtils(activity).writeFile(activity, cbValTargetFile, false, (wfCbValOpened, wfCbValStream) -> {
-            if (wfCbValOpened && GsFileUtils.copyFile(srcFile, wfCbValStream)) {
-                copyFileFinishedCallback.callback(true, cbValTargetFile);
-            }
-        });
-
-        final File tarFileInAssetsDir = new File(ApplicationObject.settings().getNotebookDirectory(), tarFile.getName());
-
-
-        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(activity)
-                .setTitle(R.string.copy_file)
-                .setMessage(R.string.file_not_in_current_folder_do_copy__appspecific)
-                .setPositiveButton(R.string.current, (dialogInterface, which) -> copyToDirInvocation.callback(tarFile))
-                .setNeutralButton(R.string.notebook, (dialogInterface, which) -> copyToDirInvocation.callback(tarFileInAssetsDir));
-        if (disableCancel) {
-            dialogBuilder.setCancelable(false);
-        } else {
-            dialogBuilder.setNegativeButton(android.R.string.no, null);
-        }
-        return dialogBuilder.show();
     }
 }

--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -104,35 +104,6 @@ public class MarkorDialogFactory {
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
     }
 
-    public static void showAttachSomethingDialog(final Activity activity, final GsCallback.a1<Integer> userCallback) {
-        final List<String> availableData = new ArrayList<>();
-        final List<Integer> availableDataToActionMap = new ArrayList<>();
-        final List<Integer> availableDataToIconMap = new ArrayList<>();
-        final GsCallback.a3<Integer, Integer, Integer> addToList = (strRes, actionRes, iconRes) -> {
-            availableData.add(activity.getString(strRes));
-            availableDataToActionMap.add(actionRes);
-            availableDataToIconMap.add(iconRes);
-        };
-        addToList.callback(R.string.color, R.id.action_attach_color, R.drawable.ic_format_color_fill_black_24dp);
-        addToList.callback(R.string.insert_link, R.id.action_attach_link, R.drawable.ic_link_black_24dp);
-        addToList.callback(R.string.file, R.id.action_attach_file, R.drawable.ic_attach_file_black_24dp);
-        addToList.callback(R.string.image, R.id.action_attach_image, R.drawable.ic_image_black_24dp);
-        addToList.callback(R.string.audio, R.id.action_attach_audio, R.drawable.ic_keyboard_voice_black_24dp);
-        addToList.callback(R.string.date, R.id.action_attach_date, R.drawable.ic_access_time_black_24dp);
-
-        DialogOptions dopt = new DialogOptions();
-        baseConf(activity, dopt);
-        dopt.callback = str -> userCallback.callback(availableDataToActionMap.get(availableData.indexOf(str)));
-        dopt.data = availableData;
-        dopt.iconsForData = availableDataToIconMap;
-        dopt.isSearchEnabled = false;
-        dopt.okButtonText = 0;
-        dopt.titleText = 0;
-        dopt.dialogWidthDp = WindowManager.LayoutParams.WRAP_CONTENT;
-        dopt.gravity = Gravity.BOTTOM | Gravity.END;
-        GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
-    }
-
     public static void showInsertTableRowDialog(final Activity activity, final boolean isHeader, GsCallback.a2<Integer, Boolean> callback) {
         final DialogOptions dopt = new DialogOptions();
         final String PREF_LAST_USED_TABLE_SIZE = "pref_key_last_used_table_size";
@@ -253,7 +224,6 @@ public class MarkorDialogFactory {
         dopt.iconsForData = availableDataToIconMap;
         dopt.dialogWidthDp = WindowManager.LayoutParams.WRAP_CONTENT;
         dopt.dialogHeightDp = 530;
-        dopt.gravity = Gravity.BOTTOM | Gravity.END;
         dopt.okButtonText = 0;
 
         dopt.titleText = R.string.sort_tasks_by_selected_order;

--- a/app/src/main/java/net/gsantner/markor/model/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/model/AppSettings.java
@@ -16,12 +16,14 @@ import android.util.Pair;
 
 import androidx.annotation.ColorRes;
 import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
 
 import net.gsantner.markor.BuildConfig;
 import net.gsantner.markor.R;
 import net.gsantner.markor.format.FormatRegistry;
+import net.gsantner.markor.frontend.textview.TextViewUtils;
 import net.gsantner.markor.util.MarkorContextUtils;
 import net.gsantner.markor.util.ShortcutUtils;
 import net.gsantner.opoc.format.GsTextUtils;
@@ -897,5 +899,14 @@ public class AppSettings extends GsSharedPreferencesPropertyBackend {
 
     public String getShareIntoPrefix() {
         return getString(R.string.pref_key__share_into_format, "\\n----\\n{{text}}");
+    }
+
+    public @NonNull File getAttachmentFolder(final File file) {
+        final File parent = file.getParentFile();
+        if (parent == null) {
+            return getNotebookDirectory();
+        }
+        final String child = getString(R.string.pref_key__attachment_folder_name, "_res").trim();
+        return TextViewUtils.isNullOrEmpty(child) ? parent : new File(parent, child);
     }
 }

--- a/app/src/main/java/net/gsantner/opoc/frontend/GsAudioRecordOmDialog.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/GsAudioRecordOmDialog.java
@@ -79,7 +79,7 @@ public class GsAudioRecordOmDialog {
         final AtomicReference<MediaPlayer> mediaPlayer = new AtomicReference<>();
         final AtomicReference<AlertDialog> dialog = new AtomicReference<>();
         final AtomicReference<Long> startTime = new AtomicReference<>();
-        final File TMP_FILE_RECORDING = new File(activity.getCacheDir(), "recording.wav");
+        final File TMP_FILE_RECORDING = generateFilename(activity.getCacheDir());
         if (TMP_FILE_RECORDING.exists()) {
             TMP_FILE_RECORDING.delete();
         }
@@ -169,9 +169,9 @@ public class GsAudioRecordOmDialog {
 
         ////////////////////////////////////
         // Callback for OK & Cancel dialog button
-        DialogInterface.OnClickListener dialogOkAndCancelListener = (dialogInterface, dialogButtonCase) -> {
+        final DialogInterface.OnClickListener dialogOkAndCancelListener = (dialogInterface, dialogButtonCase) -> {
             final boolean isSavePressed = (dialogButtonCase == DialogInterface.BUTTON_POSITIVE);
-            if (isRecordSavedOnce.get()) {
+            if (isRecording.get() || isRecordSavedOnce.get()) {
                 try {
                     recorder.get().stopRecording();
                 } catch (Exception ignored) {

--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -778,4 +778,18 @@ public class GsFileUtils {
 
         return false;
     }
+
+    public static File findNonConflictingDest(final File destDir, final String name) {
+        File dest = new File(destDir, name);
+        final String[] splits = name.split("\\.");
+        final String baseName = splits[0];
+        splits[0] = "";
+        final String extension = String.join(".", splits);
+        int i = 1;
+        while (dest.exists()) {
+            dest = new File(destDir, String.format("%s_%d%s", baseName, i, extension));
+            i++;
+        }
+        return dest;
+    }
 }

--- a/app/src/main/res/menu/document__edit__menu.xml
+++ b/app/src/main/res/menu/document__edit__menu.xml
@@ -12,42 +12,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="AlwaysShowAction">
 
-
-    <item
-        android:id="@+id/submenu_attach"
-        android:icon="@drawable/ic_attach_file_black_24dp"
-        android:title="@string/attach"
-        android:visible="false"
-        app:showAsAction="always">
-        <menu>
-            <item
-                android:id="@+id/action_attach_link"
-                android:icon="@drawable/ic_link_black_24dp"
-                android:title="@string/insert_link" />
-            <item
-                android:id="@+id/action_attach_file"
-                android:icon="@drawable/ic_file_white_24dp"
-                android:title="@string/file" />
-            <item
-                android:id="@+id/action_attach_image"
-                android:icon="@drawable/ic_image_black_24dp"
-                android:title="@string/image" />
-            <item
-                android:id="@+id/action_attach_audio"
-                android:icon="@drawable/ic_keyboard_voice_black_24dp"
-                android:title="@string/audio" />
-            <item
-                android:id="@+id/action_attach_date"
-                android:icon="@drawable/ic_date_range_black_24dp"
-                android:title="@string/date" />
-            <item
-                android:id="@+id/action_attach_color"
-                android:icon="@drawable/ic_format_color_fill_black_24dp"
-                android:title="@string/color" />
-        </menu>
-    </item>
-
-
     <item
         android:id="@+id/action_undo"
         android:icon="@drawable/ic_undo_black_24dp"

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -216,7 +216,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="abid_common_open_link_browser" translatable="false">abid_common_open_link_browser</string>
     <string name="abid_common_color_picker" translatable="false">abid_common_color_picker</string>
     <string name="abid_common_time" translatable="false">abid_common_time</string>
-    <string name="abid_common_time_insert_timestamp" translatable="false">abid_common_time_insert_timestamp</string>
     <string name="abid_common_web_jump_to_very_top_or_bottom" translatable="false">abid_common_web_jump_to_very_top_or_bottom</string>
     <string name="abid_common_web_jump_to_table_of_contents" translatable="false">abid_common_web_jump_to_table_of_contents</string>
     <string name="abid_common_view_file_in_other_app" translatable="false">abid_common_view_file_in_other_app</string>
@@ -228,6 +227,9 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="abid_common_move_text_one_line_up" translatable="false">abid_common_move_text_one_line_up</string>
     <string name="abid_common_move_text_one_line_down" translatable="false">abid_common_move_text_one_line_down</string>
     <string name="abid_common_insert_snippet" translatable="false">abid_common_insert_snippet</string>
+    <string name="abid_common_insert_image" translatable="false">abid_common_insert_image</string>
+    <string name="abid_common_insert_audio" translatable="false">abid_common_insert_audio</string>
+    <string name="abid_common_insert_link" translatable="false">abid_common_insert_link</string>
 
     <string name="abid_markdown_quote" translatable="false">abid_markdown_quote</string>
     <string name="abid_markdown_h1" translatable="false">abid_markdown_h1</string>
@@ -238,8 +240,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="abid_markdown_strikeout" translatable="false">abid_markdown_strikeout</string>
     <string name="abid_markdown_code_inline" translatable="false">abid_markdown_code_inline</string>
     <string name="abid_markdown_horizontal_line" translatable="false">abid_markdown_horizontal_line</string>
-    <string name="abid_markdown_insert_image" translatable="false">abid_markdown_insert_image</string>
-    <string name="abid_markdown_insert_link" translatable="false">abid_markdown_insert_link</string>
     <string name="abid_markdown_table_insert_columns" translatable="false">abid_markdown_table_insert_columns</string>
 
     <string name="abid_asciidoc_h1" translatable="false">abid_asciidoc_h1</string>
@@ -283,9 +283,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="abid_asciidoc_block_table" translatable="false">abid_asciidoc_block_table</string>
     <string name="abid_asciidoc_block_pass" translatable="false">abid_asciidoc_block_pass</string>
     <string name="abid_asciidoc_block_quote" translatable="false">abid_asciidoc_block_quote</string>
-
-    <string name="abid_asciidoc_insert_image" translatable="false">abid_asciidoc_insert_image</string>
-    <string name="abid_asciidoc_insert_link" translatable="false">abid_asciidoc_insert_link</string>
     <string name="abid_asciidoc_table_insert_columns" translatable="false">abid_asciidoc_table_insert_columns</string>
 
     <string name="abid_asciidoc_special_key" translatable="false">abid_asciidoc_special_key</string>
@@ -337,8 +334,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="abid_wikitext_highlight" translatable="false">abid_wikitext_highlight</string>
     <string name="abid_wikitext_strikeout" translatable="false">abid_wikitext_strikeout</string>
     <string name="abid_wikitext_code_inline" translatable="false">abid_wikitext_code_inline</string>
-    <string name="abid_wikitext_insert_link" translatable="false">abid_wikitext_insert_link</string>
-    <string name="abid_wikitext_insert_image" translatable="false">abid_wikitext_insert_image</string>
 
     <string name="abid_todotxt_toggle_done" translatable="false">abid_todotxt_toggle_done</string>
     <string name="abid_todotxt_add_context" translatable="false">abid_todotxt_add_context</string>
@@ -428,6 +423,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="action_format_todotxt" translatable="false">action_format_todotxt</string>
     <string name="action_format_wikitext" translatable="false">action_format_wikitext</string>
     <string name="pref_key__share_into_format" translatable="false">pref_key__share_into_format</string>
+    <string name="pref_key__attachment_folder_name" translatable="false">pref_key__attachment_directory_name</string>
     <string name="squarebrackets" translatable="false">Square Brackets</string>
     <string name="csv" translatable="false">CSV</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -457,6 +457,8 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="search_dynamically_for_notebook_root">In order to follow wiki links, dynamically search for the notebook.zim file to identify the root directory for the current notebook. Check this if you use multiple zim notebooks or the notebook directory set in the app does not correspond to your zim notebook.</string>
 	<string name="share_into_format_prefix_for_text_shared">Format/Prefix for text shared into Markor. Follows Android\'s SimpleDateFormat rules.\n\nUse the placeholder {{text}} to position the shared text. If not specified, the shared text is appended and the format used as a prefix.</string>
     <string name="share_into_format">Share into - Format</string>
+    <string name="attachment_folder_name">Attachment folder name</string>
+    <string name="attachment_folder_name_desc">Subfolder under the current folder where attachments will be saved. If left blank, attachments will be saved in the current folder.</string>
     <string name="auto_format">Auto-format</string>
     <string name="insert_snippet">Insert snippet</string>
     <string name="error_could_not_open_file">Error: Could not open file.</string>

--- a/app/src/main/res/xml/preferences_master.xml
+++ b/app/src/main/res/xml/preferences_master.xml
@@ -165,6 +165,13 @@
                 android:key="@string/pref_key__share_into_format"
                 android:title="@string/share_into_format" />
 
+            <androidx.preference.EditTextPreference
+                android:defaultValue="_res"
+                android:dialogMessage="@string/attachment_folder_name_desc"
+                android:icon="@drawable/ic_attach_file_black_24dp"
+                android:key="@string/pref_key__attachment_folder_name"
+                android:title="@string/attachment_folder_name" />
+
             <CheckBoxPreference
                 android:defaultValue="true"
                 android:icon="@drawable/ic_open_in_browser_black_24dp"

--- a/app/thirdparty/java/other/writeily/model/WrMarkorSingleton.java
+++ b/app/thirdparty/java/other/writeily/model/WrMarkorSingleton.java
@@ -137,7 +137,7 @@ public class WrMarkorSingleton {
             if (dest.exists()) {
                 // Special case - duplicate the file with new name if copying to same directory
                 if (resolution == ConflictResolution.KEEP_BOTH || (!isMove && file.equals(dest))) {
-                    moveOrCopy(activity, file, findNonConflictingDest(file, destDir), isMove);
+                    moveOrCopy(activity, file, GsFileUtils.findNonConflictingDest(destDir, file.getName()), isMove);
                 } else if (resolution == ConflictResolution.OVERWRITE) {
                     if (deleteFile(dest, activity)) {
                         moveOrCopy(activity, file, dest, isMove);
@@ -171,20 +171,6 @@ public class WrMarkorSingleton {
         } else {
             copyFile(src, dest);
         }
-    }
-
-    public File findNonConflictingDest(final File file, final File destDir) {
-        File dest = new File(destDir, file.getName());
-        final String[] splits = file.getName().split("\\.");
-        final String name = splits[0];
-        splits[0] = "";
-        final String extension = String.join(".", splits);
-        int i = 1;
-        while (dest.exists()) {
-            dest = new File(destDir, String.format("%s_%d%s", name, i, extension));
-            i++;
-        }
-        return dest;
     }
 
     public boolean isDirectoryEmpty(ArrayList<File> files) {


### PR DESCRIPTION
In this PR I have reworked the attachments system to fix bugs and reduce clicks.

- The attachment actions have been broken out of a nested menu into the main actions bar
- Camera, gallery and recording attachments add immediately when clicking ok. They can be edited later if needed.
- Camera permissions fixed
- User no longer given choice for where to save attachment
    - Setting include option for default attachment folder name
    - Need to consider making this per-file