### PR TITLE
 Register chess extension (.fen) for plaintext, closes #2241

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextConverter.java
+++ b/app/src/main/java/net/gsantner/markor/format/plaintext/PlaintextTextConverter.java
@@ -28,9 +28,9 @@ import java.util.Locale;
 public class PlaintextTextConverter extends TextConverterBase {
     private static final String HTML100_BODY_PRE_BEGIN = "<pre style='white-space: pre-wrap;font-family: " + TOKEN_FONT + "' >";
     private static final String HTML101_BODY_PRE_END = "</pre>";
-    private static final List<String> EXT_TEXT = Arrays.asList(".txt", ".taskpaper", ".org", ".ldg", ".ledger", ".m3u", ".m3u8");
+    private static final List<String> EXT_TEXT = Arrays.asList(".txt", ".taskpaper", ".org", ".ldg", ".ledger", ".m3u", ".m3u8", ".lrc", ".fen");
     private static final List<String> EXT_HTML = Arrays.asList(".html", ".htm");
-    private static final List<String> EXT_CODE_HL = Arrays.asList(".py", ".cpp", ".h", ".c", ".js", ".mjs", ".css", ".cs", ".kt", ".lua", ".lrc", ".perl", ".java", ".qml", ".diff", ".php", ".r", ".patch", ".rs", ".swift", ".ts", ".mm", ".go", ".sh", ".rb", ".tex", ".xml", ".xlf");
+    private static final List<String> EXT_CODE_HL = Arrays.asList(".py", ".cpp", ".h", ".c", ".js", ".mjs", ".css", ".cs", ".kt", ".lua", ".perl", ".java", ".qml", ".diff", ".php", ".r", ".patch", ".rs", ".swift", ".ts", ".mm", ".go", ".sh", ".rb", ".tex", ".xml", ".xlf");
     private static final List<String> EXT = new ArrayList<>();
 
     static {


### PR DESCRIPTION
Register chess extension (.fen) for plaintext - https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation closes #2241
