### PR TITLE
Fix conformance to Zim (and enable Insert Audio button): wrong attachment directories, linked file not found, missing image link's tags, minsdk 16-18

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,4 +52,5 @@ Where:
 * **[Li Guanglin](https://github.com/guanglinn)**<br/>~° Added line numbers support
 * **[bigger124](https://github.com/bigger124)**<br>~° Added OrgMode-Support
 * **[Ayowel](https://github.com/ayowel)**<br>~° Mermaid update
+* **[Matthew White](https://github.com/mehw)**<br>~° Zim-Wiki link/attachment conformance.
 * **[Markus Paintner](https://github.com/goli4thus)**<br/>~° Added duplicate lines action

--- a/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextActionButtons.java
@@ -62,6 +62,7 @@ public class WikitextActionButtons extends ActionButtonBase {
                 new ActionItem(R.string.abid_common_deindent, R.drawable.ic_format_indent_decrease_black_24dp, R.string.deindent),
                 new ActionItem(R.string.abid_wikitext_h4, R.drawable.format_header_4, R.string.heading_4),
                 new ActionItem(R.string.abid_wikitext_h5, R.drawable.format_header_5, R.string.heading_5),
+                new ActionItem(R.string.abid_common_insert_audio, R.drawable.ic_keyboard_voice_black_24dp, R.string.audio),
                 new ActionItem(R.string.abid_common_insert_image, R.drawable.ic_image_black_24dp, R.string.insert_image),
                 new ActionItem(R.string.abid_common_insert_link, R.drawable.ic_link_black_24dp, R.string.insert_link)
         );

--- a/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextLinkResolver.java
+++ b/app/src/main/java/net/gsantner/markor/format/wikitext/WikitextLinkResolver.java
@@ -6,6 +6,7 @@ import net.gsantner.opoc.util.GsFileUtils;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -90,7 +91,8 @@ public class WikitextLinkResolver {
         if (_shouldDynamicallyDetermineRoot) {
             _notebookRootDir = findNotebookRootDir(_currentPage);
             if (_notebookRootDir == null) {
-                return null;
+                // try the current directory as a possible notebook root dir
+                _notebookRootDir = _currentPage.getParentFile();
             }
         }
 
@@ -107,7 +109,10 @@ public class WikitextLinkResolver {
             return findFirstPageTraversingUpToRoot(_currentPage, relativeLinkToCheck);
         }
 
-        return wikitextPath; // just return the original path in case the link cannot be resolved (might be a URL)
+        // Try to resolve the path as relative to the wiki page's attachment directory.
+        // Return an absolute path, or the original path in case it cannot be resolved,
+        // it might be a URL.
+        return resolveAttachmentPath(wikitextPath, _notebookRootDir, _currentPage, _shouldDynamicallyDetermineRoot);
     }
 
     private String stripInnerPageReference(String wikitextPath) {
@@ -119,7 +124,7 @@ public class WikitextLinkResolver {
         return wikitextPath;
     }
 
-    private File findNotebookRootDir(File currentPage) {
+    private static File findNotebookRootDir(File currentPage) {
         if (currentPage != null && currentPage.exists()) {
             if (GsFileUtils.join(currentPage, "notebook.zim").exists()) {
                 return currentPage;
@@ -175,5 +180,149 @@ public class WikitextLinkResolver {
 
     public File getNotebookRootDir() {
         return _notebookRootDir;
+    }
+
+    /**
+     * Return a wiki file's Attachment Directory.<p></p>
+     *
+     * <p> By design, a Zim wiki file's Attachment Directory should
+     * have the same path of the wiki file itself, without the .txt
+     * suffix.</p><p></p>
+     *
+     * <p>Here, a difference from Zim is that any file can derive a
+     * properly named Attachment Directory, as long as that file is
+     * with a suffix.</p>
+     *
+     * @param currentPage Current wiki file's path.
+     * @return {@code currentPage}'s path without suffix.
+     *
+     * @see GsFileUtils#getFilenameWithoutExtension(File)
+     */
+    public static File findAttachmentDir(File currentPage) {
+        return GsFileUtils.join(currentPage.getParentFile(), GsFileUtils.getFilenameWithoutExtension(currentPage));
+    }
+
+    /**
+     * Return a Notebook's Root Directory.<p></p>
+     *
+     * <p> By design ({@code shouldDynamicallyDetermineRoot = true}),
+     * a Zim Notebook's Root Directory is the closest ancestor of the
+     * {@code currentPage} with a notebook.zim file in it.</p><p></p>
+     *
+     * <p> Here, a difference from Zim is that if a notebook.zim file
+     * can't be located, a {@code currentPage}'s current directory is
+     * taken as Root Directory.</p><p></p>
+     *
+     * <p> WARNING: Removing a notebook.zim file from the Notebook or
+     * changing the value of {@code notebookRootDir}, may switch to a
+     * Root Directory different than where the Notebook was organized
+     * originally.</p>
+     *
+     * @param notebookRootDir Root Directory when {@code shouldDynamicallyDetermineRoot == false}.
+     * @param currentPage Current wiki file's path used to determine the current directory.
+     * @param shouldDynamicallyDetermineRoot If {@code true}, return the closest ancestor of the
+     * {@code currentPage} with a notebook.zim file in it, or fall back to the current directory
+     * on failure.  If {@code false}, return {@code notebookRootDir}.
+     * @return Identified Notebook's Root Directory.
+     *
+     * @see WikitextLinkResolver#findNotebookRootDir(File)
+     */
+    public static File findNotebookRootDir(File notebookRootDir, File currentPage, boolean shouldDynamicallyDetermineRoot) {
+        if (shouldDynamicallyDetermineRoot) {
+            notebookRootDir = findNotebookRootDir(currentPage);
+            if (notebookRootDir == null) {
+                notebookRootDir = currentPage.getParentFile();
+            }
+        }
+        return notebookRootDir;
+    }
+
+    /**
+     * Return a system file's path as wiki attachment's path.<p></p>
+     *
+     * <p> If both {@code file} and {@code currentPage} are children
+     * of the same Notebook's Root Directory, return a path relative
+     * to the {@code currentPage}'s Attachment Directory, otherwise,
+     * return the original {@code file}'s path.</p><p></p>
+     *
+     * <p> Here, a difference from Zim is to always consider as Root
+     * Directory the {@code currentPage}'s directory before anything
+     * else.</p>
+     *
+     * @param file System file's path to resolve as wiki attachment's path.
+     * @param notebookRootDir Root Directory when {@code shouldDynamicallyDetermineRoot == false}.
+     * @param currentPage Current wiki file's path used to determine the current Attachment Directory.
+     * @param shouldDynamicallyDetermineRoot If {@code true}, the Root Directory is the closest ancestor
+     * of the {@code currentPage} with a notebook.zim file in it, or the {@code currentPage}'s directory
+     * on failure.  If {@code false}, the Root Directory is {@code notebookRootDir}.  In either cases, a
+     * {@code currentPage}'s directory is always considered as Root Directory before anything else.
+     * @return {@code file}'s path relative to the {@code currentPage}'s Attachment Directory, when both
+     * {@code file} and {@code currentPage} are children of the identified Notebook's Root Directory, or
+     * the original {@code file}'s path otherwise.
+     *
+     * @see WikitextLinkResolver#findAttachmentDir(File)
+     * @see WikitextLinkResolver#findNotebookRootDir(File, File, boolean)
+     */
+    public static String resolveSystemFilePath(File file, File notebookRootDir, File currentPage, boolean shouldDynamicallyDetermineRoot) {
+        final File currentDir = currentPage.getParentFile();
+        notebookRootDir = findNotebookRootDir(notebookRootDir, currentPage, shouldDynamicallyDetermineRoot);
+
+        if (GsFileUtils.isChild(currentDir, file) ||
+            (GsFileUtils.isChild(notebookRootDir, file) && GsFileUtils.isChild(notebookRootDir, currentPage))) {
+            final File attachmentDir = findAttachmentDir(currentPage);
+            String path = GsFileUtils.relativePath(attachmentDir, file);
+
+            // Zim prefixes also children of the Attachment Directory.
+            if (file.toString().endsWith("/" + path)) {
+                path = "./" + path;
+            }
+
+            return path;
+        }
+
+        return file.toString();
+    }
+
+    /**
+     * Return a wiki attachment's path as system absolute path.<p></p>
+     *
+     * <p> If {@code path} can be resolved as a relative path to the
+     * {@code currentPage}'s Attachment Directory, return the result
+     * of {@code path} as a system absolute path.  Otherwise, return
+     * the original {@code path}.</p><p></p>
+     *
+     * <p> Here, a difference from Zim is to always consider as Root
+     * Directory the {@code currentPage}'s directory before anything
+     * else.</p>
+     *
+     * @param path Path that might be relative to the {@code currentPage}'s Attachment Directory.
+     * @param notebookRootDir Root Directory when {@code shouldDynamicallyDetermineRoot == false}.
+     * @param currentPage Current wiki file's path used to determine the current Attachment Directory.
+     * @param shouldDynamicallyDetermineRoot If {@code true}, the Root Directory is the closest ancestor
+     * of the {@code currentPage} with a notebook.zim file in it, or the {@code currentPage}'s directory
+     * on failure.  If {@code false}, the Root Directory is {@code notebookRootDir}.  In either cases, a
+     * {@code currentPage}'s directory is always considered as Root Directory before anything else.
+     * @return {@code path} as a system absolute path, if it can be resolved as a relative path to the
+     * {@code currentPage}'s Attachment Directory, or the original {@code path} otherwise.
+     *
+     * @see WikitextLinkResolver#findAttachmentDir(File)
+     * @see WikitextLinkResolver#resolveSystemFilePath(File, File, File, boolean)
+     */
+    public static String resolveAttachmentPath(String path, File notebookRootDir, File currentPage, boolean shouldDynamicallyDetermineRoot) {
+        if (path.startsWith("./") || path.startsWith("../")) {
+            final File attachmentDir = findAttachmentDir(currentPage);
+            final File file = new File(attachmentDir, path).getAbsoluteFile();
+            final String resolved = resolveSystemFilePath(file, notebookRootDir, currentPage, shouldDynamicallyDetermineRoot);
+
+            if (path.equals(resolved)) {
+                try {
+                    return file.getCanonicalPath();
+                } catch (IOException e) {
+                    return file.toString();
+                }
+            }
+        }
+
+        return path;
     }
 }

--- a/app/src/test/java/net/gsantner/markor/format/wikitext/WikitextLinkResolverTests.java
+++ b/app/src/test/java/net/gsantner/markor/format/wikitext/WikitextLinkResolverTests.java
@@ -171,10 +171,12 @@ public class WikitextLinkResolverTests {
     }
 
     @Test
-    public void doesNotResolveTopLevelLinkIfRootCannotBeDetermined() {
+    public void assumesCurrentDirAsTopLevelLinkIfRootCannotBeDetermined() {
         WikitextLinkResolver resolver = WikitextLinkResolver.resolve("[[:Your page:The coolest page]]", null, notebookRoot.resolve("My_page/Yet_another_page.txt").toFile(), true);
-        assertNull(resolver.getNotebookRootDir());
-        assertNull(resolver.getResolvedLink());
+        Path currentDir = notebookRoot.resolve("My_page");
+        assertEquals(currentDir.toFile(), resolver.getNotebookRootDir());
+        Path expectedLink = currentDir.resolve("Your_page/The_coolest_page.txt");
+        assertEquals(expectedLink.toString(), resolver.getResolvedLink());
     }
 
     @Test


### PR DESCRIPTION
Hello,

This series of patches is to **conform the wikitext format to Zim**:
1. The expression `{{}}` is for images, other types should use `[[]]`.
2. **Notebook's links should be relative to a wiki page's attachment directory**.
3. Files pulled into a Notebook should be placed in a proper attachment directory.
4. Interpret image link's tags: `id`, `width`, `height`, `href`; images can link other files.

As an extra, the **Insert Audio** button is enabled.

**More descriptions about Zim conformance are in the commits and in the code as comments.**

# Zim attachment directories

In `wiki-example.txt`, `[[./video.mkv]]` would be a link to a file residing in the `wiki-example` directory (relative path).  Linking `notebook.zim` would add `[[../notebook.zim]]`, and `[[/home/user/README]]` would be a link to a file outside the Notebook's root (absolute path).

```
/home/user/Notebook            # Notebook directory
      |    |
      |    `- notebook.zim     # marks the root of the Notebook
      |    |
      |    `- wiki-example     # wiki page's attachment directory
      |    |  |
      |    |  `- video.mkv     # wiki-example.txt file attachment
      |    |
      |    `- wiki-example.txt # wiki file written in wiki markup
      |
      `- README                # file outside the Notebook's root
```

# Zim image link's tags

If `{{./image.png?href=.%2Fvideo.mkv&id=anchor-name&width=50}}` is in `wiki-example.txt`, `./` is resolved to the wiki page's attachment directory `wiki-example`, and in Markor you would have something like:

`<a href="/home/user/Notebook/wiki-example/video.mkv"><img src="wiki-example/image.png" alt="wiki-example.txt" id="anchor-name" width="50" /></a>`

<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
