### PR TITLE
orgmode: add more text styling syntax and buttons

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeActionButtons.java
@@ -30,7 +30,12 @@ public class OrgmodeActionButtons extends ActionButtonBase {
                 new ActionItem(R.string.abid_common_deindent, R.drawable.ic_format_indent_decrease_black_24dp, R.string.deindent),
                 new ActionItem(R.string.abid_common_insert_link, R.drawable.ic_link_black_24dp, R.string.insert_link),
                 new ActionItem(R.string.abid_common_insert_image, R.drawable.ic_image_black_24dp, R.string.insert_image),
-                new ActionItem(R.string.abid_common_insert_audio, R.drawable.ic_keyboard_voice_black_24dp, R.string.audio)
+                new ActionItem(R.string.abid_common_insert_audio, R.drawable.ic_keyboard_voice_black_24dp, R.string.audio),
+                new ActionItem(R.string.abid_orgmode_bold, R.drawable.ic_format_bold_black_24dp, R.string.bold),
+                new ActionItem(R.string.abid_orgmode_italic, R.drawable.ic_format_italic_black_24dp, R.string.italic),
+                new ActionItem(R.string.abid_orgmode_strikeout, R.drawable.ic_format_strikethrough_black_24dp, R.string.strikeout),
+                new ActionItem(R.string.abid_orgmode_underline, R.drawable.ic_format_underlined_black_24dp, R.string.underline),
+                new ActionItem(R.string.abid_orgmode_code_inline, R.drawable.ic_code_black_24dp, R.string.inline_code)
         );
     }
 
@@ -44,5 +49,34 @@ public class OrgmodeActionButtons extends ActionButtonBase {
     protected void renumberOrderedList() {
         // Use markdown format for orgmode too
         AutoTextFormatter.renumberOrderedList(_hlEditor.getText(), MarkdownReplacePatternGenerator.formatPatterns);
+    }
+
+    @Override
+    public boolean onActionClick(final @StringRes int action) {
+        switch (action) {
+            case R.string.abid_orgmode_bold: {
+                runSurroundAction("*");
+                return true;
+            }
+            case R.string.abid_orgmode_italic: {
+                runSurroundAction("/");
+                return true;
+            }
+            case R.string.abid_orgmode_strikeout: {
+                runSurroundAction("+");
+                return true;
+            }
+            case R.string.abid_orgmode_underline: {
+                runSurroundAction("_");
+                return true;
+            }
+            case R.string.abid_orgmode_code_inline: {
+                runSurroundAction("=");
+                return true;
+            }
+            default: {
+                return runCommonAction(action);
+            }
+        }
     }
 }

--- a/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeSyntaxHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeSyntaxHighlighter.java
@@ -11,11 +11,11 @@ import java.util.regex.Pattern;
 
 public class OrgmodeSyntaxHighlighter extends SyntaxHighlighterBase {
     public final static String COMMON_EMPHASIS_PATTERN = "(?<=(\\n|^|\\s|\\{|\\())([%s])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))";
-    public final static Pattern BOLD = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\*"));
-    public final static Pattern ITALICS = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\/"));
-    public final static Pattern STRIKETHROUGH = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\+"));
-    public final static Pattern UNDERLINE = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\_"));
-    public final static Pattern CODE_INLINE = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\=~"));
+    public final static Pattern BOLD = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "*"));
+    public final static Pattern ITALICS = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "/"));
+    public final static Pattern STRIKETHROUGH = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "+"));
+    public final static Pattern UNDERLINE = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "_"));
+    public final static Pattern CODE_INLINE = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "=~"));
     public final static Pattern HEADING = Pattern.compile("(?m)^(\\*+)\\s(.*?)(?=\\n|$)");
     public final static Pattern BLOCK = Pattern.compile("(?m)(?<=#\\+BEGIN_.{1,15}$\\s)[\\s\\S]*?(?=#\\+END)");
     public final static Pattern PREAMBLE = Pattern.compile("(?m)^(#\\+)(.*?)(?=\\n|$)");

--- a/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeSyntaxHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeSyntaxHighlighter.java
@@ -1,6 +1,8 @@
 package net.gsantner.markor.format.orgmode;
 
+import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Typeface;
 
 import net.gsantner.markor.frontend.textview.SyntaxHighlighterBase;
 import net.gsantner.markor.model.AppSettings;
@@ -9,6 +11,11 @@ import java.util.regex.Pattern;
 
 public class OrgmodeSyntaxHighlighter extends SyntaxHighlighterBase {
 
+    public final static Pattern BOLD = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([*])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
+    public final static Pattern ITALICS = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([/])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
+    public final static Pattern STRIKETHROUGH = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([+])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
+    public final static Pattern UNDERLINE = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([_])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
+    public final static Pattern CODE_INLINE = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([=~])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
     public final static Pattern HEADING = Pattern.compile("(?m)^(\\*+)\\s(.*?)(?=\\n|$)");
     public final static Pattern BLOCK = Pattern.compile("(?m)(?<=#\\+BEGIN_.{1,15}$\\s)[\\s\\S]*?(?=#\\+END)");
     public final static Pattern PREAMBLE = Pattern.compile("(?m)^(#\\+)(.*?)(?=\\n|$)");
@@ -44,6 +51,12 @@ public class OrgmodeSyntaxHighlighter extends SyntaxHighlighterBase {
         createColorSpanForMatches(PREAMBLE, ORG_COLOR_DIM);
         createColorSpanForMatches(COMMENT, ORG_COLOR_DIM);
         createColorBackgroundSpan(BLOCK, ORG_COLOR_BLOCK);
+
+        createStyleSpanForMatches(BOLD, Typeface.BOLD);
+        createStyleSpanForMatches(ITALICS, Typeface.ITALIC);
+        createStrikeThroughSpanForMatches(STRIKETHROUGH);
+        createColoredUnderlineSpanForMatches(UNDERLINE, Color.BLACK);
+        createMonospaceSpanForMatches(CODE_INLINE);
     }
 
 }

--- a/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeSyntaxHighlighter.java
+++ b/app/src/main/java/net/gsantner/markor/format/orgmode/OrgmodeSyntaxHighlighter.java
@@ -10,12 +10,12 @@ import net.gsantner.markor.model.AppSettings;
 import java.util.regex.Pattern;
 
 public class OrgmodeSyntaxHighlighter extends SyntaxHighlighterBase {
-
-    public final static Pattern BOLD = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([*])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
-    public final static Pattern ITALICS = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([/])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
-    public final static Pattern STRIKETHROUGH = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([+])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
-    public final static Pattern UNDERLINE = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([_])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
-    public final static Pattern CODE_INLINE = Pattern.compile("(?<=(\\n|^|\\s|\\{|\\())([=~])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))");
+    public final static String COMMON_EMPHASIS_PATTERN = "(?<=(\\n|^|\\s|\\{|\\())([%s])(?=\\S)(.*?)\\S\\2(?=(\\n|$|\\s|\\.|,|:|;|-|\\}|\\)))";
+    public final static Pattern BOLD = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\*"));
+    public final static Pattern ITALICS = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\/"));
+    public final static Pattern STRIKETHROUGH = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\+"));
+    public final static Pattern UNDERLINE = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\_"));
+    public final static Pattern CODE_INLINE = Pattern.compile(String.format(COMMON_EMPHASIS_PATTERN, "\\=~"));
     public final static Pattern HEADING = Pattern.compile("(?m)^(\\*+)\\s(.*?)(?=\\n|$)");
     public final static Pattern BLOCK = Pattern.compile("(?m)(?<=#\\+BEGIN_.{1,15}$\\s)[\\s\\S]*?(?=#\\+END)");
     public final static Pattern PREAMBLE = Pattern.compile("(?m)^(#\\+)(.*?)(?=\\n|$)");

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -348,6 +348,13 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="abid_todotxt_due_date" translatable="false">abid_todotxt_due_date</string>
     <string name="abid_todotxt_sort_todo" translatable="false">abid_todotxt_sort_todo</string>
 
+    
+    <string name="abid_orgmode_bold" translatable="false">abid_orgmode_bold</string>
+    <string name="abid_orgmode_italic" translatable="false">abid_orgmode_italic</string>
+    <string name="abid_orgmode_strikeout" translatable="false">abid_orgmode_strikeout</string>
+    <string name="abid_orgmode_underline" translatable="false">abid_orgmode_underline</string>
+    <string name="abid_orgmode_code_inline" translatable="false">abid_orgmode_code_inline</string>
+
 
     <string name="jekyll_post" translatable="false">Jekyll Post</string>
     <string name="wikitext" translatable="false">Wikitext / Zim</string>


### PR DESCRIPTION
This adds syntax highlighting for bold, italic, strikeout, underline, and inline code.

For the matching regex I've used the same one used for markdown bold. To my testing this matches the expected behaviour. The only change is that we do not want to allow square brackets as a surround.

<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
