### PR TITLE
BinaryEmbed: Support AVIF image format image viewing

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/binary/EmbedBinaryTextConverter.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class EmbedBinaryTextConverter extends TextConverterBase {
     private static final List<String> EXT = new ArrayList<>();
     private static final List<String> EXT_AUDIO = Arrays.asList(".mp3", ".ogg", ".flac", ".opus", ".oga", ".wma", ".m4a", ".aac", ".wav", ".amr", ".mid", ".midi", ".pcm");
-    private static final List<String> EXT_IMAGE = Arrays.asList(".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".svg", ".heic", ".heif");
+    private static final List<String> EXT_IMAGE = Arrays.asList(".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".svg", ".heic", ".heif", ".avif");
     private static final List<String> EXT_VIDEO = Arrays.asList(".webm", ".mp4", ".mpeg4", ".mpeg", ".mpg", ".mkv", ".3gp", ".ts", ".m4v");
 
     public static final String EXT_MATCHES_M3U_PLAYLIST = "(?i).m3u8?";

--- a/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
@@ -2498,9 +2498,15 @@ public class GsContextUtils {
             if (!TextUtils.isEmpty(v)) {
                 if (mmrfield.first == MediaMetadataRetriever.METADATA_KEY_BITRATE) {
                     v = GsFileUtils.getHumanReadableByteCountSI(Long.parseLong(v)) + "ps";
+                    if (v.startsWith("-1 ")) {
+                        continue; // invalid / unknown
+                    }
                 } else if (mmrfield.first == MediaMetadataRetriever.METADATA_KEY_DURATION) {
                     final int[] hms = GsFileUtils.getTimeDiffHMS(Long.parseLong(v), 0);
                     v = String.format("%sh %sm %ss", hms[0], hms[1], hms[2]);
+                    if (v.equals("0h 0m 0s")) {
+                        continue; // Duration key might be set but no actual duration information
+                    }
                 }
                 append.callback(mmrfield.second, v);
             }


### PR DESCRIPTION
* BinaryEmbed: Support AVIF image format image viewing
* Hide invalid bitrate & invalid duration info if detected


Since Android 14 it's minimum supported, older versions it's optional  
<https://developer.android.com/media/platform/supported-formats>

![grafik](https://github.com/gsantner/markor/assets/6735650/44bd57ec-b31b-4c2c-98eb-41ad4fe0910f)
