### PR TITLE
Override .org file extension to use text mimetype (*/* unrecognized on older devices)

### DIFF
--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -461,6 +461,8 @@ public class GsFileUtils {
             return "text/markdown";
         } else if (ext.matches("(te?xt)|(taskpaper)")) {
             return "text/plain";
+        } else if (ext.matches("org")) {
+            return "text/org";
         } else if (ext.matches("webp")) {
             return "image/webp";
         } else if (ext.matches("jpe?g")) {


### PR DESCRIPTION
Prevents `QuickNote.org` from being filtered out of the QuickNote file-picking dialog.







<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
