### PR TITLE
bugfix: action 'duplicate_lines' not working for last line in file

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
+++ b/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
@@ -894,8 +894,10 @@ public abstract class ActionButtonBase {
         final int[] selEnd = TextViewUtils.getLineOffsetFromIndex(text, sel[1]);
 
         hlEditor.withAutoFormatDisabled(() -> {
-            final String lines_final = String.format("%s\n", lines);
-            text.insert(linesEnd + 1, lines_final);
+            // Prepending the newline instead of appending it is required for making
+            // this logic work even if it's about the last line in the given file.
+            final String lines_final = String.format("\n%s", lines);
+            text.insert(linesEnd, lines_final);
         });
 
         final int sel_offset = selEnd[0] - selStart[0] + 1;


### PR DESCRIPTION
This is a bugfix for recent pull request #2238.

Based on this comment:

> Note: with a empty file or only one line of text it seemed to not work, but after adding a second line and reopening the file it worked. Something we can fix later though.

I debugged it a bit and realized there's a general problem with duplicating the last line in a given file. Also aligns with the above observation, cause an empty file or one with a single line both also count as "the to-be-duplicated line is the currently last line".

Anyway, it's a small fix, but has the desired effect, without impacting the previous behaviour (based on the same manual testing I did before, plus this new "last line" scenario).

And it makes sense, cause before this fix, the `text.insert(lines Edn + 1, ...` part could target a position "out of bounds" so to speak, which was the actual issue (did throw an exception during debugging in that case).