### PR TITLE
Changing to correct action ids for attachments

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeActionButtons.java
@@ -26,9 +26,11 @@ public class OrgmodeActionButtons extends ActionButtonBase {
                 new ActionItem(R.string.abid_common_checkbox_list, R.drawable.ic_check_box_black_24dp, R.string.check_list),
                 new ActionItem(R.string.abid_common_unordered_list_char, R.drawable.ic_list_black_24dp, R.string.unordered_list),
                 new ActionItem(R.string.abid_common_ordered_list_number, R.drawable.ic_format_list_numbered_black_24dp, R.string.ordered_list),
-                new ActionItem(R.string.abid_common_attach_something, R.drawable.ic_attach_file_black_24dp, R.string.attach),
                 new ActionItem(R.string.abid_common_indent, R.drawable.ic_format_indent_increase_black_24dp, R.string.indent),
-                new ActionItem(R.string.abid_common_deindent, R.drawable.ic_format_indent_decrease_black_24dp, R.string.deindent)
+                new ActionItem(R.string.abid_common_deindent, R.drawable.ic_format_indent_decrease_black_24dp, R.string.deindent),
+                new ActionItem(R.string.abid_common_insert_link, R.drawable.ic_link_black_24dp, R.string.insert_link),
+                new ActionItem(R.string.abid_common_insert_image, R.drawable.ic_image_black_24dp, R.string.insert_image),
+                new ActionItem(R.string.abid_common_insert_audio, R.drawable.ic_keyboard_voice_black_24dp, R.string.audio)
         );
     }
 

--- a/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextActionButtons.java
@@ -33,10 +33,12 @@ public class PlaintextActionButtons extends ActionButtonBase {
                 new ActionItem(R.string.abid_common_checkbox_list, R.drawable.ic_check_box_black_24dp, R.string.check_list),
                 new ActionItem(R.string.abid_common_unordered_list_char, R.drawable.ic_list_black_24dp, R.string.unordered_list),
                 new ActionItem(R.string.abid_common_ordered_list_number, R.drawable.ic_format_list_numbered_black_24dp, R.string.ordered_list),
-                new ActionItem(R.string.abid_common_attach_something, R.drawable.ic_attach_file_black_24dp, R.string.attach),
                 new ActionItem(R.string.abid_common_special_key, R.drawable.ic_keyboard_black_24dp, R.string.special_key),
                 new ActionItem(R.string.abid_common_indent, R.drawable.ic_format_indent_increase_black_24dp, R.string.indent),
-                new ActionItem(R.string.abid_common_deindent, R.drawable.ic_format_indent_decrease_black_24dp, R.string.deindent)
+                new ActionItem(R.string.abid_common_deindent, R.drawable.ic_format_indent_decrease_black_24dp, R.string.deindent),
+                new ActionItem(R.string.abid_common_insert_link, R.drawable.ic_link_black_24dp, R.string.insert_link),
+                new ActionItem(R.string.abid_common_insert_image, R.drawable.ic_image_black_24dp, R.string.insert_image),
+                new ActionItem(R.string.abid_common_insert_audio, R.drawable.ic_keyboard_voice_black_24dp, R.string.audio)
         );
     }
 

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
@@ -59,7 +59,9 @@ public class TodoTxtActionButtons extends ActionButtonBase {
                 new ActionItem(R.string.abid_todotxt_archive_done_tasks, R.drawable.ic_archive_black_24dp, R.string.archive_completed_tasks),
                 new ActionItem(R.string.abid_todotxt_current_date, R.drawable.ic_date_range_black_24dp, R.string.current_date),
                 new ActionItem(R.string.abid_todotxt_sort_todo, R.drawable.ic_sort_by_alpha_black_24dp, R.string.sort_by),
-                new ActionItem(R.string.abid_common_attach_something, R.drawable.ic_attach_file_black_24dp, R.string.attach)
+                new ActionItem(R.string.abid_common_insert_link, R.drawable.ic_link_black_24dp, R.string.insert_link),
+                new ActionItem(R.string.abid_common_insert_image, R.drawable.ic_image_black_24dp, R.string.insert_image),
+                new ActionItem(R.string.abid_common_insert_audio, R.drawable.ic_keyboard_voice_black_24dp, R.string.audio)
         );
     }
 

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -212,7 +212,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="abid_common_delete_lines" translatable="false">abid_common_delete_lines</string>
     <string name="abid_common_duplicate_lines" translatable="false">abid_common_duplicate_lines</string>
     <string name="abid_common_new_line_below" translatable="false">abid_common_new_line_below</string>
-    <string name="abid_common_attach_something" translatable="false">abid_common_attach_something</string>
     <string name="abid_common_unordered_list_char" translatable="false">abid_common_unordered_list_char</string>
     <string name="abid_common_ordered_list_number" translatable="false">abid_common_ordered_list_number</string>
     <string name="abid_common_ordered_list_renumber" translatable="false">abid_common_ordered_list_renumber</string>


### PR DESCRIPTION
In the last round of attachment improvements, several formats were left with old action keys. This fixes that. Attachment button on todotxt etc will now work.

This fixes #2253 