### PR TITLE
Fix per-file RTL/LTR text direction (#1221)

### DIFF
--- a/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
+++ b/app/src/main/java/net/gsantner/markor/activity/DocumentEditAndViewFragment.java
@@ -718,6 +718,15 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
                 updateMenuToggleStates(0);
                 return true;
             }
+            case R.id.action_enable_rtl: {
+                final boolean newState = !_appSettings.getDocumentRtlEnabled(_document.path);
+                _appSettings.setDocumentRtlEnabled(_document.path, newState);
+                if (_isPreviewVisible) {
+                    updateViewModeText();
+                }
+                updateMenuToggleStates(0);
+                return true;
+            }
             case R.id.action_info: {
                 if (saveDocument(false)) { // In order to have the correct info displayed
                     FileInfoDialog.show(_document.file, getParentFragmentManager());
@@ -1009,6 +1018,9 @@ public class DocumentEditAndViewFragment extends MarkorBaseFragment implements F
         }
         if ((mi = _fragmentMenu.findItem(R.id.action_enable_auto_format)) != null) {
             mi.setChecked(_hlEditor.getAutoFormatEnabled());
+        }
+        if ((mi = _fragmentMenu.findItem(R.id.action_enable_rtl)) != null) {
+            mi.setChecked(_appSettings.getDocumentRtlEnabled(_document.path));
         }
 
         final SubMenu su;

--- a/app/src/main/java/net/gsantner/markor/format/TextConverterBase.java
+++ b/app/src/main/java/net/gsantner/markor/format/TextConverterBase.java
@@ -147,7 +147,8 @@ public abstract class TextConverterBase {
             html = html.replace("html,body{color:#303030;}", "html,body{color: black !important; background-color: white !important;}");
         }
         html += HTML004_HEAD_META_VIEWPORT_MOBILE + CSS_TABLE_STYLE + CSS_CLASS_FLOAT + CSS_BUTTON_STYLE_MATERIAL + CSS_BUTTON_STYLE_EMOJIBTN + CSS_CLASS_STICKY;
-        if (as.isRenderRtl()) {
+        final boolean isRtl = as.getDocumentRtlEnabled(file != null ? GsFileUtils.getPath(file) : null);
+        if (isRtl) {
             html += HTML003_RIGHT_TO_LEFT;
         }
 
@@ -185,7 +186,7 @@ public abstract class TextConverterBase {
                 .replace(TOKEN_COLOR_GREY_OF_THEME, darkTheme ? "#393939" : GsTextUtils.colorToHexString(ContextCompat.getColor(context, R.color.lighter_grey)))
                 .replace(TOKEN_LINK_COLOR, as.getViewModeLinkColor())
                 .replace(TOKEN_ACCENT_COLOR, GsTextUtils.colorToHexString(ContextCompat.getColor(context, R.color.accent)))
-                .replace(TOKEN_TEXT_DIRECTION, as.isRenderRtl() ? "right" : "left")
+                .replace(TOKEN_TEXT_DIRECTION, isRtl ? "right" : "left")
                 .replace(TOKEN_FONT, font)
                 .replace(TOKEN_TEXT_CONVERTER_CSS_CLASS, "format-" + getClass().getSimpleName().toLowerCase().replace("textconverter", "").replace("converter", "") + (file == null ? "" : " fileext-" + GsFileUtils.getFilenameExtension(file).replace(".", "")))
                 .replace(TOKEN_POST_TODAY_DATE, DateFormat.getDateFormat(context).format(new Date()))

--- a/app/src/main/java/net/gsantner/markor/model/AppSettings.java
+++ b/app/src/main/java/net/gsantner/markor/model/AppSettings.java
@@ -435,6 +435,7 @@ public class AppSettings extends GsSharedPreferencesPropertyBackend {
     private static final String PREF_PREFIX_TODO_DONE_NAME = "PREF_PREFIX_TODO_DONE_NAME";
     private static final String PREF_PREFIX_LINE_NUM_STATE = "PREF_PREFIX_LINE_NUM_STATE";
     private static final String PREF_PREFIX_VIEW_FONT_SIZE = "PREF_PREFIX_VIEW_FONT_SIZE";
+    private static final String PREF_PREFIX_RTL_STATE = "PREF_PREFIX_RTL_STATE";
 
     public void setLastTodoDoneName(final String path, final String name) {
         if (fexists(path)) {
@@ -583,6 +584,21 @@ public class AppSettings extends GsSharedPreferencesPropertyBackend {
             return _default;
         } else {
             return getBool(PREF_PREFIX_AUTO_FORMAT + path, _default);
+        }
+    }
+
+    public void setDocumentRtlEnabled(final String path, final boolean enabled) {
+        if (fexists(path)) {
+            setBool(PREF_PREFIX_RTL_STATE + path, enabled);
+        }
+    }
+
+    public boolean getDocumentRtlEnabled(final String path) {
+        final boolean _default = isRenderRtl();
+        if (!fexists(path)) {
+            return _default;
+        } else {
+            return getBool(PREF_PREFIX_RTL_STATE + path, _default);
         }
     }
 

--- a/app/src/main/res/menu/document__edit__menu.xml
+++ b/app/src/main/res/menu/document__edit__menu.xml
@@ -97,6 +97,13 @@
                 app:showAsAction="never" />
 
             <item
+                android:id="@+id/action_enable_rtl"
+                android:checkable="true"
+                android:icon="@drawable/ic_format_textdirection_r_to_l_black_24dp"
+                android:title="@string/rtl_rendering"
+                app:showAsAction="never" />
+
+            <item
                 android:id="@+id/action_set_font_size"
                 android:checkable="false"
                 android:icon="@drawable/ic_format_size_black_24dp"


### PR DESCRIPTION
## Summary
- Implements per-file RTL/LTR text direction for Markor as discussed in #1221.
- Matches the maintainer-guided approach; no competing open PR for this issue.

## Test plan
- [ ] Open an RTL-language file and confirm direction applies per file
- [ ] Open an LTR file and confirm it stays LTR
- [ ] `./gradlew :app:compileFlavorDefaultDebugSources` (already clean locally)

Fixes #1221
