### PR TITLE
To-Do: Fix priority can not be removed when app language is Simplified Chinese

### DIFF
--- a/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
+++ b/app/src/main/java/net/gsantner/markor/format/todotxt/TodoTxtActionButtons.java
@@ -107,7 +107,7 @@ public class TodoTxtActionButtons extends ActionButtonBase {
             }
             case R.string.abid_todotxt_priority: {
                 MarkorDialogFactory.showPriorityDialog(getActivity(), selTasks.get(0).getPriority(), (priority) -> {
-                    boolean isPriority = priority.length() == 1 && TextCasingUtils.isEnglishLetter(priority.charAt(0));
+                    boolean isPriority = priority.length() == 1 && TextCasingUtils.isLatinLetter(priority.charAt(0));
                     setPriority(isPriority ? priority.charAt(0) : TodoTxtTask.PRIORITY_NONE);
                 });
                 return true;

--- a/app/src/main/java/net/gsantner/markor/util/TextCasingUtils.java
+++ b/app/src/main/java/net/gsantner/markor/util/TextCasingUtils.java
@@ -59,7 +59,7 @@ public class TextCasingUtils {
         return result.toString();
     }
 
-    public static boolean isEnglishLetter(char ch) {
+    public static boolean isLatinLetter(char ch) {
         return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');
     }
 }


### PR DESCRIPTION
Fix this issue #2701 - Priority can not be removed but set to **(无)** on priority **None** is selected when application language is Simplified Chinese.