### PR TITLE
FileManager: Remove top submenu to open special folders, load storage overview in filemanager instead

### DIFF
--- a/app/src/main/java/net/gsantner/markor/frontend/filebrowser/MarkorFileBrowserFactory.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/filebrowser/MarkorFileBrowserFactory.java
@@ -81,6 +81,9 @@ public class MarkorFileBrowserFactory {
             opts.favouriteFiles = appSettings.getFavouriteFiles();
             opts.recentFiles = appSettings.getRecentFiles();
             opts.popularFiles = appSettings.getPopularFiles();
+            opts.storageMaps.clear();
+            opts.storageMaps.put(new File("/storage", cu.rstr(context, R.string.notebook)), appSettings.getNotebookDirectory());
+            opts.storageMaps.put(new File("/storage/Download"), new File("/storage/emulated/0/Download"));
         };
         opts.refresh.callback();
 

--- a/app/src/main/java/net/gsantner/markor/model/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/model/AppSettings.java
@@ -746,59 +746,47 @@ public class AppSettings extends GsSharedPreferencesPropertyBackend {
         return getString(R.string.pref_key__navigationbar_color, "#000000");
     }
 
-    public @IdRes
-    Integer getAppStartupFolderMenuId() {
-        switch (getString(R.string.pref_key__app_start_folder, "notebook")) {
-            case "favourites":
-                return R.id.action_go_to_favourite_files;
-            case "internal_storage":
-                return R.id.action_go_to_storage;
-            case "appdata_public":
-                return R.id.action_go_to_appdata_public;
-            case "appdata_private":
-                return R.id.action_go_to_appdata_private;
-            case "popular_documents":
-                return R.id.action_go_to_popular_files;
-            case "recently_viewed_documents":
-                return R.id.action_go_to_recent_files;
-        }
-        return R.id.action_go_to_home;
+    public String getAppStartupFolderMenuId() {
+        return getString(R.string.pref_key__app_start_folder, "notebook");
     }
 
-    public File getFolderToLoadByMenuId(int itemId) {
+    public File getFolderToLoadByMenuId(String itemId) {
         List<Pair<File, String>> appDataPublicDirs = _cu.getAppDataPublicDirs(_context, false, true, false);
         switch (itemId) {
-            case R.id.action_go_to_home: {
+            case "storage": {
+                return new File("/storage");
+            }
+            case "notebook": {
                 return getNotebookDirectory();
             }
-            case R.id.action_go_to_popular_files: {
+            case "popular_documents": {
                 return GsFileBrowserListAdapter.VIRTUAL_STORAGE_POPULAR;
             }
-            case R.id.action_go_to_recent_files: {
+            case "recently_viewed_documents": {
                 return GsFileBrowserListAdapter.VIRTUAL_STORAGE_RECENTS;
             }
-            case R.id.action_go_to_favourite_files: {
+            case "favourites": {
                 return GsFileBrowserListAdapter.VIRTUAL_STORAGE_FAVOURITE;
             }
-            case R.id.action_go_to_appdata_private: {
+            case "appdata_private": {
                 return _cu.getAppDataPrivateDir(_context);
             }
-            case R.id.action_go_to_storage: {
+            case "internal_storage": {
                 return Environment.getExternalStorageDirectory();
             }
-            case R.id.action_go_to_appdata_sdcard_1: {
+            case "appdata_sdcard_1": {
                 if (appDataPublicDirs.size() > 0) {
                     return appDataPublicDirs.get(0).first;
                 }
                 return Environment.getExternalStorageDirectory();
             }
-            case R.id.action_go_to_appdata_sdcard_2: {
+            case "appdata_sdcard_2": {
                 if (appDataPublicDirs.size() > 1) {
                     return appDataPublicDirs.get(1).first;
                 }
                 return Environment.getExternalStorageDirectory();
             }
-            case R.id.action_go_to_appdata_public: {
+            case "appdata_public": {
                 appDataPublicDirs = _cu.getAppDataPublicDirs(_context, true, false, false);
                 if (appDataPublicDirs.size() > 0) {
                     return appDataPublicDirs.get(0).first;

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserFragment.java
@@ -356,7 +356,7 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
         }
 
         List<Pair<File, String>> sdcardFolders = _cu.getAppDataPublicDirs(getContext(), false, true, true);
-        int[] sdcardResIds = {R.id.action_go_to_appdata_sdcard_1, R.id.action_go_to_appdata_sdcard_2};
+        int[] sdcardResIds = {};
         for (int i = 0; i < sdcardResIds.length && i < sdcardFolders.size(); i++) {
             item = menu.findItem(sdcardResIds[i]);
             item.setTitle(item.getTitle().toString().replaceFirst("[)]\\s*$", " " + sdcardFolders.get(i).second) + ")");
@@ -432,16 +432,8 @@ public class GsFileBrowserFragment extends GsFragmentBase<GsSharedPreferencesPro
                 reloadCurrentFolder();
                 return true;
             }
-            case R.id.action_go_to_home:
-            case R.id.action_go_to_popular_files:
-            case R.id.action_go_to_recent_files:
-            case R.id.action_go_to_favourite_files:
-            case R.id.action_go_to_appdata_private:
-            case R.id.action_go_to_storage:
-            case R.id.action_go_to_appdata_sdcard_1:
-            case R.id.action_go_to_appdata_sdcard_2:
-            case R.id.action_go_to_appdata_public: {
-                final File folder = _appSettings.getFolderToLoadByMenuId(_id);
+            case R.id.action_go_to: {
+                final File folder = new File("/storage");
                 _filesystemViewerAdapter.setCurrentFolder(folder);
                 Toast.makeText(getContext(), folder.getAbsolutePath(), Toast.LENGTH_SHORT).show();
                 return true;

--- a/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserOptions.java
+++ b/app/src/main/java/net/gsantner/opoc/frontend/filebrowser/GsFileBrowserOptions.java
@@ -22,6 +22,7 @@ import net.gsantner.opoc.wrapper.GsCallback;
 import java.io.File;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.HashMap;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class GsFileBrowserOptions {
@@ -122,6 +123,7 @@ public class GsFileBrowserOptions {
         @ColorRes
         public int folderColor = 0;
 
+        public final HashMap<File, File> storageMaps = new HashMap<>();
         public Collection<File> favouriteFiles, recentFiles, popularFiles = null;
         public GsCallback.a1<CharSequence> setTitle = null, setSubtitle = null;
 

--- a/app/src/main/res/menu/filesystem__menu.xml
+++ b/app/src/main/res/menu/filesystem__menu.xml
@@ -72,63 +72,13 @@
         android:title="@string/share"
         android:visible="false"
         app:showAsAction="never" />
+
     <item
         android:id="@+id/action_go_to"
         android:layout_width="match_parent"
         android:icon="@drawable/ic_folder_white_24dp"
         android:title="@string/go_to"
-        app:showAsAction="always">
-
-        <menu>
-            <item
-                android:id="@+id/action_go_to_appdata_sdcard_1"
-                android:icon="@drawable/ic_sd_card_black_24dp"
-                android:title="@string/appdata_sdcard"
-                android:visible="false"
-                app:showAsAction="never" />
-            <item
-                android:id="@+id/action_go_to_appdata_sdcard_2"
-                android:icon="@drawable/ic_sd_card_black_24dp"
-                android:title="@string/appdata_sdcard"
-                android:visible="false"
-                app:showAsAction="never" />
-            <item
-                android:id="@+id/action_go_to_appdata_private"
-                android:icon="@drawable/ic_lock_outline_black_24dp"
-                android:title="@string/appdata_private"
-                app:showAsAction="never" />
-            <item
-                android:id="@+id/action_go_to_appdata_public"
-                android:icon="@drawable/ic_lock_outline_black_24dp"
-                android:title="@string/appdata_public"
-                app:showAsAction="never" />
-            <item
-                android:id="@+id/action_go_to_storage"
-                android:icon="@drawable/ic_storage_black_24dp"
-                android:title="@string/internal_storage"
-                app:showAsAction="never" />
-            <item
-                android:id="@+id/action_go_to_recent_files"
-                android:icon="@drawable/ic_history_black_24dp"
-                android:title="@string/recently_viewed_documents"
-                app:showAsAction="never" />
-            <item
-                android:id="@+id/action_go_to_popular_files"
-                android:icon="@drawable/ic_favorite_black_24dp"
-                android:title="@string/popular_documents"
-                app:showAsAction="never" />
-            <item
-                android:id="@+id/action_go_to_favourite_files"
-                android:icon="@drawable/ic_star_black_24dp"
-                android:title="@string/favourites"
-                app:showAsAction="never" />
-            <item
-                android:id="@+id/action_go_to_home"
-                android:icon="@drawable/ic_home_black_24dp"
-                android:title="@string/notebook"
-                app:showAsAction="never" />
-        </menu>
-    </item>
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/action_sort"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -106,6 +106,7 @@
         <item translatable="false">@string/appdata_private</item>
         <item translatable="false">@string/popular_documents</item>
         <item translatable="false">@string/recently_viewed_documents</item>
+        <item translatable="false">@string/storage</item>
     </string-array>
 
     <string-array name="pref_arrkeys__files_startup_folder" translatable="false">
@@ -116,6 +117,7 @@
         <item translatable="false">appdata_private</item>
         <item translatable="false">popular_documents</item>
         <item translatable="false">recently_viewed_documents</item>
+        <item translatable="false">storage</item>
     </string-array>
 
     <string-array name="pref_arrdisp__unordered_list_character" translatable="false">

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -183,7 +183,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__editor_markdown_bigger_headings_2" translatable="false">pref_key__editor_markdown_bigger_headings_2</string>
     <string name="pref_key__editor_unordered_list_character" translatable="false">pref_key__editor_unordered_list_character</string>
     <string name="pref_key__recent_documents" translatable="false">pref_key__recent_documents</string>
-    <string name="pref_key__storage" translatable="false">pref_key__recent_documents</string>
     <string name="pref_key__popular_documents" translatable="false">pref_key__popular_documents</string>
     <string name="pref_key__favourite_files" translatable="false">pref_key__favourite_files</string>
     <string name="pref_key__select_create_document" translatable="false">pref_key__select_create_document</string>
@@ -424,7 +423,6 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__template_title_format_map" translatable="false">pref_key__template_title_format_map</string>
     <string name="pref_key__title_format_list" translatable="false">pref_key__title_format_list</string>
     <string name="pref_key__format_share_as_link" translatable="false">pref_key__format_share_as_link</string>
-    <string name="action_go_to_storage" translatable="false">action_go_to_storage</string>
     <string name="squarebrackets" translatable="false">Square Brackets</string>
     <string name="csv" translatable="false">CSV</string>
     <string name="orgmode" translatable="false">OrgMode</string>

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -40,6 +40,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="quicknote" translatable="false">QuickNote</string>
     <string name="todo" translatable="false">To-Do</string>
     <string name="todo_txt" translatable="false">todo.txt</string>
+    <string name="storage" translatable="false">Storage</string>
     <string name="quicknote_default_filename" translatable="false">QuickNote.md</string>
     <string name="todo_default_filename" translatable="false">todo.txt</string>
     <string name="web_browser" translatable="false">Web browser</string>
@@ -182,6 +183,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__editor_markdown_bigger_headings_2" translatable="false">pref_key__editor_markdown_bigger_headings_2</string>
     <string name="pref_key__editor_unordered_list_character" translatable="false">pref_key__editor_unordered_list_character</string>
     <string name="pref_key__recent_documents" translatable="false">pref_key__recent_documents</string>
+    <string name="pref_key__storage" translatable="false">pref_key__recent_documents</string>
     <string name="pref_key__popular_documents" translatable="false">pref_key__popular_documents</string>
     <string name="pref_key__favourite_files" translatable="false">pref_key__favourite_files</string>
     <string name="pref_key__select_create_document" translatable="false">pref_key__select_create_document</string>
@@ -422,6 +424,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="pref_key__template_title_format_map" translatable="false">pref_key__template_title_format_map</string>
     <string name="pref_key__title_format_list" translatable="false">pref_key__title_format_list</string>
     <string name="pref_key__format_share_as_link" translatable="false">pref_key__format_share_as_link</string>
+    <string name="action_go_to_storage" translatable="false">action_go_to_storage</string>
     <string name="squarebrackets" translatable="false">Square Brackets</string>
     <string name="csv" translatable="false">CSV</string>
     <string name="orgmode" translatable="false">OrgMode</string>


### PR DESCRIPTION
* Remove top menu submenu  to open special folders, go to virtual storage directory folder instead
* There all special folders/devices/lists are available too, and only needs to be maintained at one location then
* this way less duplication of those options, and all of them are available outside mainactivity too


![screenshot-2024-10-14__01-22-56-append](https://github.com/user-attachments/assets/e18717d2-b904-4946-935c-ca470750d541)
