### PR TITLE
Fix multiple link insertion due to not unregistering the broadcast receiver, also provide a canonical path to the image editor

### DIFF
--- a/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
@@ -310,7 +310,7 @@ public class AttachLinkOrFileDialog {
                 break;
             }
             case IMAGE_EDIT: {
-                if (pathEdit != null) {
+                if (pathEdit != null && !TextUtils.isEmpty(pathEdit.getText().toString())) {
                     final String path = pathEdit.getText().toString().replace("%20", " ");
 
                     final File abs = new File(path).getAbsoluteFile();

--- a/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
@@ -39,6 +39,7 @@ import net.gsantner.opoc.util.GsFileUtils;
 import net.gsantner.opoc.wrapper.GsCallback;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.regex.Matcher;
 
 public class AttachLinkOrFileDialog {
@@ -314,13 +315,23 @@ public class AttachLinkOrFileDialog {
 
                     final File abs = new File(path).getAbsoluteFile();
                     if (abs.isFile()) {
-                        shu.requestFileEdit(activity, abs);
+                        try {
+                            final File canonical = new File(abs.getCanonicalPath());
+                            shu.requestFileEdit(activity, canonical);
+                        } catch (IOException e) {
+                            shu.requestFileEdit(activity, abs);
+                        }
                         break;
                     }
 
                     final File rel = new File(currentFile.getParentFile(), path).getAbsoluteFile();
                     if (rel.isFile()) {
-                        shu.requestFileEdit(activity, rel);
+                        try {
+                            final File canonical = new File(rel.getCanonicalPath());
+                            shu.requestFileEdit(activity, canonical);
+                        } catch (IOException e) {
+                            shu.requestFileEdit(activity, rel);
+                        }
                         break;
                     }
                 }

--- a/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
@@ -285,6 +285,7 @@ public class AttachLinkOrFileDialog {
                 true,
                 "" + MarkorContextUtils.REQUEST_CAMERA_PICTURE,
                 "" + MarkorContextUtils.REQUEST_PICK_PICTURE,
+                "" + MarkorContextUtils.REQUEST_FILE_EDIT,
                 "" + MarkorContextUtils.REQUEST_RECORD_AUDIO
         );
 
@@ -320,8 +321,11 @@ public class AttachLinkOrFileDialog {
                     final File rel = new File(currentFile.getParentFile(), path).getAbsoluteFile();
                     if (rel.isFile()) {
                         shu.requestFileEdit(activity, rel);
+                        break;
                     }
                 }
+
+                shu.requestFileEdit(activity, null);
                 break;
             }
             case AUDIO_RECORDING: {

--- a/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
@@ -14,6 +14,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -260,6 +261,11 @@ public class AttachLinkOrFileDialog {
         };
 
         final GsCallback.a1<File> insertFileLink = (file) -> {
+            // If path is empty, unregister the broadcast (autoUnregister == true)
+            if (TextUtils.isEmpty(file.toString())) {
+                return;
+            }
+
             // If path is not under notebook, copy it to the res folder
             if (!GsFileUtils.isChild(_appSettings.getNotebookDirectory(), file)) {
                 final File local = GsFileUtils.findNonConflictingDest(attachmentDir, file.getName());

--- a/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
@@ -348,6 +348,11 @@ public class AttachLinkOrFileDialog {
                         public void onFsViewerConfig(GsFileBrowserOptions.Options dopt) {
                             dopt.rootFolder = currentFile.getParentFile();
                         }
+
+                        @Override
+                        public void onFsViewerDismissed() {
+                            LocalBroadcastManager.getInstance(activity).unregisterReceiver(br);
+                        }
                     };
 
                     final FragmentManager f = ((AppCompatActivity) activity).getSupportFragmentManager();

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserDialog.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserDialog.java
@@ -208,6 +208,7 @@ public class GsFileBrowserDialog extends DialogFragment implements GsFileBrowser
     @Override
     public void onDismiss(final DialogInterface dialog) {
         super.onDismiss(dialog);
+        onFsViewerDismissed();
         GsContextUtils.instance.showSoftKeyboard(getActivity(), false, _searchEdit);
     }
 
@@ -226,6 +227,13 @@ public class GsFileBrowserDialog extends DialogFragment implements GsFileBrowser
         dopt.callback = (name) -> _filesystemViewerAdapter.createDirectoryHere(name, true);
 
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
+    }
+
+    @Override
+    public void onFsViewerDismissed() {
+        if (_callback != null) {
+            _callback.onFsViewerDismissed();
+        }
     }
 
     @Override

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
@@ -173,6 +173,12 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
         }
     }
 
+    @Override
+    public void onFsViewerDismissed() {
+        if (_callback != null) {
+            _callback.onFsViewerDismissed();
+        }
+    }
 
     @Override
     public void onFsViewerSelected(String request, File file, final Integer lineNumber) {

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserOptions.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserOptions.java
@@ -27,6 +27,8 @@ import java.util.List;
 public class GsFileBrowserOptions {
 
     public interface SelectionListener {
+        void onFsViewerDismissed();
+
         void onFsViewerSelected(final String request, final File file, final Integer lineNumber);
 
         void onFsViewerMultiSelected(final String request, final File... files);
@@ -122,6 +124,10 @@ public class GsFileBrowserOptions {
     }
 
     public static class SelectionListenerAdapter implements SelectionListener, Serializable {
+        @Override
+        public void onFsViewerDismissed() {
+        }
+
         @Override
         public void onFsViewerSelected(String request, File file, final Integer lineNumber) {
         }

--- a/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
@@ -1823,7 +1823,7 @@ public class GsContextUtils {
 
                     // Return path to picture on success, else null
                     if (picturePath != null) {
-                        sendLocalBroadcastWithStringExtra(context, REQUEST_CAMERA_PICTURE + "", EXTRA_FILEPATH, picturePath);
+                        sendLocalBroadcastWithStringExtra(context, REQUEST_PICK_PICTURE + "", EXTRA_FILEPATH, picturePath);
                     }
 
                     return picturePath;

--- a/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
@@ -1771,16 +1771,15 @@ public class GsContextUtils {
         switch (requestCode) {
             case REQUEST_CAMERA_PICTURE: {
                 final String picturePath = (resultCode == Activity.RESULT_OK) ? _lastCameraPictureFilepath : null;
-                if (picturePath != null) {
-                    sendLocalBroadcastWithStringExtra(context, REQUEST_CAMERA_PICTURE + "", EXTRA_FILEPATH, picturePath);
-                }
+                sendLocalBroadcastWithStringExtra(context, REQUEST_CAMERA_PICTURE + "", EXTRA_FILEPATH, picturePath);
                 return picturePath;
             }
             case REQUEST_PICK_PICTURE: {
+                String picturePath = null;
+
                 if (resultCode == Activity.RESULT_OK && intent != null) {
                     Uri selectedImage = intent.getData();
                     String[] filePathColumn = {MediaStore.Images.Media.DATA};
-                    String picturePath = null;
 
                     Cursor cursor = context.getContentResolver().query(selectedImage, filePathColumn, null, null, null);
                     if (cursor != null && cursor.moveToFirst()) {
@@ -1820,15 +1819,12 @@ public class GsContextUtils {
                             // nothing we can do here, null value will be handled below
                         }
                     }
-
-                    // Return path to picture on success, else null
-                    if (picturePath != null) {
-                        sendLocalBroadcastWithStringExtra(context, REQUEST_PICK_PICTURE + "", EXTRA_FILEPATH, picturePath);
-                    }
-
-                    return picturePath;
                 }
-                break;
+
+                // Return path to picture on success, else null to unregister the broadcast (autoUnregister == true)
+                sendLocalBroadcastWithStringExtra(context, REQUEST_PICK_PICTURE + "", EXTRA_FILEPATH, picturePath);
+
+                return picturePath;
             }
             case REQUEST_RECORD_AUDIO: {
                 String audioPath = null;


### PR DESCRIPTION
Hello,

Apparently, there's a **bug** triggering via the `showInsertImageOrLinkDialog`, when an action is canceled (touching the **Cancel** or **Back** button), not unregistering an aborted action to the **broadcast receiver** may _accumulate_ it and **execute the next successful action a number of times more as much as there are registered actions**.

I'm asking, also, if it's possible to provide a **canonical path** to the image editor.  Writing `/path/to/file` and `/path/to/../to/file` give the same result, but the latter is a bit weird.  Sometimes, relative links may contain components, like `../`, than can be resolved.

Let me know,
Thanks.

# Multiple link insertion bug

1. Open a markdown file for editing;
2. Touch the **Insert Image** button;
3. Touch the **Browse Filesystem** button;
4. Touch the **Cancel** button;
5. Touch the **Gallery Picture** button;
6. Choose a picture to be inserted;
7. The link to the picture is inserted multiple times.

![multiple_link_insertion](https://github.com/gsantner/markor/assets/6450450/3aba7eb9-4bcc-4a93-a029-8491869d428a)

# Weird path provided to the image editor

Path components may be resolved to clear the location to the user.  In the example below, the problem is exaggerated.

![weird_relative_path](https://github.com/gsantner/markor/assets/6450450/8a486f64-84e7-4db2-b650-cf6ec1a05700)

<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
