### PR TITLE
Formats: Treat any XML based mime-type as text

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -499,7 +499,7 @@ public class GsFileUtils {
 
     public static boolean isTextFile(File file) {
         final String mime = getMimeType(file);
-        return mime != null && mime.startsWith("text/");
+        return mime != null && (mime.startsWith("text/") || mime.contains("xml"));
     }
 
     /**


### PR DESCRIPTION
Downloaded some rss feed files and noticed they are not treated as text file.

By this change, many files which were previously not are now treated as textfile. Like for example:

* application/rss+xml
* application/rdf+xml
* ...