### PR TITLE
Open resources in a tag

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
@@ -147,6 +147,12 @@ public class MainActivity extends MarkorBaseActivity implements GsFileBrowserFra
             _quicknote = (DocumentEditAndViewFragment) manager.getFragment(savedInstanceState, Integer.toString(R.id.nav_quicknote));
             _todo = (DocumentEditAndViewFragment) manager.getFragment(savedInstanceState, Integer.toString(R.id.nav_todo));
             _more = (MoreFragment) manager.getFragment(savedInstanceState, Integer.toString(R.id.nav_more));
+
+            final NewFileDialog nf = (NewFileDialog) manager.findFragmentByTag(NewFileDialog.FRAGMENT_TAG);
+            if (nf != null) {
+                nf.setCallback(this::newItemCallback);
+            }
+
         } catch (NullPointerException | IllegalStateException ignored) {
             Log.d(MainActivity.class.getName(), "Child fragment not found in onRestoreInstanceState()");
         }
@@ -296,16 +302,20 @@ public class MainActivity extends MarkorBaseActivity implements GsFileBrowserFra
                 return;
             }
 
-            final NewFileDialog dialog = NewFileDialog.newInstance(_notebook.getCurrentFolder(), true, (ok, f) -> {
-                if (ok) {
-                    if (f.isFile()) {
-                        DocumentActivity.launch(MainActivity.this, f, false, null, null);
-                    } else if (f.isDirectory()) {
-                        _notebook.getAdapter().showFile(f);
-                    }
-                }
-            });
-            dialog.show(getSupportFragmentManager(), NewFileDialog.FRAGMENT_TAG);
+            NewFileDialog.newInstance(_notebook.getCurrentFolder(), true, this::newItemCallback)
+                .show(getSupportFragmentManager(), NewFileDialog.FRAGMENT_TAG);
+        }
+    }
+
+    private void newItemCallback(final boolean ok, final File file) {
+        if (!ok) {
+            return;
+        }
+
+        if (file.isFile()) {
+            DocumentActivity.launch(MainActivity.this, file, false, null, null);
+        } else if (file.isDirectory()) {
+            _notebook.getAdapter().showFile(file);
         }
     }
 

--- a/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
+++ b/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
@@ -7,6 +7,8 @@
 #########################################################*/
 package net.gsantner.markor.format;
 
+import static android.util.Patterns.WEB_URL;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -40,6 +42,7 @@ import com.flask.colorpicker.builder.ColorPickerDialogBuilder;
 
 import net.gsantner.markor.ApplicationObject;
 import net.gsantner.markor.R;
+import net.gsantner.markor.activity.DocumentActivity;
 import net.gsantner.markor.frontend.AttachLinkOrFileDialog;
 import net.gsantner.markor.frontend.DatetimeFormatDialog;
 import net.gsantner.markor.frontend.MarkorDialogFactory;
@@ -54,6 +57,7 @@ import net.gsantner.opoc.util.GsContextUtils;
 import net.gsantner.opoc.util.GsFileUtils;
 import net.gsantner.opoc.wrapper.GsCallback;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -696,7 +700,25 @@ public abstract class ActionButtonBase {
                 final int sel = TextViewUtils.getSelection(_hlEditor)[0];
                 final String line = TextViewUtils.getSelectedLines(_hlEditor, sel);
                 final int cursor = sel - TextViewUtils.getLineStart(_hlEditor.getText(), sel);
-                String url = GsTextUtils.tryExtractUrlAroundPos(line, cursor);
+
+                // First try to pull a resource
+                String url = null;
+                final String resource = GsTextUtils.tryExtractResourceAroundPos(line, cursor);
+                if (resource != null) {
+                    if (WEB_URL.matcher(resource).matches()) {
+                        url = resource;
+                    } else {
+                        final File f = GsFileUtils.makeAbsolute(resource, _document.getFile().getParentFile());
+                        if (f.canRead()) {
+                            DocumentActivity.handleFileClick(getActivity(), f, null);
+                            return true;
+                        }
+                    }
+
+                }
+
+                // Then try to pull a tag
+                url = url == null ? GsTextUtils.tryExtractUrlAroundPos(line, cursor) : url;
                 if (url != null) {
                     if (url.endsWith(")")) {
                         url = url.substring(0, url.length() - 1);

--- a/app/src/main/java/net/gsantner/markor/frontend/NewFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/NewFileDialog.java
@@ -257,6 +257,10 @@ public class NewFileDialog extends DialogFragment {
         }
     }
 
+    public void setCallback(final GsCallback.a2<Boolean, File> callback) {
+        this.callback = callback;
+    }
+
     // this code corresponds to R.arrays.arr_file_templates
     //
     // How to get content out of a file:

--- a/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
@@ -24,10 +24,17 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @SuppressWarnings({"unused", "SpellCheckingInspection"})
 public class GsTextUtils {
     public static String UTF8 = "UTF-8";
+
+    // Regex patterns used for finding resources in tags
+    public final static Pattern SELF_CLOSING_TAG = Pattern.compile("<(\\w+)([^>]*?)src='([^']+)'([^>]*?)/>");
+    public final static Pattern REGULAR_TAG = Pattern.compile("<(\\w+)([^>]*?)src='([^']+)'([^>]*?)>(.*?)</\\1>");
+
 
     /**
      * This is a simple method that tries to extract an URL around a given index.
@@ -53,6 +60,32 @@ public class GsTextUtils {
             }
         }
         return null;
+    }
+
+
+    /**
+     * This is a simple method that tries to extract the value of the 'src' attribute
+     * for any tag in the text which surrounds pos.
+     * It doesn't do any validation. Separation by whitespace or end.
+     *
+     * @param text Text to extract from
+     * @param pos  Position to start searching from (backwards)
+     * @return Extracted resource path or {@code null} if none found
+     */
+    public static String tryExtractResourceAroundPos(final String text, int pos) {
+
+        for (final Pattern pattern : Arrays.asList(SELF_CLOSING_TAG, REGULAR_TAG)) {
+            final Matcher matcher = pattern.matcher(text);
+            while (matcher.find()) {
+                int start = matcher.start();
+                int end = matcher.end();
+                if (pos >= start && pos <= end) {
+                    return matcher.group(3);
+                }
+            }
+        }
+
+        return null; // Return null if no enclosing tag with src attribute is found
     }
 
     /**


### PR DESCRIPTION
This PR allows the open link action to open a resource in a HTML tag.

For example: Place the cursor inside an audio attachment `<audio src='foo'>Title</audio>` and press the open link action to open the audio file foo