### PR TITLE
Adding SHA-256 to file info

### DIFF
--- a/app/src/main/java/net/gsantner/markor/frontend/FileInfoDialog.java
+++ b/app/src/main/java/net/gsantner/markor/frontend/FileInfoDialog.java
@@ -85,11 +85,17 @@ public class FileInfoDialog extends DialogFragment {
         tv(root, R.id.ui__fileinfodialog__last_modified_caption).setText(getString(R.string.last_modified_witharg, "").replace(":", "").trim());
         tv(root, R.id.ui__fileinfodialog__size_description).setText(GsFileUtils.getReadableFileSize(file.length(), false));
         tv(root, R.id.ui__fileinfodialog__mimetype_description).setText(GsFileUtils.getMimeType(file));
+        tv(root, R.id.ui__fileinfodialog__sha_256).setText(GsFileUtils.sha256(file));
         tv(root, R.id.ui__fileinfodialog__location).setOnLongClickListener(v -> {
             GsContextUtils.instance.setClipboard(v.getContext(), file.getAbsolutePath());
             Toast.makeText(v.getContext(), R.string.clipboard, Toast.LENGTH_SHORT).show();
-            return true;
-        });
+            return true;}
+        );
+        tv(root, R.id.ui__fileinfodialog__sha_256).setOnLongClickListener(v -> {
+            GsContextUtils.instance.setClipboard(v.getContext(), GsFileUtils.sha256(file));
+            Toast.makeText(v.getContext(), R.string.clipboard, Toast.LENGTH_SHORT).show();
+            return true;}
+        );
 
 
         // Number of lines and character count only apply for files.

--- a/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
+++ b/app/src/main/java/net/gsantner/opoc/util/GsFileUtils.java
@@ -658,12 +658,33 @@ public class GsFileUtils {
         }
     }
 
-    public static String md5(final byte[] data) {
-        return hash(data, "MD5");
-    }
+    public static String sha256(final File file) {
+        if (file == null || !file.exists() || !file.isFile()) {
+            return null;
+        }
 
-    public static String sha512(final byte[] data) {
-        return hash(data, "SHA-512");
+        try (final FileInputStream fis = new FileInputStream(file)) {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            final byte[] buffer = new byte[BUFFER_SIZE];
+            int bytesRead;
+
+            while ((bytesRead = fis.read(buffer)) != -1) {
+                digest.update(buffer, 0, bytesRead);
+            }
+        
+            byte[] hashBytes = digest.digest();
+            StringBuilder hexString = new StringBuilder();
+            
+            for (byte b : hashBytes) {
+                hexString.append(String.format("%02x", b));
+            }
+            
+            return hexString.toString();
+    
+        } catch (IOException | NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 
     public static long crc32(final CharSequence data) {

--- a/app/src/main/res/layout/file_info_dialog.xml
+++ b/app/src/main/res/layout/file_info_dialog.xml
@@ -46,7 +46,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:ellipsize="middle"
-            android:singleLine="true"
+            android:lines="1"
             android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
             tools:text="cool document.md" />
 
@@ -158,7 +158,26 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
-                tools:text="5 / 3 / 4" />
+                tools:text="0 / 0 / 0" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginTop="16dp"
+                android:ellipsize="end"
+                android:lines="1"
+                android:text="@string/sha_256"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                android:textStyle="normal" />
+
+            <TextView
+                android:id="@+id/ui__fileinfodialog__sha_256"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                tools:text="0" />
 
         </LinearLayout>
 
@@ -179,7 +198,7 @@
             <CheckBox
                 android:id="@+id/ui__fileinfodialog__recents"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="48dp"
                 android:layout_gravity="center_vertical"
                 android:text="@string/list_in_recent_files" />
 

--- a/app/src/main/res/values/string-not_translatable.xml
+++ b/app/src/main/res/values/string-not_translatable.xml
@@ -34,6 +34,7 @@ work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
     <string name="backup" translatable="false">Backup</string>
     <string name="front_matter" translatable="false">Front Matter</string>
     <string name="mime_type" translatable="false">MIME type</string>
+    <string name="sha_256" translatable="false">SHA-256</string>
 
     <string name="default_font_family" translatable="false">sans-serif-regular</string>
     <string name="start" translatable="false">Start</string>


### PR DESCRIPTION

- adding the SHA-256 of a file to the file info dialog
- the sha256 can be copied to the clipboard
- making the height of the checkbutton in the file info dialog to 48dp (better accessability)
- removing md5 and sha512 from OPOC (not used)



<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
