### PR TITLE
OrgMode: make insert-link action-button use correct syntax, closes #2527

### DIFF
--- a/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
@@ -53,6 +53,8 @@ public class AttachLinkOrFileDialog {
             return "{{%LINK%}}";
         } else if (textFormatId == FormatRegistry.FORMAT_ASCIIDOC) {
             return "image::%LINK%[\"%TITLE%\"]";
+        } else if (textFormatId == FormatRegistry.FORMAT_ORGMODE) {
+            return "#+CAPTION: %TITLE%\n[[%LINK%]]";
         } else {
             return "<img style='width:auto;max-height:256px;' alt='%TITLE%' src='%LINK%' />";
         }

--- a/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
@@ -67,6 +67,8 @@ public class AttachLinkOrFileDialog {
             return "link:%LINK%[%TITLE%]";
         } else if (textFormatId == FormatRegistry.FORMAT_TODOTXT) {
             return "%TITLE% link:%LINK%";
+        } else if (textFormatId == FormatRegistry.FORMAT_ORGMODE) {
+            return "[[%LINK%][%TITLE%]]";
         } else {
             return "<a href=\"%LINK%\">%TITLE%</a>";
         }

--- a/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/AttachLinkOrFileDialog.java
@@ -54,7 +54,7 @@ public class AttachLinkOrFileDialog {
         } else if (textFormatId == FormatRegistry.FORMAT_ASCIIDOC) {
             return "image::%LINK%[\"%TITLE%\"]";
         } else if (textFormatId == FormatRegistry.FORMAT_ORGMODE) {
-            return "#+CAPTION: %TITLE%\n[[%LINK%]]";
+            return "#+CAPTION: %TITLE%\n[[file:%LINK%]]";
         } else {
             return "<img style='width:auto;max-height:256px;' alt='%TITLE%' src='%LINK%' />";
         }
@@ -70,7 +70,7 @@ public class AttachLinkOrFileDialog {
         } else if (textFormatId == FormatRegistry.FORMAT_TODOTXT) {
             return "%TITLE% link:%LINK%";
         } else if (textFormatId == FormatRegistry.FORMAT_ORGMODE) {
-            return "[[%LINK%][%TITLE%]]";
+            return "[[file:%LINK%][%TITLE%]]";
         } else {
             return "<a href=\"%LINK%\">%TITLE%</a>";
         }


### PR DESCRIPTION
This fixes #2527

Causes the insert-link action-button to correctly insert a link formatted for OrgMode after a file has been chosen through the file-picker dialog.

<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
