### PR TITLE
Fix exceptions when audio is recorded

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
@@ -1832,13 +1832,18 @@ public class GsContextUtils {
                 break;
             }
             case REQUEST_RECORD_AUDIO: {
-                final Uri uri = intent.getData();
-                final String uriPath = uri.getPath();
-                final String ext = uriPath.substring(uriPath.lastIndexOf("."));
-                final String datestr = new SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss", Locale.ENGLISH).format(new Date());
-                final File temp = new File(context.getCacheDir(), datestr + ext);
-                GsFileUtils.copyUriToFile(context, uri, temp);
-                sendLocalBroadcastWithStringExtra(context, REQUEST_RECORD_AUDIO + "", EXTRA_FILEPATH, temp.getAbsolutePath());
+                String audioPath = null;
+                if (resultCode == Activity.RESULT_OK && intent != null) {
+                    final Uri uri = intent.getData();
+                    final String uriPath = uri.getPath();
+                    final String ext = uriPath.substring(uriPath.lastIndexOf("."));
+                    final String datestr = new SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss", Locale.ENGLISH).format(new Date());
+                    final File temp = new File(context.getCacheDir(), datestr + ext);
+                    GsFileUtils.copyUriToFile(context, uri, temp);
+                    audioPath = temp.getAbsolutePath();
+                }
+                sendLocalBroadcastWithStringExtra(context, REQUEST_RECORD_AUDIO + "", EXTRA_FILEPATH, audioPath);
+                break;
             }
             case REQUEST_SAF: {
                 if (resultCode == Activity.RESULT_OK && intent != null && intent.getData() != null) {


### PR DESCRIPTION
Hello,

This is to **prevent an exception when aborting the audio recorder**.  Also, it's possible that a `break` is missing before the `REQUEST_SAF` case, **the application may crash asking for read permission after accepting the audio recorded**, but `copyUriToFile` should suffice to get a copy of the audio file.

Let me know if this is the right solution,
Thanks.

# Aborting audio recorder exception bug

1. Open a markdown file for editing;
2. Touch the **Insert Audio** button;
3. Touch the **Record Audio** button;
4. Touch the **Cancel** button to abort the recording;
5. Markor may crash due to an exception.

![audio_exception](https://github.com/gsantner/markor/assets/6450450/e5487759-1bb4-4b91-88f7-d3c704667956)

# Accepting audio recorded exception bug

Like above, but the audio is accepted this time.

1. Open a markdown file for editing;
2. Touch the **Insert Audio** button;
3. Touch the **Record Audio** button;
4. Touch the **Accept** button to confirm the recording;
5. Markor may crash due to a permission exception.

<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
