### PR TITLE
Improvements to newfile dialog, open links, other fixes

### DIFF
--- a/app/src/main/assets/templates/cooking-recipe.md
+++ b/app/src/main/assets/templates/cooking-recipe.md
@@ -1,0 +1,20 @@
+# Title
+## Description
+
+![Text](picture.png)
+
+### Ingredients
+
+|  Ingredient   | Amount |
+|:--------------|:-------|
+| 1             | 1      |
+| 2             | 2      |
+| 3             | 3      |
+| 4             | 4      |
+
+
+### Preparation
+
+1. Text
+2. Text
+

--- a/app/src/main/assets/templates/hugo-post-front-matter.md
+++ b/app/src/main/assets/templates/hugo-post-front-matter.md
@@ -1,0 +1,6 @@
+---
+tags: []
+created: '{{date}}'
+title: '{{title}}'
+---
+

--- a/app/src/main/assets/templates/jekyll-post.adoc
+++ b/app/src/main/assets/templates/jekyll-post.adoc
@@ -1,0 +1,30 @@
+= My Title
+:page-subtitle: This is a subtitle
+:page-last-updated: 2029-01-01
+:page-tags: ['AsciiDoc', 'Markor', 'open source']
+:toc: auto
+:toclevels: 2
+// :page-description: the optional description
+// This should match the structure on the jekyll server:
+:imagesdir: ../assets/img/blog
+
+ifndef::env-site[]
+
+// on the jekyll server, the :page-subtitle: is displayed below the title.
+// but it is not shown, when rendered in html5, and the site is rendered in html5, when working locally
+// so we show it additionally only, when we work locally
+// https://docs.asciidoctor.org/asciidoc/latest/document/subtitle/
+
+[discrete] 
+=== {page-subtitle}
+
+endif::env-site[]
+
+// local testing:
+:imagesdir: ../app/src/main/assets/img
+
+image::flowerfield.jpg[]
+
+image::schindelpattern.jpg[Schindelpattern,200]
+
+before inline picture image:schindelpattern.jpg[Schindelpattern,50] and after inline picture

--- a/app/src/main/assets/templates/jekyll-post.md
+++ b/app/src/main/assets/templates/jekyll-post.md
@@ -1,0 +1,13 @@
+---
+layout: post
+tags: []
+categories: []
+#date: 2019-06-25 13:14:15
+#excerpt: ''
+#image: 'BASEURL/assets/blog/img/.png'
+#description:
+#permalink:
+title: 'title'
+---
+
+

--- a/app/src/main/assets/templates/markor-markdown-reference.md
+++ b/app/src/main/assets/templates/markor-markdown-reference.md
@@ -1,0 +1,237 @@
+# Markdown Reference
+Automatically generate _table of contents_ by checking the option here: `Settings > Format > Markdown`.
+
+## H2 Header
+### H3 header
+#### H4 Header
+##### H5 Header
+###### H6 Header
+
+<!-- --------------- -->
+
+## Format Text
+
+*Italic emphasis* , _Alternative italic emphasis_
+
+**Bold emphasis** , __Alternative bold emphasis__
+
+~~Strikethrough~~
+
+Break line (two spaces at end of line)  
+
+> Block quote
+
+`Inline code`
+
+```
+Code blocks
+are
+awesome
+```
+
+<!-- --------------- -->
+ 
+## Lists
+### Ordered & unordered
+
+* Unordered list
+* ...with asterisk/star
+* Test
+
+- Another unordered list
+- ...with hyphen/minus
+- Test
+
+1. Ordered list
+2. Test
+3. Test
+4. Test
+
+- Nested lists
+    * Unordered nested list
+    * Test
+    * Test
+    * Test
+- Ordered nested list
+    1. Test
+    2. Test
+    3. Test
+    4. Test
+- Double-nested unordered list
+    - Test
+    - Unordered
+        - Test a
+        - Test b
+    - Ordered
+        1. Test 1
+        2. Test 2
+
+### Checklist
+* [ ] Salad
+* [x] Potatoes
+
+1. [x] Clean
+2. [ ] Cook
+
+<!-- --------------- -->
+
+## Links
+[Link](https://duckduckgo.com/)
+
+[File in same folder as the document.](markor-markdown-reference.md) Use %20 for spaces!
+
+<!-- --------------- -->
+
+## Tables
+
+| Left aligned | Middle aligned | Right aligned |
+| :--------------- | :------------------: | -----------------: |
+| Test                 | Test                      | Test                    |
+| Test                 | Test                      | Test                    |
+
+÷÷÷÷
+
+Shorter | Table | Syntax
+:---: | ---: | :---
+Test | Test | Test
+Test | Test | Test
+
+<!-- Comment: Not visibile in view. Can also span across multiple lines. End with:-->
+
+<!-- ------------- -->
+
+## Math (KaTeX)
+See [reference](https://katex.org/docs/supported.html) & [examples](https://github.com/waylonflinn/markdown-it-katex/blob/master/README.md). Enable by checking Math at `Settings > Markdown`.
+
+### Math inline
+
+$ I = \frac V R $
+
+### Math block
+
+$$\begin{array}{c} 
+abla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} & = \frac{4\pi}{c}\vec{\mathbf{j}} 
+abla \cdot \vec{\mathbf{E}} & = 4 \pi \rho \\ 
+abla \times \vec{\mathbf{E}}\, +\, \frac1c\, \frac{\partial\vec{\mathbf{B}}}{\partial t} & = \vec{\mathbf{0}} \\ 
+abla \cdot \vec{\mathbf{B}} & = 0 \end{array}$$
+
+
+$$\frac{k_t}{k_e} = \sqrt{2}$$
+
+<!-- ------------- -->
+
+## Format Text (continued)
+
+### Text color
+
+<span style='background-color:#ffcb2e;'>Text with background color / highlight</span>
+
+<span style='color:#3333ff;'>Text foreground color</span>
+
+<span style='text-shadow: 0px 0px 2px #FF0000;'>Text with colored outline</span> / <span style='text-shadow: 0px 0px 2px #0000FF; color: white'>Text with colored outline</span>
+
+
+### Text sub & superscript
+
+<u>Underline</u>
+
+The <sub>Subway</sub> sandwich was <sup>super</sup>
+
+Super special characters: ⁰ ¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ⁺ ⁻ ⁼ ⁽ ⁾ ⁿ ™ ® ℠
+
+### Text positioning
+<div markdown='1' align='right'>
+
+text on the **right**
+
+</div>
+
+<div markdown='1' align='center'>
+
+text in the **center**  
+(one empy line above and below  
+required for Markdown support OR markdown='1')
+
+</div>
+
+### Block Text
+
+<div markdown='1' style='text-align: justify; text-justify: inter-word;'>
+lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. 
+</div>
+
+### Dropdown
+
+<details markdown='1'><summary>Click to Expand/Collapse</summary>
+
+Expanded content. Shows up and keeps visible when clicking expand. Hide again by clicking the dropdown button again.
+
+</details>
+
+
+### Break page
+To break the page (/start a new page), put the div below into a own line.
+Relevant for creating printable pages from the document (Print / PDF).
+
+<div style='page-break-after: always'></div>
+
+
+<!-- ------------- -->
+
+## Multimedia
+
+### Images
+![Image](file:///android_asset/img/schindelpattern.jpg)
+
+### Videos
+**Youtube** [Welcome to Upper Austria](https://www.youtube.com/watch?v=RJREFH7Lmm8)
+<iframe width='360' height='200' src='https://www.youtube.com/embed/RJREFH7Lmm8'> </iframe>
+
+**Peertube** [Road in the wood](https://open.tube/videos/watch/8116312a-dbbd-43a3-9260-9ea6367c72fc)
+<div><video controls><source src='https://peertube.mastodon.host/download/videos/8116312a-dbbd-43a3-9260-9ea6367c72fc-480.mp4' </source></video></div>
+
+<!-- **Local video** <div><video controls><source src='voice-parrot.mp4' </source></video></div> -->
+
+### Audio & Music
+**Web audio** [Guifrog - Xia Yu](https://www.freemusicarchive.org/music/Guifrog/Xia_Yu)
+<audio controls src='https://files.freemusicarchive.org/storage-freemusicarchive-org/music/ccCommunity/Guifrog/Xia_Yu/Guifrog_-_Xia_Yu.mp3'></audio>
+
+**Local audio** Yellowcard - Lights up in the sky
+<audio controls src='../Music/mp3/Yellowcard/[2007]%20Paper%20Walls/Yellowcard%20-%2005%20-%20Light%20Up%20the%20Sky.mp3'></audio>
+
+## Charts / Graphs / Diagrams (mermaidjs)
+Pie, flow, sequence, class, state, ER  
+See also: mermaidjs [live editor](https://mermaid-js.github.io/mermaid-live-editor/).
+
+```mermaid
+graph LR
+    A[Square Rect] -- Link text --> B((Circle))
+    A --> C(Round Rect)
+    B --> D{Rhombus}
+    C --> D
+```
+
+
+
+## Admonition Extension
+Create block-styled side content.  
+Use one of these qualifiers to select the icon and the block color: abstract, summary, tldr, bug, danger, error, example, snippet, failure, fail, missing, question, help, faq, info, todo, note, seealso, quote, cite, success, check, done, tip, hint, important, warning, caution, attention.
+
+!!! warning 'Optional Title'
+    Block-Styled Side Content with **Markdown support**
+
+!!! info ''
+    No-Heading Content
+
+??? bug 'Collapsed by default'
+    Collapsible Block-Styled Side Content
+
+???+ example 'Open by default'
+     Collapsible Block-Styled Side Content
+
+------------------
+
+This Markdown reference file was created for the [Markor](https://github.com/gsantner/markor) project by [Gregor Santner](https://github.com/gsanter) and is licensed [Creative Commons Zero 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode) (public domain). File revision 3.
+
+------------------
+

--- a/app/src/main/assets/templates/orgmode-reference.org
+++ b/app/src/main/assets/templates/orgmode-reference.org
@@ -1,0 +1,75 @@
+OrgMode Reference
+* Headline
+** Nested headline
+*** Deeper
+
+* Basic markup
+This is the general building block for org-mode navigation.
+- _underscores let you underline things_
+- *stars add emphasis*
+- /slashes are italics/
+- +pluses are strikethrough+
+- =equal signs are verbatim text=
+- ~tildes can also be used~
+
+* List
+** Unordered List
+- Item 1
+- Item 2
+  - Subitem 2.1
+  - Subitem 2.2
+** Ordered List
+1. First Item
+2. Second Item
+   1. Subitem 2.1
+   2. Subitem 2.2
+- [X] Completed Task
+- [ ] Uncompleted Task
+** Nested List
+   - Item A
+     - Subitem A.1
+     - Subitem A.2
+   - Item B
+
+* Tables
+
+| First Name                 | Last Name           | Years using Emacs |
+|----------------------------+---------------------+-------------------|
+| Lee                        | Hinman              |                 5 |
+| Mike                       | Hunsinger           |                 2 |
+| Daniel                     | Glauser             |                 4 |
+| Really-long-first-name-guy | long-last-name-pers |                 1 |
+
+* Org-mode links
+
+#+BEGIN_SRC fundamental
+[[http://google.com/][Google]]
+#+END_SRC
+
+[[./images/pic1.png]]
+
+
+* TODO List
+** TODO This is a task that needs doing
+** TODO Another todo task
+- [ ] sub task one
+- [X] sub task two
+- [ ] sub task three
+** DONE I've already finished this one
+*** CANCELLED learn todos
+    CLOSED: [2023-10-16 Mon 08:39]
+
+* Code
+#+BEGIN_LaTeX
+$a + b$
+#+END_LaTeX
+
+#+BEGIN_SRC emacs-lisp
+(defun my/function ()
+  "docstring"
+  (interactive)
+  (progn
+    (+ 1 1)
+    (message "Hi")))
+#+END_SRC
+

--- a/app/src/main/assets/templates/presentation-beamer.md
+++ b/app/src/main/assets/templates/presentation-beamer.md
@@ -1,0 +1,71 @@
+---
+class: beamer
+---
+
+-----------------
+# Cool presentation
+
+## Abed Nadir
+
+{{ post.date_today }}
+
+<!-- Overall slide design -->
+<style>
+.slide {
+background:url() no-repeat center center fixed; background-size: cover;
+}
+.slide_type_title {
+background: slategrey;
+}
+</style>
+
+-----------------
+
+## Slide title
+
+
+1. All Markdown features of Markor are **supported** for Slides too ~~strikeout~~ _italic_ `code`
+2. Start new slides with 3 more hyphens (---) separated by empty lines
+3. End last slide with hyphens too
+4. Slide backgrounds can be configured using CSS, for all and individual slides
+5. Print / PDF export in landscape mode
+6. Create title only slides (like first slide) by starting the slide (line after `---`) with title `# title`
+
+
+-----------------
+## Slide with centered image
+* Images can be centered by adding 'imghcenter' in alt text & grown to page size with 'imgbig'
+* Example: `![text imghcenter imgbig text](a.jpg)`
+
+![imghcenter imgbig](file:///android_asset/img/flowerfield.jpg)
+
+
+
+
+-----------------
+## Page with gradient background
+* and a picture
+* configure background color/image with CSS .slide_p4 { } (4 = the slide page number)
+
+![pic](file:///android_asset/img/flowerfield.jpg)
+
+
+<style> .slide_p4 { background: linear-gradient(to bottom, #11998e, #38ef7d); } </style>
+
+-----------------
+## Page with image background
+* containing text and a table
+
+| Left aligned | Middle aligned | Right aligned |
+| :------------------- | :----------------------: | --------------------: |
+| Test               | Test                    | Test                |
+| Test               | Test                    | Test                |
+
+
+
+<style> 
+.slide_p5 { background: url('file:///android_asset/img/schindelpattern.jpg') no-repeat center center fixed; background-size: cover; }
+.slide_p5 > .slide_body > * { color: black; }
+</style>
+
+-----------------

--- a/app/src/main/assets/templates/sample.csv
+++ b/app/src/main/assets/templates/sample.csv
@@ -1,0 +1,14 @@
+# this is a comment in csv file
+
+# below is the header
+number;text;finishing date
+
+# csv can contain markdown formatting
+1;Learn to use **Markor** formatting
+
+# use "..." if the column contains reserved chars
+2;"Use Delimitter chars like "";    :,";2019-06-24
+
+# use "..." if the column is multiline
+3;"multi
+   line";2059-12-24

--- a/app/src/main/assets/templates/todo.example.txt
+++ b/app/src/main/assets/templates/todo.example.txt
@@ -1,0 +1,12 @@
+(A) Call Mom @mobile +family
+(A) Schedule annual checkup +health
+(A) Urgently buy milk @shop
+(B) Outline chapter 5 +novel @computer
+(C) Add cover sheets @work +myproject
+Plan backyard herb garden @home
+Buy salad @shop
+Write blog post @pc
+Install Markor @mobile
+2019-06-24 scan photos @home +blog
+2019-06-25 draw diagram @work 
+x This has been done @home +renovations

--- a/app/src/main/assets/templates/zettlekasten.md
+++ b/app/src/main/assets/templates/zettlekasten.md
@@ -1,0 +1,4 @@
+source:
+category:
+tag:
+------------

--- a/app/src/main/assets/templates/zim-wiki-empty.txt
+++ b/app/src/main/assets/templates/zim-wiki-empty.txt
@@ -1,0 +1,6 @@
+Content-Type: text/x-zim-wiki
+Wiki-Format: zim 0.6
+Creation-Date: `yyyy-MM-dd'T'HH:mm:ssXXX`
+
+====== {{title}} ======
+Created `EEEE dd MMMM yyyy`

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
@@ -285,7 +285,7 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
     public void onPause() {
         saveDocument(false);
         _webView.onPause();
-        _appSettings.addRecentDocument(_document.getFile());
+        _appSettings.addRecentFile(_document.getFile());
         _appSettings.setDocumentPreviewState(_document.getPath(), _isPreviewVisible);
         _appSettings.setLastEditPosition(_document.getPath(), _hlEditor.getSelectionStart());
         super.onPause();

--- a/app/src/main/java/net/gsantner/markor/activity/DocumentShareIntoFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentShareIntoFragment.java
@@ -198,7 +198,7 @@ public class DocumentShareIntoFragment extends MarkorBaseFragment {
                 Toast.makeText(context, R.string.error_could_not_open_file, Toast.LENGTH_LONG).show();
             }
 
-            _appSettings.addRecentDocument(file);
+            _appSettings.addRecentFile(file);
             if (showEditor) {
                 showInDocumentActivity(document);
             } else {
@@ -367,8 +367,8 @@ public class DocumentShareIntoFragment extends MarkorBaseFragment {
                 @Override
                 public void onFsViewerSelected(final String request, final File sel, final Integer lineNumber) {
                     if (sel.isDirectory()) {
-                        NewFileDialog.newInstance(sel, false, (ok, f) -> {
-                            if (ok && f.isFile()) {
+                        NewFileDialog.newInstance(sel, false, f -> {
+                            if (f.isFile()) {
                                 appendToExistingDocumentAndClose(f, true);
                             }
                         }).show(getChildFragmentManager(), NewFileDialog.FRAGMENT_TAG);

--- a/app/src/main/java/net/gsantner/markor/activity/IntroActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/IntroActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.Color;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
@@ -15,6 +16,7 @@ import com.github.appintro.AppIntroFragment;
 
 import net.gsantner.markor.ApplicationObject;
 import net.gsantner.markor.R;
+import net.gsantner.markor.util.MarkorContextUtils;
 import net.gsantner.opoc.util.GsContextUtils;
 
 public class IntroActivity extends AppIntro {
@@ -50,6 +52,8 @@ public class IntroActivity extends AppIntro {
         // Permissions -- takes a permission and slide number
         setSkipButtonEnabled(false);
         setSwipeLock(false);
+        setSeparatorColor(Color.DKGRAY);
+        setIndicatorColor(GsContextUtils.instance.rcolor(this, R.color.accent), Color.LTGRAY);
     }
 
     @Override

--- a/app/src/main/java/net/gsantner/markor/activity/IntroActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/IntroActivity.java
@@ -16,7 +16,6 @@ import com.github.appintro.AppIntroFragment;
 
 import net.gsantner.markor.ApplicationObject;
 import net.gsantner.markor.R;
-import net.gsantner.markor.util.MarkorContextUtils;
 import net.gsantner.opoc.util.GsContextUtils;
 
 public class IntroActivity extends AppIntro {

--- a/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
+++ b/app/src/main/java/net/gsantner/markor/activity/MainActivity.java
@@ -296,13 +296,11 @@ public class MainActivity extends MarkorBaseActivity implements GsFileBrowserFra
                 return;
             }
 
-            final NewFileDialog dialog = NewFileDialog.newInstance(_notebook.getCurrentFolder(), true, (ok, f) -> {
-                if (ok) {
-                    if (f.isFile()) {
-                        DocumentActivity.launch(MainActivity.this, f, false, null, null);
-                    } else if (f.isDirectory()) {
-                        _notebook.getAdapter().showFile(f);
-                    }
+            final NewFileDialog dialog = NewFileDialog.newInstance(_notebook.getCurrentFolder(), true, f -> {
+                if (f.isFile()) {
+                    DocumentActivity.launch(MainActivity.this, f, false, null, null);
+                } else if (f.isDirectory()) {
+                    _notebook.getAdapter().showFile(f);
                 }
             });
             dialog.show(getSupportFragmentManager(), NewFileDialog.FRAGMENT_TAG);

--- a/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
+++ b/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
@@ -502,7 +502,7 @@ public abstract class ActionButtonBase {
             final int selStartStart = TextViewUtils.getLineStart(text, selStart);
 
             // Number of lines we will be modifying
-            final int lineCount = TextViewUtils.countChars(text, selStart, selEnd, '\n')[0] + 1;
+            final int lineCount = GsTextUtils.countChars(text, selStart, selEnd, '\n')[0] + 1;
             int lineStart = selStartStart;
 
 

--- a/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
+++ b/app/src/main/java/net/gsantner/markor/format/ActionButtonBase.java
@@ -15,7 +15,6 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Handler;
 import android.text.Editable;
-import android.text.Selection;
 import android.text.TextUtils;
 import android.view.HapticFeedbackConstants;
 import android.view.KeyEvent;

--- a/app/src/main/java/net/gsantner/markor/format/FormatRegistry.java
+++ b/app/src/main/java/net/gsantner/markor/format/FormatRegistry.java
@@ -12,6 +12,7 @@ import android.text.InputFilter;
 import android.text.TextWatcher;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 
 import net.gsantner.markor.ApplicationObject;
 import net.gsantner.markor.R;
@@ -41,6 +42,7 @@ import net.gsantner.markor.format.wikitext.WikitextActionButtons;
 import net.gsantner.markor.format.wikitext.WikitextReplacePatternGenerator;
 import net.gsantner.markor.format.wikitext.WikitextSyntaxHighlighter;
 import net.gsantner.markor.format.wikitext.WikitextTextConverter;
+import net.gsantner.markor.frontend.NewFileDialog;
 import net.gsantner.markor.frontend.textview.AutoTextFormatter;
 import net.gsantner.markor.frontend.textview.ListHandler;
 import net.gsantner.markor.frontend.textview.SyntaxHighlighterBase;
@@ -72,6 +74,32 @@ public class FormatRegistry {
     public final static AsciidocTextConverter CONVERTER_ASCIIDOC = new AsciidocTextConverter();
     public final static EmbedBinaryTextConverter CONVERTER_EMBEDBINARY = new EmbedBinaryTextConverter();
     public final static OrgmodeTextConverter CONVERTER_ORGMODE = new OrgmodeTextConverter();
+
+
+
+    public static class Format {
+        public final @StringRes int format, name;
+        public final String ext;
+        public final TextConverterBase converter;
+
+        Format(int format, int name, String ext, final TextConverterBase converter) {
+            this.format = format;
+            this.name = name;
+            this.ext = ext;
+            this.converter = converter;
+        }
+    }
+
+    public static final Format[] FORMATS = new Format[] {
+            new Format(FormatRegistry.FORMAT_MARKDOWN, R.string.markdown, ".md", CONVERTER_MARKDOWN),
+            new Format(FormatRegistry.FORMAT_PLAIN, R.string.plaintext, ".txt", CONVERTER_PLAINTEXT),
+            new Format(FormatRegistry.FORMAT_TODOTXT, R.string.todo_txt, ".todo.txt", CONVERTER_TODOTXT),
+            new Format(FormatRegistry.FORMAT_WIKITEXT, R.string.wikitext, ".txt", CONVERTER_WIKITEXT),
+            new Format(FormatRegistry.FORMAT_ASCIIDOC, R.string.asciidoc, ".adoc", CONVERTER_ASCIIDOC),
+            new Format(FormatRegistry.FORMAT_CSV, R.string.csv, ".csv", CONVERTER_CSV),
+            new Format(FormatRegistry.FORMAT_ORGMODE, R.string.orgmode, ".org", CONVERTER_ORGMODE),
+            new Format(FormatRegistry.FORMAT_UNKNOWN, R.string.none, "", null),
+    };
 
 
     // Order here is used to **determine** format by it's file extension and/or content heading

--- a/app/src/main/java/net/gsantner/markor/format/FormatRegistry.java
+++ b/app/src/main/java/net/gsantner/markor/format/FormatRegistry.java
@@ -42,7 +42,6 @@ import net.gsantner.markor.format.wikitext.WikitextActionButtons;
 import net.gsantner.markor.format.wikitext.WikitextReplacePatternGenerator;
 import net.gsantner.markor.format.wikitext.WikitextSyntaxHighlighter;
 import net.gsantner.markor.format.wikitext.WikitextTextConverter;
-import net.gsantner.markor.frontend.NewFileDialog;
 import net.gsantner.markor.frontend.textview.AutoTextFormatter;
 import net.gsantner.markor.frontend.textview.ListHandler;
 import net.gsantner.markor.frontend.textview.SyntaxHighlighterBase;

--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtAutoTextFormatter.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtAutoTextFormatter.java
@@ -11,6 +11,7 @@ import android.text.InputFilter;
 import android.text.Spanned;
 
 import net.gsantner.markor.frontend.textview.TextViewUtils;
+import net.gsantner.opoc.format.GsTextUtils;
 
 import java.util.Date;
 
@@ -19,7 +20,7 @@ public class TodoTxtAutoTextFormatter implements InputFilter {
     @Override
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
         try {
-            if (start < source.length() && dstart <= dest.length() && TextViewUtils.isNewLine(source, start, end)) {
+            if (start < source.length() && dstart <= dest.length() && GsTextUtils.isNewLine(source, start, end)) {
                 return autoIndent(source);
             }
         } catch (IndexOutOfBoundsException | NullPointerException e) {

--- a/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/MarkorDialogFactory.java
@@ -39,7 +39,6 @@ import androidx.core.content.ContextCompat;
 
 import net.gsantner.markor.ApplicationObject;
 import net.gsantner.markor.R;
-import net.gsantner.markor.format.FormatRegistry;
 import net.gsantner.markor.format.markdown.MarkdownTextConverter;
 import net.gsantner.markor.format.todotxt.TodoTxtBasicSyntaxHighlighter;
 import net.gsantner.markor.format.todotxt.TodoTxtFilter;
@@ -67,7 +66,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -978,39 +976,18 @@ public class MarkorDialogFactory {
         }
     }
 
-    // Read all files in snippets folder with appropriate extension
-    // Create a map of snippet title -> text
-    public static Map<String, File> getSnippets(final AppSettings as) {
-        final Map<String, File> texts = new TreeMap<>();
-        final File folder = new File(as.getNotebookDirectory(), ".app/snippets");
-        if ((!folder.exists() || !folder.isDirectory() || !folder.canRead())) {
-            if (!folder.mkdirs()) {
-                return texts;
-            }
-        }
-
-        // Read all files in snippets folder with appropriate extension
-        // Create a map of snippet title -> text
-        for (final File f : folder.listFiles()) {
-            if (f.exists() && f.canRead() && FormatRegistry.isFileSupported(f, true)) {
-                texts.put(f.getName(), f);
-            }
-        }
-        return texts;
-    }
 
     public static void showInsertSnippetDialog(final Activity activity, final GsCallback.a1<String> callback) {
         final DialogOptions dopt = new DialogOptions();
         baseConf(activity, dopt);
 
-        final Map<String, File> texts = getSnippets(as());
+        final List<Pair<String, File>> snippets = as().getSnippetFiles();
 
-        final List<String> data = new ArrayList<>(texts.keySet());
-        dopt.data = data;
+        dopt.data = GsCollectionUtils.map(snippets, p -> p.first);
         dopt.isSearchEnabled = true;
         dopt.titleText = R.string.insert_snippet;
         dopt.messageText = Html.fromHtml("<small><small>" + as().getSnippetsDirectory().getAbsolutePath() + "</small></small>");
-        dopt.positionCallback = (ind) -> callback.callback(GsFileUtils.readTextFileFast(texts.get(data.get(ind.get(0)))).first);
+        dopt.positionCallback = (ind) -> callback.callback(GsFileUtils.readTextFileFast(snippets.get(ind.get(0)).second).first);
         GsSearchOrCustomTextDialog.showMultiChoiceDialogWithSearchFilterUI(activity, dopt);
     }
 

--- a/app/src/main/java/net/gsantner/markor/frontend/NewFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/NewFileDialog.java
@@ -9,21 +9,26 @@
 package net.gsantner.markor.frontend;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.app.Dialog;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.text.InputFilter;
-import android.text.TextUtils;
 import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.ListPopupWindow;
+import android.widget.SimpleAdapter;
 import android.widget.Spinner;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
@@ -32,27 +37,21 @@ import androidx.fragment.app.DialogFragment;
 
 import net.gsantner.markor.ApplicationObject;
 import net.gsantner.markor.R;
-import net.gsantner.markor.format.todotxt.TodoTxtTask;
-import net.gsantner.markor.format.wikitext.WikitextActionButtons;
+import net.gsantner.markor.format.FormatRegistry;
 import net.gsantner.markor.frontend.textview.HighlightingEditor;
 import net.gsantner.markor.frontend.textview.TextViewUtils;
 import net.gsantner.markor.model.AppSettings;
 import net.gsantner.markor.model.Document;
 import net.gsantner.markor.util.MarkorContextUtils;
+import net.gsantner.opoc.util.GsCollectionUtils;
 import net.gsantner.opoc.util.GsContextUtils;
 import net.gsantner.opoc.util.GsFileUtils;
 import net.gsantner.opoc.wrapper.GsAndroidSpinnerOnItemSelectedAdapter;
 import net.gsantner.opoc.wrapper.GsCallback;
 
 import java.io.File;
-import java.security.SecureRandom;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import other.de.stanetz.jpencconverter.JavaPasswordbasedCryption;
 
@@ -60,9 +59,16 @@ public class NewFileDialog extends DialogFragment {
     public static final String FRAGMENT_TAG = NewFileDialog.class.getName();
     public static final String EXTRA_DIR = "EXTRA_DIR";
     public static final String EXTRA_ALLOW_CREATE_DIR = "EXTRA_ALLOW_CREATE_DIR";
-    private GsCallback.a2<Boolean, File> callback;
 
-    public static NewFileDialog newInstance(final File sourceFile, final boolean allowCreateDir, final GsCallback.a2<Boolean, File> callback) {
+    public static final int MAX_TITLE_FORMATS = 10;
+
+    private GsCallback.a1<File> callback;
+
+    public static NewFileDialog newInstance(
+            final File sourceFile,
+            final boolean allowCreateDir,
+            final GsCallback.a1<File> callback
+    ) {
         NewFileDialog dialog = new NewFileDialog();
         Bundle args = new Bundle();
         args.putSerializable(EXTRA_DIR, sourceFile);
@@ -90,79 +96,116 @@ public class NewFileDialog extends DialogFragment {
 
     @SuppressLint("SetTextI18n")
     private AlertDialog.Builder makeDialog(final File basedir, final boolean allowCreateDir, LayoutInflater inflater) {
-        View root;
-        AlertDialog.Builder dialogBuilder;
+        final Activity activity = getActivity();
         final AppSettings appSettings = ApplicationObject.settings();
-        dialogBuilder = new AlertDialog.Builder(inflater.getContext(), R.style.Theme_AppCompat_DayNight_Dialog);
-        root = inflater.inflate(R.layout.new_file_dialog, null);
+        final AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(inflater.getContext(), R.style.Theme_AppCompat_DayNight_Dialog);
+        final View root = inflater.inflate(R.layout.new_file_dialog, null);
 
-        final EditText fileNameEdit = root.findViewById(R.id.new_file_dialog__name);
-        final EditText fileExtEdit = root.findViewById(R.id.new_file_dialog__ext);
+        final EditText titleEdit = root.findViewById(R.id.new_file_dialog__name);
+        final EditText extEdit = root.findViewById(R.id.new_file_dialog__ext);
         final CheckBox encryptCheckbox = root.findViewById(R.id.new_file_dialog__encrypt);
         final CheckBox utf8BomCheckbox = root.findViewById(R.id.new_file_dialog__utf8_bom);
         final Spinner typeSpinner = root.findViewById(R.id.new_file_dialog__type);
         final Spinner templateSpinner = root.findViewById(R.id.new_file_dialog__template);
-        final String[] typeSpinnerToExtension = getResources().getStringArray(R.array.new_file_types__file_extension);
+        final AutoCompleteTextView titleFormatEdit = root.findViewById(R.id.new_file_dialog__title_format);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && appSettings.isDefaultPasswordSet()) {
             encryptCheckbox.setChecked(appSettings.getNewFileDialogLastUsedEncryption());
         } else {
             encryptCheckbox.setVisibility(View.GONE);
         }
+
         utf8BomCheckbox.setChecked(appSettings.getNewFileDialogLastUsedUtf8Bom());
         utf8BomCheckbox.setVisibility(appSettings.isExperimentalFeaturesEnabled() ? View.VISIBLE : View.GONE);
-        fileExtEdit.setText(appSettings.getNewFileDialogLastUsedExtension());
-        fileNameEdit.requestFocus();
-        new Handler().postDelayed(new GsContextUtils.DoTouchView(fileNameEdit), 200);
+        extEdit.setText(appSettings.getNewFileDialogLastUsedExtension());
+        titleEdit.requestFocus();
+        new Handler().postDelayed(new GsContextUtils.DoTouchView(titleEdit), 200);
 
-        fileNameEdit.setFilters(new InputFilter[]{GsContextUtils.instance.makeFilenameInputFilter()});
-        fileExtEdit.setFilters(fileNameEdit.getFilters());
+        titleEdit.setFilters(new InputFilter[]{GsContextUtils.instance.makeFilenameInputFilter()});
+        extEdit.setFilters(titleEdit.getFilters());
 
-        loadTemplatesIntoSpinner(appSettings, templateSpinner);
-        final AtomicBoolean typeSpinnerNoTriggerOnFirst = new AtomicBoolean(true);
-        typeSpinner.setOnItemSelectedListener(new GsAndroidSpinnerOnItemSelectedAdapter(pos -> {
-            if (pos == 3) { // Wikitext
-                templateSpinner.setSelection(7); // Zim empty
-            }
-            if (typeSpinnerNoTriggerOnFirst.getAndSet(false)) {
-                return;
-            }
-            String ext = pos < typeSpinnerToExtension.length ? typeSpinnerToExtension[pos] : "";
 
-            if (ext != null) {
-                if (encryptCheckbox.isChecked()) {
-                    fileExtEdit.setText(ext + JavaPasswordbasedCryption.DEFAULT_ENCRYPTION_EXTENSION);
-                } else {
-                    fileExtEdit.setText(ext);
-                }
-            }
-            fileNameEdit.setSelection(fileNameEdit.length());
-            appSettings.setNewFileDialogLastUsedType(typeSpinner.getSelectedItemPosition());
-        }));
-        typeSpinner.setSelection(appSettings.getNewFileDialogLastUsedType());
+        // Setup title format spinner and actions
+        // -----------------------------------------------------------------------------------------
+
+        final ArrayAdapter<String> titleFormatAdapter = new ArrayAdapter<>(
+                activity, android.R.layout.simple_list_item_1);
+
+        titleFormatAdapter.add("");
+        titleFormatAdapter.addAll(appSettings.getTitleFormats());
+
+        titleFormatEdit.setAdapter(titleFormatAdapter);
+
+        // // Popup window for ComboBox
+        // final ListPopupWindow popupWindow = new ListPopupWindow(activity);
+        // popupWindow.setAdapter(titleFormatAdapter);
+
+        // popupWindow.setOnItemClickListener((parent, view, position, id) ->
+        //         titleFormatEdit.setText(titleFormatAdapter.getItem(position))
+        // );
+
+        // popupWindow.setAnchorView(titleFormatEdit);
+        // popupWindow.setModal(true);
+
+
+        // Setup template spinner and action
+        // -----------------------------------------------------------------------------------------
+        final List<Pair<String, File>> snippets = appSettings.getSnippetFiles();
+        final List<Pair<String, String>> templates = appSettings.getBuiltinTemplates();
+        final ArrayAdapter<String> templateAdapter = new ArrayAdapter<>(activity, android.R.layout.simple_spinner_item);
+        templateAdapter.add(activity.getString(R.string.empty_file));
+        templateAdapter.addAll(GsCollectionUtils.map(snippets, p -> p.first));
+        templateAdapter.addAll(GsCollectionUtils.map(templates, p -> p.first));
+        templateSpinner.setAdapter(templateAdapter);
 
         templateSpinner.setOnItemSelectedListener(new GsAndroidSpinnerOnItemSelectedAdapter(pos -> {
-            String prefix = null;
-
-            if (pos == 3) { // Jekyll
-                prefix = TodoTxtTask.DATEF_YYYY_MM_DD.format(new Date()) + "-";
-            } else if (pos == 9) { // ZettelKasten
-                prefix = new SimpleDateFormat("yyyyMMddHHmm", Locale.ROOT).format(new Date()) + "-";
-            }
-            if (!TextUtils.isEmpty(prefix) && !fileNameEdit.getText().toString().startsWith(prefix)) {
-                fileNameEdit.setText(prefix + fileNameEdit.getText().toString());
-            }
-            fileNameEdit.setSelection(fileNameEdit.length());
+            final String template = templateAdapter.getItem(pos);
+            final String format = appSettings.getTemplateTitleFormat(template);
+            titleFormatEdit.setText(format == null ? "" : format);
         }));
 
+        // Setup type / format spinner and action
+        // -----------------------------------------------------------------------------------------
+        final ArrayAdapter<String> typeAdapter = new ArrayAdapter<>(activity, android.R.layout.simple_spinner_item);
+        typeAdapter.addAll(GsCollectionUtils.map(Arrays.asList(FormatRegistry.FORMATS), f -> activity.getString(f.name)));
+        typeSpinner.setAdapter(typeAdapter);
+
+        // Load name formats into spinner
+        final GsCallback.a1<Integer> typeCallback = pos -> {
+            final FormatRegistry.Format fmt = FormatRegistry.FORMATS[pos];
+            if (fmt.ext != null) {
+                if (encryptCheckbox.isChecked()) {
+                    extEdit.setText(fmt.ext + JavaPasswordbasedCryption.DEFAULT_ENCRYPTION_EXTENSION);
+                } else {
+                    extEdit.setText(fmt.ext);
+                }
+            }
+
+            final int tpos = templateAdapter.getPosition(appSettings.getTypeTemplate(fmt.format));
+            if (tpos >= 0) {
+                templateSpinner.setSelection(tpos);
+            }
+        };
+
+        typeSpinner.setOnItemSelectedListener(new GsAndroidSpinnerOnItemSelectedAdapter(typeCallback));
+
+        // TODO - make it so re-clicking works
+        // // We set on clicked for each loop so that re-clicking triggers again
+        // for (final int pos : GsCollectionUtils.range(typeSpinner.getCount())) {
+        //     typeSpinner.getChildAt(pos).setOnClickListener(v -> typeCallback.callback(pos));
+        // }
+
+
+        // Setup other checkboxes etc
+        // -----------------------------------------------------------------------------------------
         encryptCheckbox.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            final String currentExtention = fileExtEdit.getText().toString();
+            final String currentExtention = extEdit.getText().toString();
             if (isChecked) {
                 if (!currentExtention.endsWith(JavaPasswordbasedCryption.DEFAULT_ENCRYPTION_EXTENSION)) {
-                    fileExtEdit.setText(currentExtention + JavaPasswordbasedCryption.DEFAULT_ENCRYPTION_EXTENSION);
+                    extEdit.setText(currentExtention + JavaPasswordbasedCryption.DEFAULT_ENCRYPTION_EXTENSION);
                 }
             } else if (currentExtention.endsWith(JavaPasswordbasedCryption.DEFAULT_ENCRYPTION_EXTENSION)) {
-                fileExtEdit.setText(currentExtention.replace(JavaPasswordbasedCryption.DEFAULT_ENCRYPTION_EXTENSION, ""));
+                extEdit.setText(currentExtention.replace(JavaPasswordbasedCryption.DEFAULT_ENCRYPTION_EXTENSION, ""));
             }
             appSettings.setNewFileDialogLastUsedEncryption(isChecked);
         });
@@ -172,51 +215,84 @@ public class NewFileDialog extends DialogFragment {
         });
 
         dialogBuilder.setView(root);
-        fileNameEdit.requestFocus();
+
+        // Setup button click actions
+        // -----------------------------------------------------------------------------------------
 
         final MarkorContextUtils cu = new MarkorContextUtils(getContext());
         dialogBuilder.setNegativeButton(R.string.cancel, (dialogInterface, i) -> dialogInterface.dismiss());
         dialogBuilder.setPositiveButton(getString(android.R.string.ok), (dialogInterface, i) -> {
-            if (ez(fileNameEdit)) {
-                return;
+
+            final String titleFormat = titleFormatEdit.getText().toString().trim();
+            final String title = assembleTitle(titleFormat, titleEdit.getText());
+            final String ext = extEdit.getText().toString().trim();
+            final String fileName = GsFileUtils.getFilteredFilenameWithoutDisallowedChars(title + ext);
+
+            // Get template string
+            // -------------------------------------------------------------------------------------
+            final int ti = templateSpinner.getSelectedItemPosition();
+            final String template;
+            if (ti == 0) {
+                template = "";
+            } else if (ti <= snippets.size()) {
+                template = GsFileUtils.readTextFileFast(snippets.get(ti - 1).second).first;
+            } else {
+                template = templates.get(ti - snippets.size()).second;
             }
 
-            appSettings.setNewFileDialogLastUsedExtension(fileExtEdit.getText().toString().trim());
-            final String usedFilename = getFileNameWithoutExtension(fileNameEdit.getText().toString(), templateSpinner.getSelectedItemPosition());
-            final File f = new File(basedir, Document.normalizeFilename(usedFilename.trim()) + fileExtEdit.getText().toString().trim());
-            final Pair<byte[], Integer> templateContents = getTemplateContent(templateSpinner, basedir, f.getName(), encryptCheckbox.isChecked());
-            cu.writeFile(getActivity(), f, false, (arg_ok, arg_fos) -> {
-                try {
-                    if (appSettings.getNewFileDialogLastUsedUtf8Bom()) {
-                        arg_fos.write(0xEF);
-                        arg_fos.write(0xBB);
-                        arg_fos.write(0xBF);
-                    }
-                    if (templateContents.first != null && (!f.exists() || f.length() < GsContextUtils.TEXTFILE_OVERWRITE_MIN_TEXT_LENGTH)) {
-                        arg_fos.write(templateContents.first);
-                    }
-                } catch (Exception ignored) {
-                }
-                if (templateContents.second >= 0) {
-                    appSettings.setLastEditPosition(f.getAbsolutePath(), templateContents.second);
-                }
-                callback(arg_ok || f.exists(), f);
-                dialogInterface.dismiss();
-            });
+            final Pair<String, Integer> content = getTemplateContent(template, title);
+            // -------------------------------------------------------------------------------------
+
+            final File file = new File(basedir, fileName);
+
+            // Most of the logic we want is in the document class so we just reuse it
+            final Document document = new Document(file);
+
+            // These are done even if the file doesn
+            appSettings.setTemplateTitleFormat(templateAdapter.getItem(ti), titleFormat);
+            final FormatRegistry.Format fmt = FormatRegistry.FORMATS[typeSpinner.getSelectedItemPosition()];
+            appSettings.setTypeTemplate(fmt.format, (String) templateSpinner.getSelectedItem());
+            appSettings.setNewFileDialogLastUsedType(fmt.format);
+
+            if (!titleFormat.isEmpty()) {
+                appSettings.saveTitleFormat(titleFormat, MAX_TITLE_FORMATS);
+            }
+
+            if (!file.exists() || file.length() <= GsContextUtils.TEXTFILE_OVERWRITE_MIN_TEXT_LENGTH) {
+                document.saveContent(activity, content.first, cu, true);
+
+                // We only make these changes if the file did not exist
+                document.setFormat(FormatRegistry.FORMATS[typeSpinner.getSelectedItemPosition()].format);
+                appSettings.setLastEditPosition(document.getPath(), content.second);
+                appSettings.setNewFileDialogLastUsedExtension(extEdit.getText().toString().trim());
+
+                callback(file);
+
+            } else if (file.canWrite()) {
+                callback(file);
+            } else {
+                Toast.makeText(activity, R.string.failed_to_create_backup, Toast.LENGTH_LONG).show();
+            }
+
+            dialogInterface.dismiss();
         });
 
         dialogBuilder.setNeutralButton(R.string.folder, (dialogInterface, i) -> {
-            if (ez(fileNameEdit)) {
-                return;
-            }
-            final String usedFoldername = getFileNameWithoutExtension(fileNameEdit.getText().toString().trim(), templateSpinner.getSelectedItemPosition());
-            final File f = new File(basedir, usedFoldername);
+
+            final String titleFormat = titleFormatEdit.getText().toString().trim();
+            final String title = assembleTitle(titleFormat, titleEdit.getText());
+            final String dirName = GsFileUtils.getFilteredFilenameWithoutDisallowedChars(title);
+            final File f = new File(basedir, dirName);
+
             if (cu.isUnderStorageAccessFolder(getContext(), f, true)) {
                 DocumentFile dof = cu.getDocumentFile(getContext(), f, true);
-                callback(dof != null && dof.exists(), f);
-            } else {
-                callback(f.mkdirs() || f.exists(), f);
+                if (dof != null && dof.exists()) {
+                    callback(f);
+                }
+            } else if (f.isDirectory() || f.mkdirs()) {
+                callback(f);
             }
+
             dialogInterface.dismiss();
         });
 
@@ -224,150 +300,56 @@ public class NewFileDialog extends DialogFragment {
             dialogBuilder.setNeutralButton("", null);
         }
 
+        // Initial creation - loop through and set type
+        final int lastUsedType = appSettings.getNewFileDialogLastUsedType();
+        for (int i = 0; i < FormatRegistry.FORMATS.length; i++) {
+            final FormatRegistry.Format fmt = FormatRegistry.FORMATS[i];
+            if (fmt.format == lastUsedType) {
+                typeSpinner.setSelection(i);
+                typeCallback.callback(i);
+                break;
+            }
+        }
+
+        titleEdit.requestFocus();
+
         return dialogBuilder;
     }
 
-    private void loadTemplatesIntoSpinner(final AppSettings appSettings, final Spinner templateSpinner) {
-        List<String> templates = new ArrayList<>();
-        for (int i = 0; i < templateSpinner.getCount(); i++) {
-            templates.add((String) templateSpinner.getAdapter().getItem(i));
-        }
-        templates.addAll(MarkorDialogFactory.getSnippets(appSettings).keySet());
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_spinner_item, templates.toArray(new String[0]));
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        templateSpinner.setAdapter(adapter);
-    }
-
-    private boolean ez(EditText et) {
-        return et.getText().toString().trim().isEmpty();
-    }
-
-    private String getFileNameWithoutExtension(String typedFilename, int selectedTemplatePos) {
-        if (selectedTemplatePos == 7) {
-            // Wikitext files always use underscores instead of spaces
-            return typedFilename.trim().replace(' ', '_');
-        }
-        return typedFilename.trim();
-    }
-
-    private void callback(boolean ok, File file) {
+    private void callback(final File file) {
         try {
-            callback.callback(ok, file);
+            callback.callback(file);
         } catch (Exception ignored) {
         }
     }
 
-    // this code corresponds to R.arrays.arr_file_templates
-    //
-    // How to get content out of a file:
-    // 1) Replace \n with \n | copy to clipboard
-    //    cat markor-markdown-reference.md  | sed 's@\\@\\\\@g' | sed -z 's@\n@\n@g'  | xclip
-    //
-    // 2) t = "<cursor>";  | ctrl+shift+v "paste without formatting"
-    //
-    // -----
-    // if you use Androidstudio/IntelliJ copy file content into t = "<cursor>". Android studio takes care of escaping
-    private String getTemplateByPos(
-            final int spinnerPos,
-            final String fileName,
-            final File basedir
-    ) {
-        switch (spinnerPos) {
-            case 1: {
-                return "# Markdown Reference\nAutomatically generate _table of contents_ by checking the option here: `Settings > Format > Markdown`.\n\n## H2 Header\n### H3 header\n#### H4 Header\n##### H5 Header\n###### H6 Header\n\n<!-- --------------- -->\n\n## Format Text\n\n*Italic emphasis* , _Alternative italic emphasis_\n\n**Bold emphasis** , __Alternative bold emphasis__\n\n~~Strikethrough~~\n\nBreak line (two spaces at end of line)  \n\n> Block quote\n\n`Inline code`\n\n```\nCode blocks\nare\nawesome\n```\n\n<!-- --------------- -->\n \n## Lists\n### Ordered & unordered\n\n* Unordered list\n* ...with asterisk/star\n* Test\n\n- Another unordered list\n- ...with hyphen/minus\n- Test\n\n1. Ordered list\n2. Test\n3. Test\n4. Test\n\n- Nested lists\n    * Unordered nested list\n    * Test\n    * Test\n    * Test\n- Ordered nested list\n    1. Test\n    2. Test\n    3. Test\n    4. Test\n- Double-nested unordered list\n    - Test\n    - Unordered\n        - Test a\n        - Test b\n    - Ordered\n        1. Test 1\n        2. Test 2\n\n### Checklist\n* [ ] Salad\n* [x] Potatoes\n\n1. [x] Clean\n2. [ ] Cook\n\n<!-- --------------- -->\n\n## Links\n[Link](https://duckduckgo.com/)\n\n[File in same folder as the document.](markor-markdown-reference.md) Use %20 for spaces!\n\n<!-- --------------- -->\n\n## Tables\n\n| Left aligned | Middle aligned | Right aligned |\n| :--------------- | :------------------: | -----------------: |\n| Test                 | Test                      | Test                    |\n| Test                 | Test                      | Test                    |\n\n÷÷÷÷\n\nShorter | Table | Syntax\n:---: | ---: | :---\nTest | Test | Test\nTest | Test | Test\n\n<!-- Comment: Not visibile in view. Can also span across multiple lines. End with:-->\n\n<!-- ------------- -->\n\n## Math (KaTeX)\nSee [reference](https://katex.org/docs/supported.html) & [examples](https://github.com/waylonflinn/markdown-it-katex/blob/master/README.md). Enable by checking Math at `Settings > Markdown`.\n\n### Math inline\n\n$ I = \\frac V R $\n\n### Math block\n\n$$\\begin{array}{c} \nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} & = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \nabla \\cdot \\vec{\\mathbf{E}} & = 4 \\pi \\rho \\\\ \nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} & = \\vec{\\mathbf{0}} \\\\ \nabla \\cdot \\vec{\\mathbf{B}} & = 0 \\end{array}$$\n\n\n$$\\frac{k_t}{k_e} = \\sqrt{2}$$\n\n<!-- ------------- -->\n\n## Format Text (continued)\n\n### Text color\n\n<span style='background-color:#ffcb2e;'>Text with background color / highlight</span>\n\n<span style='color:#3333ff;'>Text foreground color</span>\n\n<span style='text-shadow: 0px 0px 2px #FF0000;'>Text with colored outline</span> / <span style='text-shadow: 0px 0px 2px #0000FF; color: white'>Text with colored outline</span>\n\n\n### Text sub & superscript\n\n<u>Underline</u>\n\nThe <sub>Subway</sub> sandwich was <sup>super</sup>\n\nSuper special characters: ⁰ ¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹ ⁺ ⁻ ⁼ ⁽ ⁾ ⁿ ™ ® ℠\n\n### Text positioning\n<div markdown='1' align='right'>\n\ntext on the **right**\n\n</div>\n\n<div markdown='1' align='center'>\n\ntext in the **center**  \n(one empy line above and below  \nrequired for Markdown support OR markdown='1')\n\n</div>\n\n### Block Text\n\n<div markdown='1' style='text-align: justify; text-justify: inter-word;'>\nlorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. \n</div>\n\n### Dropdown\n\n<details markdown='1'><summary>Click to Expand/Collapse</summary>\n\nExpanded content. Shows up and keeps visible when clicking expand. Hide again by clicking the dropdown button again.\n\n</details>\n\n\n### Break page\nTo break the page (/start a new page), put the div below into a own line.\nRelevant for creating printable pages from the document (Print / PDF).\n\n<div style='page-break-after: always'></div>\n\n\n<!-- ------------- -->\n\n## Multimedia\n\n### Images\n![Image](file:///android_asset/img/schindelpattern.jpg)\n\n### Videos\n**Youtube** [Welcome to Upper Austria](https://www.youtube.com/watch?v=RJREFH7Lmm8)\n<iframe width='360' height='200' src='https://www.youtube.com/embed/RJREFH7Lmm8'> </iframe>\n\n**Peertube** [Road in the wood](https://open.tube/videos/watch/8116312a-dbbd-43a3-9260-9ea6367c72fc)\n<div><video controls><source src='https://peertube.mastodon.host/download/videos/8116312a-dbbd-43a3-9260-9ea6367c72fc-480.mp4' </source></video></div>\n\n<!-- **Local video** <div><video controls><source src='voice-parrot.mp4' </source></video></div> -->\n\n### Audio & Music\n**Web audio** [Guifrog - Xia Yu](https://www.freemusicarchive.org/music/Guifrog/Xia_Yu)\n<audio controls src='https://files.freemusicarchive.org/storage-freemusicarchive-org/music/ccCommunity/Guifrog/Xia_Yu/Guifrog_-_Xia_Yu.mp3'></audio>\n\n**Local audio** Yellowcard - Lights up in the sky\n<audio controls src='../Music/mp3/Yellowcard/[2007]%20Paper%20Walls/Yellowcard%20-%2005%20-%20Light%20Up%20the%20Sky.mp3'></audio>\n\n## Charts / Graphs / Diagrams (mermaidjs)\nPie, flow, sequence, class, state, ER  \nSee also: mermaidjs [live editor](https://mermaid-js.github.io/mermaid-live-editor/).\n\n```mermaid\ngraph LR\n    A[Square Rect] -- Link text --> B((Circle))\n    A --> C(Round Rect)\n    B --> D{Rhombus}\n    C --> D\n```\n\n\n\n## Admonition Extension\nCreate block-styled side content.  \nUse one of these qualifiers to select the icon and the block color: abstract, summary, tldr, bug, danger, error, example, snippet, failure, fail, missing, question, help, faq, info, todo, note, seealso, quote, cite, success, check, done, tip, hint, important, warning, caution, attention.\n\n!!! warning 'Optional Title'\n    Block-Styled Side Content with **Markdown support**\n\n!!! info ''\n    No-Heading Content\n\n??? bug 'Collapsed by default'\n    Collapsible Block-Styled Side Content\n\n???+ example 'Open by default'\n     Collapsible Block-Styled Side Content\n\n------------------\n\nThis Markdown reference file was created for the [Markor](https://github.com/gsantner/markor) project by [Gregor Santner](https://github.com/gsanter) and is licensed [Creative Commons Zero 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode) (public domain). File revision 3.\n\n------------------\n\n\n";
-            }
-            case 2: {
-                return "(A) Call Mom @mobile +family\n(A) Schedule annual checkup +health\n(A) Urgently buy milk @shop\n(B) Outline chapter 5 +novel @computer\n(C) Add cover sheets @work +myproject\nPlan backyard herb garden @home\nBuy salad @shop\nWrite blog post @pc\nInstall Markor @mobile\n2019-06-24 scan photos @home +blog\n2019-06-25 draw diagram @work \nx This has been done @home +renovations";
-            }
-            case 3: {
-                return "---\nlayout: post\ntags: []\ncategories: []\n#date: 2019-06-25 13:14:15\n#excerpt: ''\n#image: 'BASEURL/assets/blog/img/.png'\n#description:\n#permalink:\ntitle: 'title'\n---\n\n\n";
-            }
-            case 4: {
-                return "# Title\n## Description\n\n![Text](picture.png)\n\n### Ingredients\n\n|  Ingredient   | Amount |\n|:--------------|:-------|\n| 1             | 1      |\n| 2             | 2      |\n| 3             | 3      |\n| 4             | 4      |\n\n\n### Preparation\n\n1. Text\n2. Text\n\n";
-            }
-            case 5: {
-                return "---\nclass: beamer\n---\n\n-----------------\n# Cool presentation\n\n## Abed Nadir\n\n{{ post.date_today }}\n\n<!-- Overall slide design -->\n<style>\n.slide {\nbackground:url() no-repeat center center fixed; background-size: cover;\n}\n.slide_type_title {\nbackground: slategrey;\n}\n</style>\n\n-----------------\n\n## Slide title\n\n\n1. All Markdown features of Markor are **supported** for Slides too ~~strikeout~~ _italic_ `code`\n2. Start new slides with 3 more hyphens (---) separated by empty lines\n3. End last slide with hyphens too\n4. Slide backgrounds can be configured using CSS, for all and individual slides\n5. Print / PDF export in landscape mode\n6. Create title only slides (like first slide) by starting the slide (line after `---`) with title `# title`\n\n\n-----------------\n## Slide with centered image\n* Images can be centered by adding 'imghcenter' in alt text & grown to page size with 'imgbig'\n* Example: `![text imghcenter imgbig text](a.jpg)`\n\n![imghcenter imgbig](file:///android_asset/img/flowerfield.jpg)\n\n\n\n\n-----------------\n## Page with gradient background\n* and a picture\n* configure background color/image with CSS .slide_p4 { } (4 = the slide page number)\n\n![pic](file:///android_asset/img/flowerfield.jpg)\n\n\n<style> .slide_p4 { background: linear-gradient(to bottom, #11998e, #38ef7d); } </style>\n\n-----------------\n## Page with image background\n* containing text and a table\n\n| Left aligned | Middle aligned | Right aligned |\n| :------------------- | :----------------------: | --------------------: |\n| Test               | Test                    | Test                |\n| Test               | Test                    | Test                |\n\n\n\n<style> \n.slide_p5 { background: url('file:///android_asset/img/schindelpattern.jpg') no-repeat center center fixed; background-size: cover; }\n.slide_p5 > .slide_body > * { color: black; }\n</style>\n\n-----------------\n";
-            }
-            case 6: {
-                return "Content-Type: text/x-zim-wiki\nWiki-Format: zim 0.4\nCreation-Date: 2019-01-28T20:53:47+01:00\n\n====== Zim Wiki ======\nLet me try to gather a list of the formatting options Zim provides.\n\n====== Head 1 ======\n\n===== Head 2 =====\n\n==== Head 3 ====\n\n=== Head 4 ===\n\n== Head 5 ==\n\n**Bold**\n//italics//\n__marked (yellow Background)__\n~~striked~~\n\n* Unordered List\n* second item\n	* [[Sub-Item]]\n		* Subsub-Item\n			* and one more sub\n* Back to first indent level\n\n1. ordered list\n2. second item\n	a. item 2a\n		1. Item 2a1\n		2. Item 2a2\n	b. item 2b\n		1. 2b1\n			a. 2b1a\n3. an so on...\n\n[ ] Checklist\n[ ] unchecked item\n[*] checked item\n[x] crossed item\n[>] Item marked with a yellow left-to-right-arrow\n[ ] another unchecked item\n\n\nThis ist ''preformatted text'' inline.\n\n'''\nThis is a preformatted text block.\nIt spans multiple lines.\nAnd it's visually indented.\n'''\n\nWe also have _{subscript} and ^{superscript}.\n\nIt seems there is no way to combine those styles.\n//**this is simply italic**// and you can see the asterisks.\n**//This is simply bold//** and you can see the slashes.\n__**This is simply marked yellow**__ and you can see the asterisks.\n\nThis is a web link: [[https://github.com/gsantner/markor|Markor on Github]]\nLinks inside the Zim Wiki project can be made by simply using the [[Page Name]] in double square brackets.\nThis my also contain some hierarchy information, like [[Folder:Subfolder:Document Name]]\n\n\nThis zim wiki reference file was created for the [[https://github.com/gsantner/markor|Markor]] project by [[https://github.com/gsantner|Gregor Santner]] and is licensed [[https://creativecommons.org/publicdomain/zero/1.0/legalcode|Creative Commons Zero 1.0]] (public domain). File revision 1.";
-            }
-            case 7: {
-                return WikitextActionButtons.createWikitextHeaderAndTitleContents(fileName.replaceAll("(\\.((zim)|(txt)))*$", "").trim().replace(' ', '_'), new Date(), getResources().getString(R.string.created));
-            }
-            case 8: {
-                final String header = TextViewUtils.interpolateEscapedDateTime("---\ntags: []\ncreated: '`yyyy-MM-dd`'\ntitle: ''\n---\n\n");
-                if (basedir != null && new File(basedir.getParentFile(), ".notabledir").exists()) {
-                    return header.replace("created:", "modified:");
-                }
-                return header;
-            }
-            case 9: {
-                return "source:\ncategory:\ntag:\n------------\n";
-            }
-            case 10: {
-                return "= My Title\n:page-subtitle: This is a subtitle\n:page-last-updated: 2029-01-01\n:page-tags: ['AsciiDoc', 'Markor', 'open source']\n:toc: auto\n:toclevels: 2\n// :page-description: the optional description\n// This should match the structure on the jekyll server:\n:imagesdir: ../assets/img/blog\n\nifndef::env-site[]\n\n// on the jekyll server, the :page-subtitle: is displayed below the title.\n// but it is not shown, when rendered in html5, and the site is rendered in html5, when working locally\n// so we show it additionally only, when we work locally\n// https://docs.asciidoctor.org/asciidoc/latest/document/subtitle/\n\n[discrete] \n=== {page-subtitle}\n\nendif::env-site[]\n\n// local testing:\n:imagesdir: ../app/src/main/assets/img\n\nimage::flowerfield.jpg[]\n\nimage::schindelpattern.jpg[Schindelpattern,200]\n\nbefore inline picture image:schindelpattern.jpg[Schindelpattern,50] and after inline picture\n";
-            }
-            case 11: {
-                // sample.csv
-                return "# this is a comment in csv file\n" +
-                        "\n" +
-                        "# below is the header\n" +
-                        "number;text;finishing date\n" +
-                        "\n" +
-                        "# csv can contain markdown formatting\n" +
-                        "1;Learn to use **Markor** formatting\n" +
-                        "\n" +
-                        "# use \"...\" if the column contains reserved chars\n" +
-                        "2;\"Use Delimitter chars like \"\";    :,\";2019-06-24\n" +
-                        "\n" +
-                        "# use \"...\" if the column is multiline\n" +
-                        "3;\"multi\n" +
-                        "   line\";2059-12-24\n";
-            }
-            case 12: {
-                // Org-mode
-                return "OrgMode Reference\n" + "* Headline\n" + "** Nested headline\n" + "*** Deeper\n" + "\n" + "* Basic markup\n" + "This is the general building block for org-mode navigation.\n" + "- _underscores let you underline things_\n" + "- *stars add emphasis*\n" + "- /slashes are italics/\n" + "- +pluses are strikethrough+\n" + "- =equal signs are verbatim text=\n" + "- ~tildes can also be used~\n" + "\n" + "* List\n" + "** Unordered List\n" + "- Item 1\n" + "- Item 2\n" + "  - Subitem 2.1\n" + "  - Subitem 2.2\n" + "** Ordered List\n" + "1. First Item\n" + "2. Second Item\n" + "   1. Subitem 2.1\n" + "   2. Subitem 2.2\n" + "- [X] Completed Task\n" + "- [ ] Uncompleted Task\n" + "** Nested List\n" + "   - Item A\n" + "     - Subitem A.1\n" + "     - Subitem A.2\n" + "   - Item B\n" + "\n" + "* Tables\n" + "\n" + "| First Name                 | Last Name           | Years using Emacs |\n" + "|----------------------------+---------------------+-------------------|\n" + "| Lee                        | Hinman              |                 5 |\n" + "| Mike                       | Hunsinger           |                 2 |\n" + "| Daniel                     | Glauser             |                 4 |\n" + "| Really-long-first-name-guy | long-last-name-pers |                 1 |\n" + "\n" + "* Org-mode links\n" + "\n" + "#+BEGIN_SRC fundamental\n" + "[[http://google.com/][Google]]\n" + "#+END_SRC\n" + "\n" + "[[./images/pic1.png]]\n" + "\n" + "\n" + "* TODO List\n" + "** TODO This is a task that needs doing\n" + "** TODO Another todo task\n" + "- [ ] sub task one\n" + "- [X] sub task two\n" + "- [ ] sub task three\n" + "** DONE I've already finished this one\n" + "*** CANCELLED learn todos\n" + "    CLOSED: [2023-10-16 Mon 08:39]\n" + "\n" + "* Code\n" + "#+BEGIN_LaTeX\n" + "$a + b$\n" + "#+END_LaTeX\n" + "\n" + "#+BEGIN_SRC emacs-lisp\n" + "(defun my/function ()\n" + "  \"docstring\"\n" + "  (interactive)\n" + "  (progn\n" + "    (+ 1 1)\n" + "    (message \"Hi\")))\n" + "#+END_SRC\n" + "\n";
-            }
+    private String assembleTitle(final CharSequence rawFmt, final CharSequence rawName) {
+        String format = rawFmt.toString().trim();
+        final String name = rawName.toString().trim();
+
+        // Include title if not included
+        if (!name.isEmpty() && !format.contains("{{title}}")) {
+            format = format + (format.isEmpty() ? "" : "_") + "{{title}}";
         }
-        return null;
+
+        final String formatted = TextViewUtils.interpolateSnippet(format, name, "").trim();
+
+        if (formatted.isEmpty()) {
+            return TextViewUtils.interpolateSnippet("`yyyyMMddHHmmss`", "", "");
+        }
+
+        return formatted;
     }
 
-    private Pair<byte[], Integer> getTemplateContent(
-            final Spinner templateSpinner,
-            final File basedir,
-            final String filename,
-            final boolean encrypt
-    ) {
-
-        String template = getTemplateByPos(templateSpinner.getSelectedItemPosition(), filename, basedir);
-        if (template == null) {
-            final Map<String, File> snippets = MarkorDialogFactory.getSnippets(ApplicationObject.settings());
-            final Object sel = templateSpinner.getSelectedItem();
-            if (sel instanceof String && snippets.containsKey((String) sel)) {
-                final String t = GsFileUtils.readTextFileFast(snippets.get((String) sel)).first;
-                final String title = GsFileUtils.getNameWithoutExtension(filename);
-                template = TextViewUtils.interpolateSnippet(t, title, "");
-            }
-        }
-
-        if (template == null) {
-            return Pair.create(null, -1);
-        }
+    private Pair<String, Integer> getTemplateContent(final String template, final String name) {
+        String text = TextViewUtils.interpolateSnippet(template, name, "");
 
         final int startingIndex = template.indexOf(HighlightingEditor.PLACE_CURSOR_HERE_TOKEN);
-        template = template.replace(HighlightingEditor.PLACE_CURSOR_HERE_TOKEN, "");
+        text = text.replace(HighlightingEditor.PLACE_CURSOR_HERE_TOKEN, "");
 
         // Has no utility in a new file
-        template = template.replace(HighlightingEditor.INSERT_SELECTION_HERE_TOKEN, "");
+        text = text.replace(HighlightingEditor.INSERT_SELECTION_HERE_TOKEN, "");
 
-        final byte[] bytes;
-        if (encrypt && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            final char[] pass = ApplicationObject.settings().getDefaultPassword();
-            bytes = new JavaPasswordbasedCryption(Build.VERSION.SDK_INT, new SecureRandom()).encrypt(template, pass);
-        } else {
-            bytes = template.getBytes();
-        }
-
-        return Pair.create(bytes, startingIndex);
+        return Pair.create(text, startingIndex);
     }
 }

--- a/app/src/main/java/net/gsantner/markor/frontend/NewFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/NewFileDialog.java
@@ -20,7 +20,6 @@ import android.util.AttributeSet;
 import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.ArrayAdapter;
@@ -32,7 +31,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.DialogFragment;

--- a/app/src/main/java/net/gsantner/markor/frontend/filebrowser/MarkorFileBrowserFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/filebrowser/MarkorFileBrowserFactory.java
@@ -72,9 +72,9 @@ public class MarkorFileBrowserFactory {
         opts.fileImage = R.drawable.ic_file_white_24dp;
         opts.folderImage = R.drawable.ic_folder_white_24dp;
 
-        opts.recentFiles = appSettings.getAsFileList(appSettings.getRecentDocuments());
-        opts.popularFiles = appSettings.getAsFileList(appSettings.getPopularDocuments());
-        opts.favouriteFiles = appSettings.getFavouriteFiles();
+        opts.getRecentFiles = appSettings::getRecentFiles;
+        opts.getPopularFiles = appSettings::getPopularFiles;
+        opts.getFavouriteFiles = appSettings::getFavouriteFiles;
 
         opts.titleText = R.string.select;
 

--- a/app/src/main/java/net/gsantner/markor/frontend/filebrowser/MarkorFileBrowserFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/filebrowser/MarkorFileBrowserFactory.java
@@ -58,11 +58,6 @@ public class MarkorFileBrowserFactory {
         opts.contentDescriptionSelected = R.string.selected;
         opts.contentDescriptionFile = R.string.file;
 
-        opts.sortFolderFirst = appSettings.isFileBrowserSortFolderFirst();
-        opts.sortByType = appSettings.getFileBrowserSortByType();
-        opts.sortReverse = appSettings.isFileBrowserSortReverse();
-        opts.filterShowDotFiles = appSettings.isFileBrowserFilterShowDotFiles();
-
         opts.accentColor = R.color.accent;
         opts.primaryColor = R.color.primary;
         opts.primaryTextColor = R.color.primary_text;
@@ -72,13 +67,21 @@ public class MarkorFileBrowserFactory {
         opts.fileImage = R.drawable.ic_file_white_24dp;
         opts.folderImage = R.drawable.ic_folder_white_24dp;
 
-        opts.getRecentFiles = appSettings::getRecentFiles;
-        opts.getPopularFiles = appSettings::getPopularFiles;
-        opts.getFavouriteFiles = appSettings::getFavouriteFiles;
-
         opts.titleText = R.string.select;
 
         opts.mountedStorageFolder = cu.getStorageAccessFolder(context);
+
+        opts.refresh = () -> {
+            opts.sortFolderFirst = appSettings.isFileBrowserSortFolderFirst();
+            opts.sortByType = appSettings.getFileBrowserSortByType();
+            opts.sortReverse = appSettings.isFileBrowserSortReverse();
+            opts.filterShowDotFiles = appSettings.isFileBrowserFilterShowDotFiles();
+            opts.favouriteFiles = appSettings.getFavouriteFiles();
+            opts.recentFiles = appSettings.getRecentFiles();
+            opts.popularFiles = appSettings.getPopularFiles();
+        };
+        opts.refresh.callback();
+
         return opts;
     }
 

--- a/app/src/main/java/net/gsantner/markor/frontend/textview/AutoTextFormatter.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/textview/AutoTextFormatter.java
@@ -30,7 +30,7 @@ public class AutoTextFormatter implements InputFilter {
     @Override
     public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
         try {
-            if (start < source.length() && dstart <= dest.length() && TextViewUtils.isNewLine(source, start, end)) {
+            if (start < source.length() && dstart <= dest.length() && GsTextUtils.isNewLine(source, start, end)) {
                 return autoIndent(source, dest, dstart, dend);
             }
         } catch (IndexOutOfBoundsException | NullPointerException e) {
@@ -277,7 +277,7 @@ public class AutoTextFormatter implements InputFilter {
     public static void renumberOrderedList(final Editable edit, final FormatPatterns patterns) {
 
         final int[] sel = TextViewUtils.getSelection(edit);
-        if (!TextViewUtils.inRange(0, edit.length(), sel)) {
+        if (!GsTextUtils.inRange(0, edit.length(), sel)) {
             return;
         }
 
@@ -351,7 +351,7 @@ public class AutoTextFormatter implements InputFilter {
             chunked.applyChanges();
 
             final int[] newSel = new int[]{sel[0] + shifts[0], sel[1] + shifts[1]};
-            if (TextViewUtils.inRange(0, edit.length(), newSel)) {
+            if (GsTextUtils.inRange(0, edit.length(), newSel)) {
                 Selection.setSelection(edit, newSel[0], newSel[1]);
             }
 

--- a/app/src/main/java/net/gsantner/markor/frontend/textview/HighlightingEditor.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/textview/HighlightingEditor.java
@@ -30,6 +30,7 @@ import androidx.appcompat.widget.AppCompatEditText;
 import net.gsantner.markor.ApplicationObject;
 import net.gsantner.markor.activity.MainActivity;
 import net.gsantner.markor.model.AppSettings;
+import net.gsantner.opoc.format.GsTextUtils;
 import net.gsantner.opoc.wrapper.GsCallback;
 import net.gsantner.opoc.wrapper.GsTextWatcherAdapter;
 
@@ -457,7 +458,7 @@ public class HighlightingEditor extends AppCompatEditText {
     }
 
     public boolean indexesValid(int... indexes) {
-        return TextViewUtils.inRange(0, length(), indexes);
+        return GsTextUtils.inRange(0, length(), indexes);
     }
 
     static class LineNumbersDrawer {
@@ -482,12 +483,12 @@ public class HighlightingEditor extends AppCompatEditText {
         private final GsTextWatcherAdapter _lineTrackingWatcher = new GsTextWatcherAdapter() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                _maxNumber -= TextViewUtils.countChar(s, start, start + count, '\n');
+                _maxNumber -= GsTextUtils.countChar(s, start, start + count, '\n');
             }
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
-                _maxNumber += TextViewUtils.countChar(s, start, start + count, '\n');
+                _maxNumber += GsTextUtils.countChar(s, start, start + count, '\n');
             }
         };
 
@@ -549,7 +550,7 @@ public class HighlightingEditor extends AppCompatEditText {
             _maxNumber = 1;
             final CharSequence text = _editor.getText();
             if (text != null) {
-                _maxNumber += TextViewUtils.countChar(text, 0, text.length(), '\n');
+                _maxNumber += GsTextUtils.countChar(text, 0, text.length(), '\n');
             }
             _editor.addTextChangedListener(_lineTrackingWatcher);
         }

--- a/app/src/main/java/net/gsantner/markor/frontend/textview/TextViewUtils.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/textview/TextViewUtils.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+import net.gsantner.opoc.format.GsTextUtils;
 import net.gsantner.opoc.util.GsContextUtils;
 import net.gsantner.opoc.wrapper.GsCallback;
 
@@ -47,27 +48,13 @@ public final class TextViewUtils {
         throw new AssertionError();
     }
 
-    public static boolean isValidIndex(final CharSequence s, final int... indices) {
-        return s != null && inRange(0, s.length() - 1, indices);
-    }
-
-    // Checks if all values are in [min, max] _inclusive_
-    public static boolean inRange(final int min, final int max, final int... values) {
-        for (final int i : values) {
-            if (i < min || i > max) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     public static int getLineStart(CharSequence s, int start) {
         return getLineStart(s, start, 0);
     }
 
     public static int getLineStart(CharSequence s, int start, int minRange) {
         int i = start;
-        if (isValidIndex(s, start - 1, minRange)) {
+        if (GsTextUtils.isValidIndex(s, start - 1, minRange)) {
             for (; i > minRange; i--) {
                 if (s.charAt(i - 1) == '\n') {
                     break;
@@ -84,7 +71,7 @@ public final class TextViewUtils {
 
     public static int getLineEnd(CharSequence s, int start, int maxRange) {
         int i = start;
-        if (isValidIndex(s, start, maxRange - 1)) {
+        if (GsTextUtils.isValidIndex(s, start, maxRange - 1)) {
             for (; i < maxRange; i++) {
                 if (s.charAt(i) == '\n') {
                     break;
@@ -218,7 +205,7 @@ public final class TextViewUtils {
      */
     public static int[] getLineOffsetFromIndex(final CharSequence s, int p) {
         p = Math.min(Math.max(p, 0), s.length());
-        final int line = countChars(s, 0, p, '\n')[0];
+        final int line = GsTextUtils.countChars(s, 0, p, '\n')[0];
         final int offset = getLineEnd(s, p) - p;
 
         return new int[]{line, offset};
@@ -259,61 +246,6 @@ public final class TextViewUtils {
         return i;
     }
 
-    public static int[] countChars(final CharSequence s, final char... chars) {
-        return countChars(s, 0, s.length(), chars);
-    }
-
-    /**
-     * Count instances of chars between start and end
-     *
-     * @param s     Sequence to count in
-     * @param start start of section to count within
-     * @param end   end of section to count within
-     * @param chars Array of chars to count
-     * @return number of instances of each char in [start, end)
-     */
-    public static int[] countChars(final CharSequence s, int start, int end, final char... chars) {
-        // Faster specialization for the common single case
-        if (chars.length == 1) {
-            return new int[]{countChar(s, start, end, chars[0])};
-        }
-
-        final int[] counts = new int[chars.length];
-        start = Math.max(0, start);
-        end = Math.min(end, s.length());
-        for (int i = start; i < end; i++) {
-            final char c = s.charAt(i);
-            for (int j = 0; j < chars.length; j++) {
-                if (c == chars[j]) {
-                    counts[j]++;
-                }
-            }
-        }
-        return counts;
-    }
-
-    public static int countChar(final CharSequence s, final char c) {
-        return countChar(s, 0, s.length(), c);
-    }
-
-    /**
-     * Count instances of a single char in a charsequence
-     */
-    public static int countChar(final CharSequence s, int start, int end, final char c) {
-        start = Math.max(0, start);
-        end = Math.min(end, s.length());
-        int count = 0;
-        for (int i = start; i < end; i++) {
-            if (s.charAt(i) == c) {
-                count++;
-            }
-        }
-        return count;
-    }
-
-    public static boolean isNewLine(CharSequence source, int start, int end) {
-        return isValidIndex(source, start, end - 1) && (source.charAt(start) == '\n' || source.charAt(end - 1) == '\n');
-    }
 
     public static void selectLines(final EditText edit, final Integer... positions) {
         selectLines(edit, Arrays.asList(positions));
@@ -423,7 +355,7 @@ public final class TextViewUtils {
         final int start = sel[0];
         final int end = sel.length > 1 ? sel[1] : start;
 
-        if (inRange(0, edit.length(), start, end)) {
+        if (GsTextUtils.inRange(0, edit.length(), start, end)) {
             edit.post(() -> {
                 if (!edit.hasFocus() && edit.getVisibility() != View.GONE) {
                     edit.requestFocus();
@@ -803,7 +735,7 @@ public final class TextViewUtils {
     }
 
     public static boolean checkRange(final int length, final int... indices) {
-        return indices != null && indices.length >= 2 && inRange(0, length, indices) && indices[1] > indices[0];
+        return indices != null && indices.length >= 2 && GsTextUtils.inRange(0, length, indices) && indices[1] > indices[0];
     }
 
     public static boolean isViewVisible(final View view) {

--- a/app/src/main/java/net/gsantner/markor/model/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/model/AppSettings.java
@@ -1022,6 +1022,43 @@ public class AppSettings extends GsSharedPreferencesPropertyBackend {
         return map.get(format == 0 ? "" : _context.getString(format));
     }
 
+    public void setTemplateTitleFormat(final String templateName, final String titleFormat) {
+        final String js = getString(R.string.pref_key__template_title_format_map, "{}");
+        final Map<String, String> map = jsonStringToMap(js);
+        map.put(templateName, titleFormat);
+        setString(R.string.pref_key__template_title_format_map, mapToJsonString(map));
+    }
+
+    public @Nullable String getTemplateTitleFormat(final String templateName) {
+        final String js = getString(R.string.pref_key__template_title_format_map, "{}");
+        final Map<String, String> map = jsonStringToMap(js);
+        return map.get(templateName);
+    }
+
+    public Set<String> getTitleFormats() {
+        final String js = getString(R.string.pref_key__title_format_list, "[]");
+        final Set<String> formats = new LinkedHashSet<>(jsonStringToList(js));
+        formats.addAll(Arrays.asList(
+            "{{date}}_{{title}}",
+            "{{date}}T{{time}}_{{title}}",
+            "`yyyyMMddHHmmSS`_{{title}}",
+            "{{uuid}}"
+        ));
+        return formats;
+    }
+
+    public void saveTitleFormat(final String format, final int maxCount) {
+        final Set<String> formats = getTitleFormats();
+        final Set<String> updated = new LinkedHashSet<>(Collections.singleton(format));
+        for (final String f : formats) {
+            updated.add(f);
+            if (updated.size() >= maxCount) {
+                break;
+            }
+        }
+        setString(R.string.pref_key__title_format_list, toJsonString(updated));
+    }
+
     private static String mapToJsonString(final Map<String, String> map) {
         return new JSONObject(map).toString();
     }

--- a/app/src/main/java/net/gsantner/markor/model/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/model/AppSettings.java
@@ -1022,43 +1022,6 @@ public class AppSettings extends GsSharedPreferencesPropertyBackend {
         return map.get(format == 0 ? "" : _context.getString(format));
     }
 
-    public void setTemplateTitleFormat(final String templateName, final String titleFormat) {
-        final String js = getString(R.string.pref_key__template_title_format_map, "{}");
-        final Map<String, String> map = jsonStringToMap(js);
-        map.put(templateName, titleFormat);
-        setString(R.string.pref_key__template_title_format_map, mapToJsonString(map));
-    }
-
-    public @Nullable String getTemplateTitleFormat(final String templateName) {
-        final String js = getString(R.string.pref_key__template_title_format_map, "{}");
-        final Map<String, String> map = jsonStringToMap(js);
-        return map.get(templateName);
-    }
-
-    public Set<String> getTitleFormats() {
-        final String js = getString(R.string.pref_key__title_format_list, "[]");
-        final Set<String> formats = new LinkedHashSet<>(jsonStringToList(js));
-        formats.addAll(Arrays.asList(
-            "{{date}}_{{title}}",
-            "{{date}}T{{time}}_{{title}}",
-            "`yyyyMMddHHmmSS`_{{title}}",
-            "{{uuid}}"
-        ));
-        return formats;
-    }
-
-    public void saveTitleFormat(final String format, final int maxCount) {
-        final Set<String> formats = getTitleFormats();
-        final Set<String> updated = new LinkedHashSet<>(Collections.singleton(format));
-        for (final String f : formats) {
-            updated.add(f);
-            if (updated.size() >= maxCount) {
-                break;
-            }
-        }
-        setString(R.string.pref_key__title_format_list, toJsonString(updated));
-    }
-
     private static String mapToJsonString(final Map<String, String> map) {
         return new JSONObject(map).toString();
     }

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -76,24 +76,11 @@ public class Document implements Serializable {
 
         // Set initial format
         final String fnlower = _file.getName().toLowerCase();
-        if (FormatRegistry.CONVERTER_TODOTXT.isFileOutOfThisFormat(fnlower)) {
-            setFormat(FormatRegistry.FORMAT_TODOTXT);
-        } else if (FormatRegistry.CONVERTER_KEYVALUE.isFileOutOfThisFormat(fnlower)) {
-            setFormat(FormatRegistry.FORMAT_KEYVALUE);
-        } else if (FormatRegistry.CONVERTER_MARKDOWN.isFileOutOfThisFormat(fnlower)) {
-            setFormat(FormatRegistry.FORMAT_MARKDOWN);
-        } else if (FormatRegistry.CONVERTER_CSV.isFileOutOfThisFormat(fnlower)) {
-            setFormat(FormatRegistry.FORMAT_CSV);
-        } else if (FormatRegistry.CONVERTER_ASCIIDOC.isFileOutOfThisFormat(fnlower)) {
-            setFormat(FormatRegistry.FORMAT_ASCIIDOC);
-        } else if (FormatRegistry.CONVERTER_WIKITEXT.isFileOutOfThisFormat(getPath())) {
-            setFormat(FormatRegistry.FORMAT_WIKITEXT);
-        } else if (FormatRegistry.CONVERTER_EMBEDBINARY.isFileOutOfThisFormat(getPath())) {
-            setFormat(FormatRegistry.FORMAT_EMBEDBINARY);
-        } else if (FormatRegistry.CONVERTER_ORGMODE.isFileOutOfThisFormat(getPath())) {
-            setFormat(FormatRegistry.FORMAT_ORGMODE);
-        } else {
-            setFormat(FormatRegistry.FORMAT_PLAIN);
+        for (final FormatRegistry.Format format : FormatRegistry.FORMATS) {
+            if (format.converter.isFileOutOfThisFormat(fnlower)) {
+                setFormat(format.format);
+                break;
+            }
         }
     }
 

--- a/app/src/main/java/net/gsantner/markor/model/Document.java
+++ b/app/src/main/java/net/gsantner/markor/model/Document.java
@@ -354,6 +354,7 @@ public class Document implements Serializable {
                         if (isContentResolverProxyFile) {
                             GsFileUtils.writeFile(_file, contentAsBytes, _fileInfo);
                         }
+
                     } catch (Exception e) {
                         Log.i(Document.class.toString(), e.getMessage());
                     }

--- a/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/format/GsTextUtils.java
@@ -10,6 +10,7 @@
 package net.gsantner.opoc.format;
 
 import android.util.Base64;
+import android.widget.EditText;
 
 import net.gsantner.opoc.wrapper.GsCallback;
 
@@ -364,5 +365,76 @@ public class GsTextUtils {
             start = end + 1;
         }
         callback.callback(i, start, text.length());
+    }
+
+
+    public static int[] countChars(final CharSequence s, final char... chars) {
+        return countChars(s, 0, s.length(), chars);
+    }
+
+    /**
+     * Count instances of chars between start and end
+     *
+     * @param s     Sequence to count in
+     * @param start start of section to count within
+     * @param end   end of section to count within
+     * @param chars Array of chars to count
+     * @return number of instances of each char in [start, end)
+     */
+    public static int[] countChars(final CharSequence s, int start, int end, final char... chars) {
+        // Faster specialization for the common single case
+        if (chars.length == 1) {
+            return new int[]{countChar(s, start, end, chars[0])};
+        }
+
+        final int[] counts = new int[chars.length];
+        start = Math.max(0, start);
+        end = Math.min(end, s.length());
+        for (int i = start; i < end; i++) {
+            final char c = s.charAt(i);
+            for (int j = 0; j < chars.length; j++) {
+                if (c == chars[j]) {
+                    counts[j]++;
+                }
+            }
+        }
+        return counts;
+    }
+
+    public static int countChar(final CharSequence s, final char c) {
+        return countChar(s, 0, s.length(), c);
+    }
+
+    /**
+     * Count instances of a single char in a charsequence
+     */
+    public static int countChar(final CharSequence s, int start, int end, final char c) {
+        start = Math.max(0, start);
+        end = Math.min(end, s.length());
+        int count = 0;
+        for (int i = start; i < end; i++) {
+            if (s.charAt(i) == c) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public static boolean isNewLine(CharSequence source, int start, int end) {
+        return isValidIndex(source, start, end - 1) && (source.charAt(start) == '\n' || source.charAt(end - 1) == '\n');
+    }
+
+    public static boolean isValidIndex(final CharSequence s, final int... indices) {
+        return s != null && inRange(0, s.length() - 1, indices);
+    }
+
+    // Checks if all values are in [min, max] _inclusive_
+    public static boolean inRange(final int min, final int max, final int... values) {
+        for (final int i : values) {
+            if (i < min || i > max) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
@@ -446,14 +446,16 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
             }
             case R.id.action_favourite: {
                 if (_filesystemViewerAdapter.areItemsSelected()) {
-                    _appSettings.setFavouriteFiles(GsCollectionUtils.union(_dopt.favouriteFiles, currentSelection));
+                    _dopt.favouriteFiles = GsCollectionUtils.union(_dopt.favouriteFiles, currentSelection);
+                    _appSettings.setFavouriteFiles(_dopt.favouriteFiles);
                     updateMenuItems();
                 }
                 return true;
             }
             case R.id.action_favourite_remove: {
                 if (_filesystemViewerAdapter.areItemsSelected()) {
-                    _appSettings.setFavouriteFiles(GsCollectionUtils.setDiff(_dopt.favouriteFiles, currentSelection));
+                    _dopt.favouriteFiles = GsCollectionUtils.setDiff(_dopt.favouriteFiles, currentSelection);
+                    _appSettings.setFavouriteFiles(_dopt.favouriteFiles);
                     updateMenuItems();
                 }
                 return true;

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
@@ -236,7 +236,7 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
         boolean selDirectoriesOnly = true;
         boolean selWritable = (!curFilepath.equals("/storage") && !curFilepath.equals("/storage/emulated"));
         boolean allSelectedFav = true;
-        final Collection<File> favFiles = _dopt.favouriteFiles != null ? _dopt.favouriteFiles : Collections.emptySet();
+        final Collection<File> favFiles = _appSettings.getFavouriteFiles();
         for (final File f : selFiles) {
             selTextFilesOnly &= FormatRegistry.isFileSupported(f, true);
             selWritable &= f.canWrite();
@@ -463,7 +463,6 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
                     final Set<File> favs = _appSettings.getFavouriteFiles();
                     favs.addAll(currentSelection);
                     _appSettings.setFavouriteFiles(favs);
-                    _dopt.favouriteFiles = favs;
                     updateMenuItems();
                 }
                 return true;
@@ -473,7 +472,6 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
                     final Set<File> favs = _appSettings.getFavouriteFiles();
                     favs.removeAll(currentSelection);
                     _appSettings.setFavouriteFiles(favs);
-                    _dopt.favouriteFiles = favs;
                     updateMenuItems();
                 }
                 return true;

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
@@ -49,6 +49,7 @@ import net.gsantner.markor.model.AppSettings;
 import net.gsantner.markor.util.MarkorContextUtils;
 import net.gsantner.opoc.frontend.base.GsFragmentBase;
 import net.gsantner.opoc.model.GsSharedPreferencesPropertyBackend;
+import net.gsantner.opoc.util.GsCollectionUtils;
 import net.gsantner.opoc.util.GsContextUtils;
 import net.gsantner.opoc.util.GsFileUtils;
 
@@ -86,7 +87,6 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
     private GsFileBrowserListAdapter _filesystemViewerAdapter;
     private GsFileBrowserOptions.Options _dopt;
     private GsFileBrowserOptions.SelectionListener _callback;
-    private boolean firstResume = true;
     private AppSettings _appSettings;
     private Menu _fragmentMenu;
     private MarkorContextUtils _cu;
@@ -120,7 +120,6 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
         LinearLayoutManager lam = (LinearLayoutManager) _recyclerList.getLayoutManager();
         DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(activity, lam.getOrientation());
         _recyclerList.addItemDecoration(dividerItemDecoration);
-        _previousNotebookDirectory = _appSettings.getNotebookDirectory();
 
         _filesystemViewerAdapter = new GsFileBrowserListAdapter(_dopt, context);
         _recyclerList.setAdapter(_filesystemViewerAdapter);
@@ -236,7 +235,7 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
         boolean selDirectoriesOnly = true;
         boolean selWritable = (!curFilepath.equals("/storage") && !curFilepath.equals("/storage/emulated"));
         boolean allSelectedFav = true;
-        final Collection<File> favFiles = _appSettings.getFavouriteFiles();
+        final Collection<File> favFiles = _dopt.favouriteFiles != null ? _dopt.favouriteFiles : Collections.emptySet();
         for (final File f : selFiles) {
             selTextFilesOnly &= FormatRegistry.isFileSupported(f, true);
             selWritable &= f.canWrite();
@@ -311,24 +310,12 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
         _filesystemViewerAdapter.restoreSavedInstanceState(savedInstanceState);
     }
 
-    private static File _previousNotebookDirectory;
-
     @Override
     public void onResume() {
         super.onResume();
-        if (!_appSettings.getNotebookDirectory().equals(_previousNotebookDirectory)) {
-            _dopt.rootFolder = _appSettings.getNotebookDirectory();
-            _filesystemViewerAdapter.setCurrentFolder(_dopt.rootFolder);
+        if (_dopt.refresh != null) {
+            _dopt.refresh.callback();
         }
-
-        if (!firstResume) {
-            if (_filesystemViewerAdapter.getCurrentFolder() != null) {
-                _filesystemViewerAdapter.reloadCurrentFolder();
-            }
-        }
-
-        onFsViewerDoUiUpdate(_filesystemViewerAdapter);
-        firstResume = false;
 
         final File folder = getCurrentFolder();
         final Activity activity = getActivity();
@@ -337,7 +324,6 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
             reloadCurrentFolder();
         }
     }
-
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
@@ -397,31 +383,31 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
             case R.id.action_sort_by_name: {
                 item.setChecked(true);
                 _dopt.sortByType = _appSettings.setFileBrowserSortByType(GsFileUtils.SORT_BY_NAME);
-                sortAdapter();
+                reloadCurrentFolder();
                 return true;
             }
             case R.id.action_sort_by_date: {
                 item.setChecked(true);
                 _dopt.sortByType = _appSettings.setFileBrowserSortByType(GsFileUtils.SORT_BY_MTIME);
-                sortAdapter();
+                reloadCurrentFolder();
                 return true;
             }
             case R.id.action_sort_by_filesize: {
                 item.setChecked(true);
                 _dopt.sortByType = _appSettings.setFileBrowserSortByType(GsFileUtils.SORT_BY_FILESIZE);
-                sortAdapter();
+                reloadCurrentFolder();
                 return true;
             }
             case R.id.action_sort_by_mimetype: {
                 item.setChecked(true);
                 _dopt.sortByType = _appSettings.setFileBrowserSortByType(GsFileUtils.SORT_BY_MIMETYPE);
-                sortAdapter();
+                reloadCurrentFolder();
                 return true;
             }
             case R.id.action_sort_reverse: {
                 item.setChecked(!item.isChecked());
                 _dopt.sortReverse = _appSettings.setFileBrowserSortReverse(item.isChecked());
-                sortAdapter();
+                reloadCurrentFolder();
                 return true;
             }
             case R.id.action_show_dotfiles: {
@@ -441,7 +427,7 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
             case R.id.action_folder_first: {
                 item.setChecked(!item.isChecked());
                 _dopt.sortFolderFirst = _appSettings.setFileBrowserSortFolderFirst(item.isChecked());
-                sortAdapter();
+                reloadCurrentFolder();
                 return true;
             }
             case R.id.action_go_to_home:
@@ -460,18 +446,14 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
             }
             case R.id.action_favourite: {
                 if (_filesystemViewerAdapter.areItemsSelected()) {
-                    final Set<File> favs = _appSettings.getFavouriteFiles();
-                    favs.addAll(currentSelection);
-                    _appSettings.setFavouriteFiles(favs);
+                    _appSettings.setFavouriteFiles(GsCollectionUtils.union(_dopt.favouriteFiles, currentSelection));
                     updateMenuItems();
                 }
                 return true;
             }
             case R.id.action_favourite_remove: {
                 if (_filesystemViewerAdapter.areItemsSelected()) {
-                    final Set<File> favs = _appSettings.getFavouriteFiles();
-                    favs.removeAll(currentSelection);
-                    _appSettings.setFavouriteFiles(favs);
+                    _appSettings.setFavouriteFiles(GsCollectionUtils.setDiff(_dopt.favouriteFiles, currentSelection));
                     updateMenuItems();
                 }
                 return true;
@@ -553,10 +535,6 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
                 _filesystemViewerAdapter.showFile(load);
             }
         });
-    }
-
-    public void sortAdapter() {
-        reloadCurrentFolder();
     }
 
     public void clearSelection() {

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
@@ -89,6 +89,7 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
     private final SharedPreferences _prefApp;
     private final HashMap<File, File> _virtualMapping = new HashMap<>();
     private final Map<File, Integer> _fileIdMap = new HashMap<>();
+    private GsCallback.a0 _blinkCallback;
 
     //########################
     //## Methods
@@ -598,7 +599,7 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
             _recyclerView.postDelayed(() -> {
                 final RecyclerView.ViewHolder holder = _recyclerView.findViewHolderForLayoutPosition(pos);
                 if (holder != null) {
-                    GsContextUtils.blinkView(holder.itemView);
+                    _blinkCallback = GsContextUtils.blinkView(holder.itemView);
                 }
             }, 250);
         }
@@ -619,7 +620,16 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
 
     private static final ExecutorService executorService = new ThreadPoolExecutor(0, 3, 60, TimeUnit.SECONDS, new SynchronousQueue<>());
 
+    // Stop blinking if we are currently blinking
+    private void stopBlinking() {
+        if (_blinkCallback != null) {
+            _blinkCallback.callback();
+            _blinkCallback = null;
+        }
+    }
+
     private void loadFolder(final File folder) {
+        stopBlinking();
         executorService.execute(() -> {
             synchronized (LOAD_FOLDER_SYNC_OBJECT) {
 

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
@@ -556,7 +556,7 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
         });
     }
 
-                              // Switch to folder and show the file
+    // Switch to folder and show the file
     public void showFile(final File file) {
         if (file == null || !file.exists() || _recyclerView == null) {
             return;

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserListAdapter.java
@@ -37,6 +37,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import net.gsantner.markor.R;
 import net.gsantner.markor.frontend.textview.TextViewUtils;
+import net.gsantner.markor.model.AppSettings;
 import net.gsantner.opoc.util.GsCollectionUtils;
 import net.gsantner.opoc.util.GsContextUtils;
 import net.gsantner.opoc.util.GsFileUtils;
@@ -46,6 +47,8 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -87,6 +90,7 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
     private final SharedPreferences _prefApp;
     private final HashMap<File, File> _virtualMapping = new HashMap<>();
     private final Map<File, Integer> _fileIdMap = new HashMap<>();
+    private Collection<File> _favouriteFiles, _recentFiles, _popularFiles;
 
     //########################
     //## Methods
@@ -156,8 +160,8 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
         final File descriptionFile = file.equals(_currentFolder.getParentFile()) ? file : fileParent;
         final boolean isGoUp = file.equals(_currentFolder.getParentFile());
         final boolean isSelected = _currentSelection.contains(file);
-        final boolean isFavourite = _dopt.favouriteFiles != null && _dopt.favouriteFiles.contains(file);
-        final boolean isPopular = _dopt.popularFiles != null && _dopt.popularFiles.contains(file);
+        final boolean isFavourite = _favouriteFiles != null && _favouriteFiles.contains(file);
+        final boolean isPopular = _popularFiles != null && _popularFiles.contains(file);
         final int descriptionRes = isSelected ? _dopt.contentDescriptionSelected : (file.isDirectory() ? _dopt.contentDescriptionFolder : _dopt.contentDescriptionFile);
         String titleText = filename;
         if (isCurrentFolderVirtual() && "index.html".equals(filename)) {
@@ -626,6 +630,10 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
                 _virtualMapping.clear();
                 final List<File> newData = new ArrayList<>();
 
+                _recentFiles = _dopt.getRecentFiles != null ? _dopt.getRecentFiles.callback() : Collections.emptyList();
+                _popularFiles = _dopt.getPopularFiles != null ? _dopt.getPopularFiles.callback(): Collections.emptyList();
+                _favouriteFiles = _dopt.getFavouriteFiles != null ? _dopt.getFavouriteFiles.callback() : Collections.emptyList();
+
                 if (folder.equals(VIRTUAL_STORAGE_ROOT)) {
                     // Scan for /storage/emulated/{0,1,2,..}
                     for (int i = 0; i < 10; i++) {
@@ -639,15 +647,15 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
                         }
                     }
 
-                    if (_dopt.recentFiles != null) {
+                    if (_dopt.getRecentFiles != null) {
                         _virtualMapping.put(VIRTUAL_STORAGE_RECENTS, VIRTUAL_STORAGE_RECENTS);
                         newData.add(VIRTUAL_STORAGE_RECENTS);
                     }
-                    if (_dopt.popularFiles != null) {
+                    if (_dopt.getPopularFiles != null) {
                         _virtualMapping.put(VIRTUAL_STORAGE_POPULAR, VIRTUAL_STORAGE_POPULAR);
                         newData.add(VIRTUAL_STORAGE_POPULAR);
                     }
-                    if (_dopt.favouriteFiles != null) {
+                    if (_dopt.getFavouriteFiles != null) {
                         _virtualMapping.put(VIRTUAL_STORAGE_FAVOURITE, VIRTUAL_STORAGE_FAVOURITE);
                         newData.add(VIRTUAL_STORAGE_FAVOURITE);
                     }
@@ -659,11 +667,11 @@ public class GsFileBrowserListAdapter extends RecyclerView.Adapter<GsFileBrowser
                 } else if (_currentFolder.isDirectory()) {
                     GsCollectionUtils.addAll(newData, _currentFolder.listFiles(GsFileBrowserListAdapter.this));
                 } else if (_currentFolder.equals(VIRTUAL_STORAGE_RECENTS)) {
-                    newData.addAll(_dopt.recentFiles);
+                    newData.addAll(_recentFiles);
                 } else if (_currentFolder.equals(VIRTUAL_STORAGE_POPULAR)) {
-                    newData.addAll(_dopt.popularFiles);
+                    newData.addAll(_popularFiles);
                 } else if (_currentFolder.equals(VIRTUAL_STORAGE_FAVOURITE)) {
-                    GsCollectionUtils.addAll(newData, _dopt.favouriteFiles);
+                    newData.addAll(_favouriteFiles);
                 } else if (folder.getAbsolutePath().equals("/storage/emulated")) {
                     newData.add(new File(folder, "0"));
                 } else if (folder.getAbsolutePath().equals("/")) {

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserOptions.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserOptions.java
@@ -117,7 +117,7 @@ public class GsFileBrowserOptions {
         @ColorRes
         public int titleTextColor = 0;
 
-        public Collection<File> favouriteFiles, recentFiles, popularFiles = null;
+        public GsCallback.r0<Collection<File>> getFavouriteFiles, getRecentFiles, getPopularFiles = null;
         public GsCallback.a1<CharSequence> setTitle = null, setSubtitle = null;
     }
 

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserOptions.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserOptions.java
@@ -22,6 +22,8 @@ import net.gsantner.opoc.wrapper.GsCallback;
 import java.io.File;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class GsFileBrowserOptions {
@@ -117,8 +119,10 @@ public class GsFileBrowserOptions {
         @ColorRes
         public int titleTextColor = 0;
 
-        public GsCallback.r0<Collection<File>> getFavouriteFiles, getRecentFiles, getPopularFiles = null;
+        public Collection<File> favouriteFiles, recentFiles, popularFiles = null;
         public GsCallback.a1<CharSequence> setTitle = null, setSubtitle = null;
+
+        public GsCallback.a0 refresh = null;
     }
 
     public static class SelectionListenerAdapter implements SelectionListener, Serializable {

--- a/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsContextUtils.java
@@ -2880,10 +2880,38 @@ public class GsContextUtils {
         return false;
     }
 
-    public static void blinkView(final View view) {
-        if (view != null) {
-            ObjectAnimator.ofFloat(view, View.ALPHA, 1.0f, 0.1f, 1.0f, 0.1f, 1.0f).setDuration(800).start();
+    /**
+     * Blinks the view passed in as parameter
+     * @param view View to be blinked
+     * @return A callback to terminate the blinking
+     */
+    public static @Nullable GsCallback.a0 blinkView(final View view) {
+
+        if (view == null) {
+            return null;
         }
+
+        final ObjectAnimator animator = ObjectAnimator.ofFloat(
+                view, View.ALPHA, 1.0f, 0.1f, 1.0f, 0.1f, 1.0f)
+                .setDuration(800);
+        animator.addListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                view.setAlpha(1.0f);
+            }
+        });
+
+        final WeakReference<ObjectAnimator> animatorRef = new WeakReference<>(animator);
+        final GsCallback.a0 terminateCallback = () -> {
+            final ObjectAnimator a = animatorRef.get();
+            if (a != null) {
+                a.cancel();
+            }
+        };
+
+        animator.start();
+
+        return terminateCallback;
     }
 
     public static boolean fadeInOut(final View in, final View out, final boolean animate) {

--- a/app/src/main/res/layout/new_file_dialog.xml
+++ b/app/src/main/res/layout/new_file_dialog.xml
@@ -40,7 +40,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="-10dp"
+            android:layout_marginTop="-5dp"
             android:orientation="horizontal"
             android:weightSum="100">
 
@@ -50,7 +50,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:layout_weight="70"
-                android:hint="{{date}}"
+                android:hint="@string/title"
                 android:importantForAutofill="no"
                 android:singleLine="true"
                 android:textAppearance="@style/TextAppearance.AppCompat.Caption"
@@ -63,8 +63,8 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:layout_marginEnd="32dp"
-                android:layout_marginRight="32dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
                 android:layout_weight="30"
                 android:gravity="end"
                 android:hint=".md"
@@ -76,6 +76,53 @@
                 tools:ignore="HardcodedText"
                 tools:text=".md" />
         </LinearLayout>
+
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:ellipsize="end"
+            android:lines="1"
+            android:text="@string/format"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="-5dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginRight="16dp"
+            android:orientation="horizontal"
+            android:weightSum="100">
+
+            <EditText
+                android:id="@+id/new_file_dialog__name_format"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:hint="{{title}}"
+                android:importantForAutofill="no"
+                android:singleLine="true"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                android:textSize="15sp"
+                tools:ignore="HardcodedText,TextFields"/>
+
+            <TextView
+                android:id="@+id/new_file_dialog__name_format_spinner"
+                style="@style/Base.Widget.AppCompat.Spinner"
+                android:layout_width="60dp"
+                android:layout_height="match_parent"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_centerInParent="true"
+                android:layout_gravity="center_vertical"
+                android:layout_marginRight="-16dp"
+                android:layout_marginEnd="-16dp"
+                android:contentDescription="@string/choose_format"
+                android:inputType="none" />
+
+        </RelativeLayout>
 
 
         <TextView

--- a/app/src/main/res/layout/new_file_dialog.xml
+++ b/app/src/main/res/layout/new_file_dialog.xml
@@ -11,7 +11,6 @@
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/new_file_dialog__root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -51,17 +50,21 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:layout_weight="70"
-                android:hint="@string/my_note"
+                android:hint="{{date}}"
                 android:importantForAutofill="no"
                 android:singleLine="true"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption"
                 android:textSize="15sp"
-                tools:ignore="TextFields" />
+                tools:ignore="HardcodedText,TextFields"/>
+
 
             <EditText
                 android:id="@+id/new_file_dialog__ext"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
+                android:layout_marginEnd="32dp"
+                android:layout_marginRight="32dp"
                 android:layout_weight="30"
                 android:gravity="end"
                 android:hint=".md"
@@ -70,55 +73,26 @@
                 android:lines="1"
                 android:textAppearance="@style/TextAppearance.AppCompat.Caption"
                 android:textSize="15sp"
-                tools:text=".md"
-                tools:ignore="HardcodedText" />
+                tools:ignore="HardcodedText"
+                tools:text=".md" />
         </LinearLayout>
 
-       <LinearLayout
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginTop="8dp"
+            android:ellipsize="end"
+            android:lines="1"
+            android:text="@string/type"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+        <view class="net.gsantner.markor.frontend.NewFileDialog$ReselectSpinner"
+            android:id="@+id/new_file_dialog__type"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:weightSum="100">
-
-           <com.google.android.material.textfield.TextInputLayout
-               style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.ExposedDropdownMenu"
-               android:id="@+id/new_file_dialog__title_format_holder"
-               android:layout_width="0dp"
-               android:layout_height="match_parent"
-               android:layout_weight="60"
-               android:hint="@string/format">
-
-                <AutoCompleteTextView
-                    android:id="@+id/new_file_dialog__title_format"
-                    android:layout_width="match_parent"
-                    android:layout_marginRight="10dp"
-                    android:layout_marginEnd="10dp"
-                    android:layout_height="match_parent"
-                    android:layout_gravity="center_vertical"
-                    android:importantForAutofill="no"
-                    android:lines="1"
-                    android:textSize="15sp"
-                    android:hint="{{date}}_{{title}}"
-                    tools:ignore="HardcodedText"/>
-
-           </com.google.android.material.textfield.TextInputLayout>
-
-           <Spinner
-               android:id="@+id/new_file_dialog__type"
-               android:drawSelectorOnTop="true"
-               android:layout_width="0dp"
-               android:layout_height="match_parent"
-               android:layout_gravity="center_vertical"
-               android:layout_marginEnd="-10dp"
-               android:layout_marginRight="-10dp"
-               android:layout_weight="40"
-               android:gravity="end"
-               android:importantForAutofill="no"
-               android:lines="1"
-               android:textSize="15sp" />
-
-       </LinearLayout>
-
+            android:drawSelectorOnTop="true"/>
 
         <TextView
             android:layout_width="wrap_content"
@@ -134,8 +108,7 @@
             android:id="@+id/new_file_dialog__template"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="15sp"
-            android:drawSelectorOnTop="true" />
+            android:drawSelectorOnTop="true"/>
 
         <CheckBox
             android:id="@+id/new_file_dialog__encrypt"

--- a/app/src/main/res/layout/new_file_dialog.xml
+++ b/app/src/main/res/layout/new_file_dialog.xml
@@ -11,6 +11,7 @@
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/new_file_dialog__root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -40,7 +41,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="-14dp"
+            android:layout_marginTop="-10dp"
             android:orientation="horizontal"
             android:weightSum="100">
 
@@ -53,18 +54,14 @@
                 android:hint="@string/my_note"
                 android:importantForAutofill="no"
                 android:singleLine="true"
-                android:textAppearance="@style/TextAppearance.AppCompat.Caption"
                 android:textSize="15sp"
                 tools:ignore="TextFields" />
-
 
             <EditText
                 android:id="@+id/new_file_dialog__ext"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:layout_marginEnd="32dp"
-                android:layout_marginRight="32dp"
                 android:layout_weight="30"
                 android:gravity="end"
                 android:hint=".md"
@@ -73,27 +70,55 @@
                 android:lines="1"
                 android:textAppearance="@style/TextAppearance.AppCompat.Caption"
                 android:textSize="15sp"
-                tools:ignore="HardcodedText"
-                tools:text=".md" />
+                tools:text=".md"
+                tools:ignore="HardcodedText" />
         </LinearLayout>
 
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginTop="8dp"
-            android:ellipsize="end"
-            android:lines="1"
-            android:text="@string/type"
-            android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
-
-        <Spinner
-            android:id="@+id/new_file_dialog__type"
+       <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:drawSelectorOnTop="true"
-            android:entries="@array/new_file_types" />
+            android:orientation="horizontal"
+            android:weightSum="100">
+
+           <com.google.android.material.textfield.TextInputLayout
+               style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.ExposedDropdownMenu"
+               android:id="@+id/new_file_dialog__title_format_holder"
+               android:layout_width="0dp"
+               android:layout_height="match_parent"
+               android:layout_weight="60"
+               android:hint="@string/format">
+
+                <AutoCompleteTextView
+                    android:id="@+id/new_file_dialog__title_format"
+                    android:layout_width="match_parent"
+                    android:layout_marginRight="10dp"
+                    android:layout_marginEnd="10dp"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center_vertical"
+                    android:importantForAutofill="no"
+                    android:lines="1"
+                    android:textSize="15sp"
+                    android:hint="{{date}}_{{title}}"
+                    tools:ignore="HardcodedText"/>
+
+           </com.google.android.material.textfield.TextInputLayout>
+
+           <Spinner
+               android:id="@+id/new_file_dialog__type"
+               android:drawSelectorOnTop="true"
+               android:layout_width="0dp"
+               android:layout_height="match_parent"
+               android:layout_gravity="center_vertical"
+               android:layout_marginEnd="-10dp"
+               android:layout_marginRight="-10dp"
+               android:layout_weight="40"
+               android:gravity="end"
+               android:importantForAutofill="no"
+               android:lines="1"
+               android:textSize="15sp" />
+
+       </LinearLayout>
+
 
         <TextView
             android:layout_width="wrap_content"
@@ -109,8 +134,8 @@
             android:id="@+id/new_file_dialog__template"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:drawSelectorOnTop="true"
-            android:entries="@array/arr_file_templates" />
+            android:textSize="15sp"
+            android:drawSelectorOnTop="true" />
 
         <CheckBox
             android:id="@+id/new_file_dialog__encrypt"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -97,45 +97,6 @@
         <item translatable="false">@string/asciidoc_break_page</item>
     </string-array>
 
-    <string-array name="new_file_types" translatable="false">
-        <item translatable="false">@string/markdown</item>
-        <item translatable="false">@string/plaintext</item>
-        <item translatable="false">@string/todo_txt</item>
-        <item translatable="false">@string/wikitext</item>
-        <item translatable="false">@string/asciidoc</item>
-        <item translatable="false">@string/csv</item>
-        <item translatable="false">@string/orgmode</item>
-        <item translatable="false">@string/none</item>
-    </string-array>
-
-    <!-- arr_file_templates : add new templates always at the end and corresponding code to NewFileDialog.java : getTemplateContent() -->
-    <string-array name="arr_file_templates" translatable="false">
-        <item translatable="false">@string/empty_file</item>
-        <item translatable="false">@string/file_template__md_markor_markdown_reference</item>
-        <item translatable="false">@string/file_template__txt_todo_sample</item>
-        <item translatable="false">@string/file_template__md_jekyll_post</item>
-        <item translatable="false">@string/file_template__md_cooking_recipe</item>
-        <item translatable="false">@string/file_template__md_presentation_beamer</item>
-        <item translatable="false">@string/file_template__zim_wiki_reference</item>
-        <item translatable="false">@string/file_template__zim_wiki_empty</item>
-        <item translatable="false">@string/file_template__md_hugo_post_front_matter</item>
-        <item translatable="false">@string/file_template__md_zettelkasten</item>
-        <item translatable="false">@string/file_template__ad_jekyll_post</item>
-        <item translatable="false">@string/file_template__csv_sample</item>
-        <item translatable="false">@string/file_template__orgmode_reference</item>
-    </string-array>
-
-    <string-array name="new_file_types__file_extension" translatable="false">
-        <item translatable="false">.md</item>
-        <item translatable="false">.txt</item>
-        <item translatable="false">.todo.txt</item>
-        <item translatable="false">.txt</item>
-        <item translatable="false">.adoc</item>
-        <item translatable="false">.csv</item>
-        <item translatable="false">.org</item>
-        <item translatable="false" />
-    </string-array>
-
     <string-array name="pref_arrdisp__files_startup_folder" translatable="false">
         <item translatable="false">@string/notebook</item>
         <item translatable="false">@string/favourites</item>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -366,18 +366,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__open_links_with_chrome_custom_tabs" translatable="false">pref_key__open_links_with_chrome_custom_tabs</string>
     <string name="features" translatable="false">Features</string>
     <string name="chrome_custom_tabs" translatable="false">Chrome Custom Tabs</string>
-    <string name="file_template__md_markor_markdown_reference" translatable="false">markor-markdown-reference.md</string>
-    <string name="file_template__md_jekyll_post" translatable="false">2029-01-01-jekyll-post.md</string>
-    <string name="file_template__ad_jekyll_post" translatable="false">2029-01-01-jekyll-post.adoc</string>
-    <string name="file_template__md_zettelkasten" translatable="false">202901012359-zettelkasten.md</string>
-    <string name="file_template__md_cooking_recipe" translatable="false">cooking-recipe.md</string>
-    <string name="file_template__txt_todo_sample" translatable="false">todo.example.txt</string>
-    <string name="file_template__zim_wiki_reference" translatable="false">zim-wiki-reference.txt</string>
-    <string name="file_template__zim_wiki_empty" translatable="false">zim-wiki-empty.txt</string>
-    <string name="file_template__md_hugo_post_front_matter" translatable="false">hugo-post-front-matter.md</string>
-    <string name="file_template__md_presentation_beamer" translatable="false">presentation-beamer.md</string>
-    <string name="file_template__csv_sample" translatable="false">sample.csv</string>
-    <string name="file_template__orgmode_reference" translatable="false">orgmode-reference.org</string>
     <string name="asciidoc" translatable="false">AsciiDoc</string>
     <string name="key_value" translatable="false">Key - Value</string>
     <string name="ohm" translatable="false">Ohm (Ω)</string>
@@ -431,6 +419,9 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="action_format_orgmode" translatable="false">action_format_orgmode</string>
     <string name="pref_key__share_into_format" translatable="false">pref_key__share_into_format</string>
     <string name="pref_key__attachment_folder_name" translatable="false">pref_key__attachment_directory_name</string>
+    <string name="pref_key__filetype_template_map" translatable="false">pref_key__filetype_template_map</string>
+    <string name="pref_key__template_title_format_map" translatable="false">pref_key__template_title_format_map</string>
+    <string name="pref_key__title_format_list" translatable="false">pref_key__title_format_list</string>
     <string name="squarebrackets" translatable="false">Square Brackets</string>
     <string name="csv" translatable="false">CSV</string>
     <string name="orgmode" translatable="false">OrgMode</string>

--- a/app/thirdparty/java/other/writeily/widget/WrFilesWidgetFactory.java
+++ b/app/thirdparty/java/other/writeily/widget/WrFilesWidgetFactory.java
@@ -54,9 +54,9 @@ public class WrFilesWidgetFactory implements RemoteViewsService.RemoteViewsFacto
         final AppSettings as = ApplicationObject.settings();
 
         if (dir.equals(GsFileBrowserListAdapter.VIRTUAL_STORAGE_RECENTS)) {
-            _widgetFilesList.addAll(Arrays.asList(MarkorFileBrowserFactory.strlistToArray(ApplicationObject.settings().getRecentDocuments())));
+            _widgetFilesList.addAll(ApplicationObject.settings().getRecentFiles());
         } else if (dir.equals(GsFileBrowserListAdapter.VIRTUAL_STORAGE_POPULAR)) {
-            _widgetFilesList.addAll(Arrays.asList(MarkorFileBrowserFactory.strlistToArray(ApplicationObject.settings().getPopularDocuments())));
+            _widgetFilesList.addAll(ApplicationObject.settings().getPopularFiles());
         } else if (dir.equals(GsFileBrowserListAdapter.VIRTUAL_STORAGE_FAVOURITE)) {
             _widgetFilesList.addAll(ApplicationObject.settings().getFavouriteFiles());
         } else if (dir.exists() && dir.canRead()) {


### PR DESCRIPTION
In this PR I have added the ability to format at new file title similarly to how we format snippets.

Additionally, we now remember template and name format per file type.

This should 
- address #2225 (default note title is `yyyyMMddHHmmSS`)
- address #2217
- minimize #2199 
- Also includes an unrelated fix for #2153

EDIT:
I have merged in my open links in tags PR so more things have been pulled in here:

1. Open any link in an html tag (such as our audio attachment format)
2. Fixes for new files not showing when newfile dialog rotated
3. Tweaks to prevent screen flashing when file opened in view mode
